### PR TITLE
fix(ci): verify release asset before updating Homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Verify release asset is downloadable
+        run: |
+          ASSET_URL="https://github.com/AThevon/TokenEater/releases/download/${GITHUB_REF_NAME}/TokenEater.dmg"
+          echo "Verifying asset at: ${ASSET_URL}"
+          HTTP_STATUS=$(curl -sL -o /dev/null -w '%{http_code}' "$ASSET_URL")
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "::error::Release asset not downloadable (HTTP ${HTTP_STATUS}). Aborting Homebrew update."
+            exit 1
+          fi
+          echo "Asset verified (HTTP ${HTTP_STATUS})"
+
       - name: Update Homebrew Cask
         env:
           TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds a verification step between the GitHub Release upload and the Homebrew tap update
- The step confirms the DMG asset is actually downloadable (HTTP 200) before proceeding
- If verification fails, the workflow aborts with an error, leaving the Homebrew tap pointing at the last known-good version

## Context

I can't install the latest version via Homebrew — the cask points to v2.1.0 but the release has no artifacts:

```
Download failed on Cask 'tokeneater' with message: Download failed: https://github.com/AThevon/TokenEater/releases/download/v2.1.0/TokenEater.dmg
```

The Homebrew tap was updated to v2.1.0 even though the release doesn't have a downloadable DMG. This PR prevents that from happening again by gating the tap update on a successful download check.

Note: v2.1.0 still needs to be fixed separately (either re-release or revert the tap to v2.0.0).

## Test plan

- [ ] Push a tag where the release upload succeeds — verify the asset check passes and Homebrew tap is updated
- [ ] Simulate a missing asset — verify the workflow fails at the verification step and the tap is not updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)