### PR TITLE
fix: notification delegate at launch + status refresh on focus

### DIFF
--- a/ClaudeUsageApp/ClaudeUsageApp.swift
+++ b/ClaudeUsageApp/ClaudeUsageApp.swift
@@ -7,6 +7,7 @@ struct ClaudeUsageApp: App {
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
 
     init() {
+        UsageNotificationManager.setupDelegate()
         syncProxyConfig()
         ThemeManager.shared.syncToSharedContainer()
     }

--- a/ClaudeUsageApp/SettingsView.swift
+++ b/ClaudeUsageApp/SettingsView.swift
@@ -300,6 +300,9 @@ struct SettingsView: View {
             loadPinnedMetrics()
             Task { notifStatus = await UsageNotificationManager.checkAuthorizationStatus() }
         }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            Task { notifStatus = await UsageNotificationManager.checkAuthorizationStatus() }
+        }
         .onChange(of: pinnedFiveHour) { _ in savePinnedMetrics() }
         .onChange(of: pinnedSevenDay) { _ in savePinnedMetrics() }
         .onChange(of: pinnedSonnet) { _ in savePinnedMetrics() }

--- a/Shared/UsageNotificationManager.swift
+++ b/Shared/UsageNotificationManager.swift
@@ -28,8 +28,13 @@ final class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
 enum UsageNotificationManager {
     private static let center = UNUserNotificationCenter.current()
 
-    static func requestPermission() {
+    /// Must be called early at app launch to ensure banners display in foreground.
+    static func setupDelegate() {
         center.delegate = NotificationDelegate.shared
+    }
+
+    static func requestPermission() {
+        setupDelegate()
         center.requestAuthorization(options: [.alert, .sound]) { _, _ in }
     }
 


### PR DESCRIPTION
## Summary

Two notification fixes:

- **Banner notifications after fresh install**: The `NotificationDelegate` was only set inside `requestPermission()`, which isn't called until after onboarding completes. Notifications sent before that (or during onboarding) went silently to the notification center. Now `setupDelegate()` is called in `ClaudeUsageApp.init()` so banners work from the very first launch.

- **Status refresh when returning from System Settings**: The notification status indicator in Settings > Display only checked on `onAppear`. If the user opened System Settings to toggle notifications and came back, the status was stale. Now it refreshes on `NSApplication.didBecomeActiveNotification`.