### PR TITLE
feat: enrich notifications with reset times and pacing context

### DIFF
--- a/Shared/Helpers/NotificationBodyFormatter.swift
+++ b/Shared/Helpers/NotificationBodyFormatter.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+enum NotificationBodyFormatter {
+
+    enum MetricType {
+        case session
+        case weekly
+    }
+
+    // MARK: - Escalation (orange / red)
+
+    static func escalationBody(
+        metricType: MetricType,
+        level: UsageLevel,
+        resetsAt: Date?,
+        pacingZone: PacingZone?,
+        thresholds: UsageThresholds,
+        now: Date = Date()
+    ) -> String {
+        guard let resetsAt, resetsAt.timeIntervalSince(now) > 0 else {
+            return fallbackEscalation(level: level, thresholds: thresholds)
+        }
+
+        switch (level, metricType) {
+        case (.orange, .session):
+            let countdown = formatCountdown(from: now, to: resetsAt)
+            let time = formatTime(resetsAt)
+            let key: String
+            switch pacingZone ?? .onTrack {
+            case .chill: key = "notif.orange.body.session.chill"
+            case .onTrack: key = "notif.orange.body.session.ontrack"
+            case .hot: key = "notif.orange.body.session.hot"
+            }
+            return String(format: String(localized: String.LocalizationValue(key)), countdown, time)
+
+        case (.orange, .weekly):
+            let dateTime = formatDateTime(resetsAt)
+            return String(format: String(localized: "notif.orange.body.weekly"), dateTime)
+
+        case (.red, .session):
+            let countdown = formatCountdown(from: now, to: resetsAt)
+            let time = formatTime(resetsAt)
+            return String(format: String(localized: "notif.red.body.session"), countdown, time)
+
+        case (.red, .weekly):
+            let dateTime = formatDateTime(resetsAt)
+            return String(format: String(localized: "notif.red.body.weekly"), dateTime)
+
+        case (.green, _):
+            return fallbackEscalation(level: level, thresholds: thresholds)
+        }
+    }
+
+    // MARK: - Recovery (green)
+
+    static func recoveryBody(
+        metricType: MetricType,
+        resetsAt: Date?,
+        now: Date = Date()
+    ) -> String {
+        guard let resetsAt, resetsAt.timeIntervalSince(now) > 0 else {
+            return String(localized: "notif.green.body")
+        }
+
+        switch metricType {
+        case .session:
+            let time = formatTime(resetsAt)
+            return String(format: String(localized: "notif.green.body.session"), time)
+        case .weekly:
+            let dateTime = formatDateTime(resetsAt)
+            return String(format: String(localized: "notif.green.body.weekly"), dateTime)
+        }
+    }
+
+    // MARK: - Time Formatting
+
+    static func formatCountdown(from now: Date, to target: Date) -> String {
+        let diff = target.timeIntervalSince(now)
+        guard diff > 0 else { return String(localized: "relative.now") }
+
+        let totalMinutes = Int(diff) / 60
+        let h = totalMinutes / 60
+        let m = totalMinutes % 60
+
+        if h >= 24 {
+            let d = h / 24
+            let remainH = h % 24
+            return String(format: String(localized: "duration.days.hours"), d, remainH)
+        } else if h > 0 {
+            return "\(h)h \(m)min"
+        } else {
+            return "\(m)min"
+        }
+    }
+
+    static func formatTime(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+
+    static func formatDateTime(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = DateFormatter.dateFormat(
+            fromTemplate: "EEE MMM d, h:mm a",
+            options: 0,
+            locale: .current
+        )
+        return formatter.string(from: date)
+    }
+
+    // MARK: - Fallback
+
+    private static func fallbackEscalation(level: UsageLevel, thresholds: UsageThresholds) -> String {
+        switch level {
+        case .orange:
+            return String(format: String(localized: "notif.orange.body"), thresholds.warningPercent)
+        case .red:
+            return String(localized: "notif.red.body")
+        case .green:
+            return ""
+        }
+    }
+}

--- a/Shared/Services/Protocols/NotificationServiceProtocol.swift
+++ b/Shared/Services/Protocols/NotificationServiceProtocol.swift
@@ -1,10 +1,21 @@
 import Foundation
 import UserNotifications
 
+struct MetricSnapshot {
+    let pct: Int
+    let resetsAt: Date?
+}
+
 protocol NotificationServiceProtocol {
     func setupDelegate()
     func requestPermission()
     func checkAuthorizationStatus() async -> UNAuthorizationStatus
     func sendTest()
-    func checkThresholds(fiveHour: Int, sevenDay: Int, sonnet: Int, thresholds: UsageThresholds)
+    func checkThresholds(
+        fiveHour: MetricSnapshot,
+        sevenDay: MetricSnapshot,
+        sonnet: MetricSnapshot,
+        pacingZone: PacingZone?,
+        thresholds: UsageThresholds
+    )
 }

--- a/Shared/Stores/UsageStore.swift
+++ b/Shared/Stores/UsageStore.swift
@@ -60,9 +60,10 @@ final class UsageStore: ObservableObject {
             lastUpdate = Date()
             WidgetReloader.scheduleReload()
             notificationService.checkThresholds(
-                fiveHour: fiveHourPct,
-                sevenDay: sevenDayPct,
-                sonnet: sonnetPct,
+                fiveHour: MetricSnapshot(pct: fiveHourPct, resetsAt: usage.fiveHour?.resetsAtDate),
+                sevenDay: MetricSnapshot(pct: sevenDayPct, resetsAt: usage.sevenDay?.resetsAtDate),
+                sonnet: MetricSnapshot(pct: sonnetPct, resetsAt: usage.sevenDaySonnet?.resetsAtDate),
+                pacingZone: pacingZone,
                 thresholds: thresholds
             )
         } catch let error as APIError {

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -103,11 +103,23 @@
 "pacing.label" = "Pacing";
 "pacing.reset" = "reset %@";
 
-/* Notifications */
+/* Notifications — fallback (no reset time available) */
 "notif.orange.body" = "You're past %d%% — consider slowing down";
 "notif.red.body" = "Critical usage — limit almost reached";
 "notif.green.body" = "Usage reset — you're back in the green";
 "notif.test.body" = "Notifications are working — you're all set!";
+
+/* Notifications — escalation with reset time */
+"notif.orange.body.session.chill" = "Resets in %1$@ (at %2$@) — your pace is fine";
+"notif.orange.body.session.ontrack" = "Resets in %1$@ (at %2$@) — pace yourself";
+"notif.orange.body.session.hot" = "Resets in %1$@ (at %2$@) — you're burning fast";
+"notif.orange.body.weekly" = "Resets on %@ — pace yourself";
+"notif.red.body.session" = "Limit almost reached — resets in %1$@ (at %2$@)";
+"notif.red.body.weekly" = "Limit almost reached — resets on %@";
+
+/* Notifications — recovery with next reset time */
+"notif.green.body.session" = "You're back! Next reset at %@";
+"notif.green.body.weekly" = "You're back! Next reset on %@";
 "settings.notifications.title" = "Notifications";
 "settings.notifications.status" = "Status";
 "settings.notifications.on" = "Enabled";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -103,11 +103,23 @@
 "pacing.label" = "Rythme";
 "pacing.reset" = "reset %@";
 
-/* Notifications */
+/* Notifications — fallback (pas de temps de reset dispo) */
 "notif.orange.body" = "Tu dépasses %d%% — lève le pied";
 "notif.red.body" = "Usage critique — limite presque atteinte";
 "notif.green.body" = "Usage réinitialisé — t'es de retour dans le vert";
 "notif.test.body" = "Les notifications fonctionnent — c'est bon !";
+
+/* Notifications — escalade avec temps de reset */
+"notif.orange.body.session.chill" = "Reset dans %1$@ (à %2$@) — ton rythme est bon";
+"notif.orange.body.session.ontrack" = "Reset dans %1$@ (à %2$@) — lève le pied";
+"notif.orange.body.session.hot" = "Reset dans %1$@ (à %2$@) — tu flambes";
+"notif.orange.body.weekly" = "Reset le %@ — lève le pied";
+"notif.red.body.session" = "Limite presque atteinte — reset dans %1$@ (à %2$@)";
+"notif.red.body.weekly" = "Limite presque atteinte — reset le %@";
+
+/* Notifications — recovery avec prochain reset */
+"notif.green.body.session" = "T'es de retour ! Prochain reset à %@";
+"notif.green.body.weekly" = "T'es de retour ! Prochain reset le %@";
 "settings.notifications.title" = "Notifications";
 "settings.notifications.status" = "Statut";
 "settings.notifications.on" = "Activées";

--- a/TokenEaterTests/Fixtures/UsageResponse+Fixture.swift
+++ b/TokenEaterTests/Fixtures/UsageResponse+Fixture.swift
@@ -18,12 +18,14 @@ extension UsageResponse {
         fiveHourUtil: Double = 42,
         sevenDayUtil: Double = 65,
         sonnetUtil: Double = 30,
-        sevenDayResetsAt: String? = nil
+        fiveHourResetsAt: String? = nil,
+        sevenDayResetsAt: String? = nil,
+        sonnetResetsAt: String? = nil
     ) -> UsageResponse {
         UsageResponse(
-            fiveHour: .fixture(utilization: fiveHourUtil),
+            fiveHour: .fixture(utilization: fiveHourUtil, resetsAt: fiveHourResetsAt),
             sevenDay: .fixture(utilization: sevenDayUtil, resetsAt: sevenDayResetsAt),
-            sevenDaySonnet: .fixture(utilization: sonnetUtil)
+            sevenDaySonnet: .fixture(utilization: sonnetUtil, resetsAt: sonnetResetsAt)
         )
     }
 }

--- a/TokenEaterTests/Mocks/MockNotificationService.swift
+++ b/TokenEaterTests/Mocks/MockNotificationService.swift
@@ -3,7 +3,7 @@ import UserNotifications
 
 final class MockNotificationService: NotificationServiceProtocol {
     var permissionRequested = false
-    var lastThresholdCheck: (fiveHour: Int, sevenDay: Int, sonnet: Int)?
+    var lastThresholdCheck: (fiveHour: MetricSnapshot, sevenDay: MetricSnapshot, sonnet: MetricSnapshot, pacingZone: PacingZone?)?
     var stubbedAuthStatus: UNAuthorizationStatus = .notDetermined
     var testSent = false
 
@@ -11,7 +11,13 @@ final class MockNotificationService: NotificationServiceProtocol {
     func requestPermission() { permissionRequested = true }
     func checkAuthorizationStatus() async -> UNAuthorizationStatus { stubbedAuthStatus }
     func sendTest() { testSent = true }
-    func checkThresholds(fiveHour: Int, sevenDay: Int, sonnet: Int, thresholds: UsageThresholds) {
-        lastThresholdCheck = (fiveHour, sevenDay, sonnet)
+    func checkThresholds(
+        fiveHour: MetricSnapshot,
+        sevenDay: MetricSnapshot,
+        sonnet: MetricSnapshot,
+        pacingZone: PacingZone?,
+        thresholds: UsageThresholds
+    ) {
+        lastThresholdCheck = (fiveHour, sevenDay, sonnet, pacingZone)
     }
 }

--- a/TokenEaterTests/NotificationBodyFormatterTests.swift
+++ b/TokenEaterTests/NotificationBodyFormatterTests.swift
@@ -1,0 +1,245 @@
+import Testing
+import Foundation
+
+@Suite("NotificationBodyFormatter")
+struct NotificationBodyFormatterTests {
+
+    // MARK: - Helpers
+
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - formatCountdown
+
+    @Test("formatCountdown shows minutes only when < 1h")
+    func countdownMinutesOnly() {
+        let target = now.addingTimeInterval(45 * 60)
+        let result = NotificationBodyFormatter.formatCountdown(from: now, to: target)
+        #expect(result == "45min")
+    }
+
+    @Test("formatCountdown shows 0min for very short interval")
+    func countdownVeryShort() {
+        let target = now.addingTimeInterval(20) // 20 seconds
+        let result = NotificationBodyFormatter.formatCountdown(from: now, to: target)
+        #expect(result == "0min")
+    }
+
+    @Test("formatCountdown shows hours and minutes")
+    func countdownHoursAndMinutes() {
+        let target = now.addingTimeInterval(2 * 3600 + 34 * 60)
+        let result = NotificationBodyFormatter.formatCountdown(from: now, to: target)
+        #expect(result == "2h 34min")
+    }
+
+    @Test("formatCountdown shows exact hours")
+    func countdownExactHours() {
+        let target = now.addingTimeInterval(3 * 3600)
+        let result = NotificationBodyFormatter.formatCountdown(from: now, to: target)
+        #expect(result == "3h 0min")
+    }
+
+    @Test("formatCountdown returns non-empty for >= 24h")
+    func countdownDays() {
+        let target = now.addingTimeInterval(3 * 24 * 3600 + 5 * 3600)
+        let result = NotificationBodyFormatter.formatCountdown(from: now, to: target)
+        #expect(!result.isEmpty)
+    }
+
+    @Test("formatCountdown returns non-empty for past date")
+    func countdownPastDate() {
+        let target = now.addingTimeInterval(-60)
+        let result = NotificationBodyFormatter.formatCountdown(from: now, to: target)
+        #expect(!result.isEmpty)
+    }
+
+    // MARK: - formatTime
+
+    @Test("formatTime returns non-empty string")
+    func formatTimeNonEmpty() {
+        let result = NotificationBodyFormatter.formatTime(now)
+        #expect(!result.isEmpty)
+    }
+
+    @Test("formatTime returns consistent results for same date")
+    func formatTimeConsistent() {
+        let a = NotificationBodyFormatter.formatTime(now)
+        let b = NotificationBodyFormatter.formatTime(now)
+        #expect(a == b)
+    }
+
+    // MARK: - formatDateTime
+
+    @Test("formatDateTime returns non-empty string")
+    func formatDateTimeNonEmpty() {
+        let result = NotificationBodyFormatter.formatDateTime(now)
+        #expect(!result.isEmpty)
+    }
+
+    @Test("formatDateTime includes day information for different dates")
+    func formatDateTimeDifferentDates() {
+        let date1 = now
+        let date2 = now.addingTimeInterval(3 * 24 * 3600)
+        let result1 = NotificationBodyFormatter.formatDateTime(date1)
+        let result2 = NotificationBodyFormatter.formatDateTime(date2)
+        #expect(result1 != result2)
+    }
+
+    // MARK: - Escalation body — routing
+
+    @Test("escalation returns non-empty for all valid levels")
+    func escalationNonEmpty() {
+        for level: UsageLevel in [.orange, .red] {
+            let body = NotificationBodyFormatter.escalationBody(
+                metricType: .session, level: level,
+                resetsAt: now.addingTimeInterval(3600),
+                pacingZone: .onTrack, thresholds: .default, now: now
+            )
+            #expect(!body.isEmpty, "Body should not be empty for level \(level)")
+        }
+    }
+
+    @Test("escalation green returns empty")
+    func escalationGreenEmpty() {
+        let body = NotificationBodyFormatter.escalationBody(
+            metricType: .session, level: .green,
+            resetsAt: now.addingTimeInterval(3600),
+            pacingZone: .onTrack, thresholds: .default, now: now
+        )
+        #expect(body.isEmpty)
+    }
+
+    @Test("escalation with nil resetsAt returns fallback")
+    func escalationNilFallback() {
+        let withReset = NotificationBodyFormatter.escalationBody(
+            metricType: .session, level: .orange,
+            resetsAt: now.addingTimeInterval(3600),
+            pacingZone: .onTrack, thresholds: .default, now: now
+        )
+        let withoutReset = NotificationBodyFormatter.escalationBody(
+            metricType: .session, level: .orange,
+            resetsAt: nil,
+            pacingZone: .onTrack, thresholds: .default, now: now
+        )
+        // Different path → different output (key vs. formatted string)
+        #expect(withReset != withoutReset)
+    }
+
+    @Test("escalation with past resetsAt returns fallback")
+    func escalationPastFallback() {
+        let withFuture = NotificationBodyFormatter.escalationBody(
+            metricType: .session, level: .orange,
+            resetsAt: now.addingTimeInterval(3600),
+            pacingZone: .onTrack, thresholds: .default, now: now
+        )
+        let withPast = NotificationBodyFormatter.escalationBody(
+            metricType: .session, level: .orange,
+            resetsAt: now.addingTimeInterval(-3600),
+            pacingZone: .onTrack, thresholds: .default, now: now
+        )
+        #expect(withFuture != withPast)
+    }
+
+    @Test("escalation session uses different keys per pacing zone")
+    func escalationPacingDifferentiation() {
+        let reset = now.addingTimeInterval(2 * 3600)
+        let chill = NotificationBodyFormatter.escalationBody(
+            metricType: .session, level: .orange,
+            resetsAt: reset, pacingZone: .chill,
+            thresholds: .default, now: now
+        )
+        let hot = NotificationBodyFormatter.escalationBody(
+            metricType: .session, level: .orange,
+            resetsAt: reset, pacingZone: .hot,
+            thresholds: .default, now: now
+        )
+        #expect(chill != hot)
+    }
+
+    @Test("escalation session vs weekly uses different paths")
+    func escalationSessionVsWeekly() {
+        let reset = now.addingTimeInterval(2 * 3600)
+        let session = NotificationBodyFormatter.escalationBody(
+            metricType: .session, level: .orange,
+            resetsAt: reset, pacingZone: .onTrack,
+            thresholds: .default, now: now
+        )
+        let weekly = NotificationBodyFormatter.escalationBody(
+            metricType: .weekly, level: .orange,
+            resetsAt: reset, pacingZone: nil,
+            thresholds: .default, now: now
+        )
+        #expect(session != weekly)
+    }
+
+    @Test("red escalation session vs weekly uses different paths")
+    func redEscalationSessionVsWeekly() {
+        let reset = now.addingTimeInterval(2 * 3600)
+        let session = NotificationBodyFormatter.escalationBody(
+            metricType: .session, level: .red,
+            resetsAt: reset, pacingZone: nil,
+            thresholds: .default, now: now
+        )
+        let weekly = NotificationBodyFormatter.escalationBody(
+            metricType: .weekly, level: .red,
+            resetsAt: reset, pacingZone: nil,
+            thresholds: .default, now: now
+        )
+        #expect(session != weekly)
+    }
+
+    // MARK: - Recovery body — routing
+
+    @Test("recovery returns non-empty for all metric types")
+    func recoveryNonEmpty() {
+        for type: NotificationBodyFormatter.MetricType in [.session, .weekly] {
+            let body = NotificationBodyFormatter.recoveryBody(
+                metricType: type,
+                resetsAt: now.addingTimeInterval(5 * 3600),
+                now: now
+            )
+            #expect(!body.isEmpty, "Body should not be empty for \(type)")
+        }
+    }
+
+    @Test("recovery with nil resetsAt returns fallback")
+    func recoveryNilFallback() {
+        let withReset = NotificationBodyFormatter.recoveryBody(
+            metricType: .session,
+            resetsAt: now.addingTimeInterval(5 * 3600),
+            now: now
+        )
+        let withoutReset = NotificationBodyFormatter.recoveryBody(
+            metricType: .session,
+            resetsAt: nil,
+            now: now
+        )
+        #expect(withReset != withoutReset)
+    }
+
+    @Test("recovery with past resetsAt returns fallback")
+    func recoveryPastFallback() {
+        let withFuture = NotificationBodyFormatter.recoveryBody(
+            metricType: .session,
+            resetsAt: now.addingTimeInterval(5 * 3600),
+            now: now
+        )
+        let withPast = NotificationBodyFormatter.recoveryBody(
+            metricType: .session,
+            resetsAt: now.addingTimeInterval(-60),
+            now: now
+        )
+        #expect(withFuture != withPast)
+    }
+
+    @Test("recovery session vs weekly uses different paths")
+    func recoverySessionVsWeekly() {
+        let reset = now.addingTimeInterval(5 * 3600)
+        let session = NotificationBodyFormatter.recoveryBody(
+            metricType: .session, resetsAt: reset, now: now
+        )
+        let weekly = NotificationBodyFormatter.recoveryBody(
+            metricType: .weekly, resetsAt: reset, now: now
+        )
+        #expect(session != weekly)
+    }
+}

--- a/TokenEaterTests/UsageStoreTests.swift
+++ b/TokenEaterTests/UsageStoreTests.swift
@@ -73,9 +73,9 @@ struct UsageStoreTests {
 
         await store.refresh()
 
-        #expect(notif.lastThresholdCheck?.fiveHour == 42)
-        #expect(notif.lastThresholdCheck?.sevenDay == 65)
-        #expect(notif.lastThresholdCheck?.sonnet == 30)
+        #expect(notif.lastThresholdCheck?.fiveHour.pct == 42)
+        #expect(notif.lastThresholdCheck?.sevenDay.pct == 65)
+        #expect(notif.lastThresholdCheck?.sonnet.pct == 30)
     }
 
     // MARK: - refresh — hasConfig


### PR DESCRIPTION
## Summary

- **Escalation notifications** (orange/red) now show the reset countdown + exact time (e.g. "Resets in 2h 34min (at 3:45 PM)")
- **Recovery notifications** (green) show the exact next reset time (e.g. "Next reset at 8:15 PM" for session, "Next reset on Mon Mar 2 at 2:00 PM" for weekly)
- **Pacing integration**: session notifications adapt their tone based on pacing zone (chill/onTrack/hot)
- **Metric-aware formatting**: session uses countdown + time, weekly/sonnet uses full date+time
- Falls back gracefully to original messages when `resetsAt` is unavailable

## Changes

| File | What |
|------|------|
| `NotificationBodyFormatter.swift` | New pure helper — formats notification body with reset times and pacing |
| `NotificationServiceProtocol.swift` | New `MetricSnapshot` struct, updated `checkThresholds` signature |
| `NotificationService.swift` | Wires formatter into escalation/recovery notifications |
| `UsageStore.swift` | Passes `resetsAt` dates and `pacingZone` to notification service |
| `Localizable.strings` (EN/FR) | 8 new localized notification body templates per language |
| `MockNotificationService.swift` | Updated to match new protocol |
| `UsageResponse+Fixture.swift` | Added `fiveHourResetsAt` and `sonnetResetsAt` params |
| `NotificationBodyFormatterTests.swift` | 21 new tests for formatter logic |
| `UsageStoreTests.swift` | Updated assertions for new `MetricSnapshot` type |

## Test plan

- [x] All 101 unit tests pass (80 existing + 21 new)
- [ ] Build + nuke + install, trigger orange threshold → verify notification shows countdown + reset time
- [ ] Let session reset → verify recovery notification shows next reset time
- [ ] Test with weekly metric crossing threshold → verify date+time format

Closes #46