### PR TITLE
fix(settings): hide pacing display type when pacing is disabled

### DIFF
--- a/TokenEaterApp/SettingsView.swift
+++ b/TokenEaterApp/SettingsView.swift
@@ -422,6 +422,7 @@ private struct DisplayTab: View {
                     }
                     .pickerStyle(.radioGroup)
                 }
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
 
             Section("settings.theme.thresholds") {
@@ -507,13 +508,19 @@ private struct DisplayTab: View {
         .onChange(of: showFiveHour) { _, new in syncMetric(.fiveHour, on: new, revert: { showFiveHour = true }) }
         .onChange(of: showSevenDay) { _, new in syncMetric(.sevenDay, on: new, revert: { showSevenDay = true }) }
         .onChange(of: showSonnet) { _, new in syncMetric(.sonnet, on: new, revert: { showSonnet = true }) }
-        .onChange(of: showPacing) { _, new in syncMetric(.pacing, on: new, revert: { showPacing = true }) }
+        .onChange(of: showPacing) { _, new in
+            withAnimation(.easeInOut(duration: 0.2)) {
+                syncMetric(.pacing, on: new, revert: { showPacing = true })
+            }
+        }
         // Sync: store → local toggles (for external changes, e.g. from MenuBar popover)
         .onChange(of: settingsStore.pinnedMetrics) { _, metrics in
             if showFiveHour != metrics.contains(.fiveHour) { showFiveHour = metrics.contains(.fiveHour) }
             if showSevenDay != metrics.contains(.sevenDay) { showSevenDay = metrics.contains(.sevenDay) }
             if showSonnet != metrics.contains(.sonnet) { showSonnet = metrics.contains(.sonnet) }
-            if showPacing != metrics.contains(.pacing) { showPacing = metrics.contains(.pacing) }
+            if showPacing != metrics.contains(.pacing) {
+                withAnimation(.easeInOut(duration: 0.2)) { showPacing = metrics.contains(.pacing) }
+            }
         }
         // Sync: local slider → store (with constraint enforcement)
         .onChange(of: warningSlider) { _, new in


### PR DESCRIPTION
## Summary

- Hide the pacing display type picker section when pacing is not enabled in pinned metrics
- The section reappears automatically when the user toggles pacing back on

Wraps the existing `Section("settings.pacing.display")` in an `if showPacing` conditional, using the same `@State` that drives the pacing toggle.

Closes #41

## Test plan

- [x] 80/80 unit tests pass
- [ ] Toggle pacing off → pacing display type section disappears
- [ ] Toggle pacing on → pacing display type section reappears
- [ ] Selected pacing display mode is preserved after toggling off/on