### PR TITLE
feat: read OAuth token from credentials file instead of Keychain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ xcuserdata/
 
 # Claude Code
 .claude/
+.worktrees/
 
 # Dependencies
 Pods/

--- a/Shared/Services/CredentialsFileReader.swift
+++ b/Shared/Services/CredentialsFileReader.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+final class CredentialsFileReader: CredentialsFileReaderProtocol, @unchecked Sendable {
+
+    private let filePath: String
+
+    init() {
+        guard let pw = getpwuid(getuid()) else {
+            filePath = ""
+            return
+        }
+        let home = String(cString: pw.pointee.pw_dir)
+        filePath = home + "/.claude/.credentials.json"
+    }
+
+    init(filePath: String) {
+        self.filePath = filePath
+    }
+
+    func readToken() -> String? {
+        guard let data = FileManager.default.contents(atPath: filePath),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let oauth = json["claudeAiOauth"] as? [String: Any],
+              let token = oauth["accessToken"] as? String,
+              !token.isEmpty
+        else {
+            return nil
+        }
+        return token
+    }
+
+    func tokenExists() -> Bool {
+        FileManager.default.fileExists(atPath: filePath)
+    }
+}

--- a/Shared/Services/Protocols/CredentialsFileReaderProtocol.swift
+++ b/Shared/Services/Protocols/CredentialsFileReaderProtocol.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol CredentialsFileReaderProtocol: Sendable {
+    func readToken() -> String?
+    func tokenExists() -> Bool
+}

--- a/TokenEaterApp/TokenEaterApp.entitlements
+++ b/TokenEaterApp/TokenEaterApp.entitlements
@@ -11,6 +11,10 @@
         <string>/Library/Application Support/com.tokeneater.shared/</string>
         <string>/Library/Application Support/com.claudeusagewidget.shared/</string>
     </array>
+    <key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
+    <array>
+        <string>/.claude/</string>
+    </array>
     <key>com.apple.security.temporary-exception.apple-events</key>
     <array>
         <string>com.apple.Terminal</string>

--- a/TokenEaterTests/CredentialsFileReaderTests.swift
+++ b/TokenEaterTests/CredentialsFileReaderTests.swift
@@ -1,0 +1,101 @@
+import Testing
+import Foundation
+
+@Suite("CredentialsFileReader")
+struct CredentialsFileReaderTests {
+
+    // MARK: - readToken
+
+    @Test("readToken returns token from valid credentials file")
+    func readTokenReturnsTokenFromValidFile() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let filePath = tempDir.appendingPathComponent(".credentials.json").path
+        let json = """
+        {"claudeAiOauth":{"accessToken":"test-token-123"}}
+        """
+        FileManager.default.createFile(atPath: filePath, contents: json.data(using: .utf8))
+
+        let reader = CredentialsFileReader(filePath: filePath)
+        #expect(reader.readToken() == "test-token-123")
+    }
+
+    @Test("readToken returns nil when file does not exist")
+    func readTokenReturnsNilWhenFileDoesNotExist() {
+        let reader = CredentialsFileReader(filePath: "/nonexistent/path/.credentials.json")
+        #expect(reader.readToken() == nil)
+    }
+
+    @Test("readToken returns nil when JSON is malformed")
+    func readTokenReturnsNilWhenJSONMalformed() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let filePath = tempDir.appendingPathComponent(".credentials.json").path
+        FileManager.default.createFile(atPath: filePath, contents: "not json".data(using: .utf8))
+
+        let reader = CredentialsFileReader(filePath: filePath)
+        #expect(reader.readToken() == nil)
+    }
+
+    @Test("readToken returns nil when accessToken is missing")
+    func readTokenReturnsNilWhenAccessTokenMissing() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let filePath = tempDir.appendingPathComponent(".credentials.json").path
+        let json = """
+        {"claudeAiOauth":{"refreshToken":"abc"}}
+        """
+        FileManager.default.createFile(atPath: filePath, contents: json.data(using: .utf8))
+
+        let reader = CredentialsFileReader(filePath: filePath)
+        #expect(reader.readToken() == nil)
+    }
+
+    @Test("readToken returns nil when accessToken is empty")
+    func readTokenReturnsNilWhenAccessTokenEmpty() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let filePath = tempDir.appendingPathComponent(".credentials.json").path
+        let json = """
+        {"claudeAiOauth":{"accessToken":""}}
+        """
+        FileManager.default.createFile(atPath: filePath, contents: json.data(using: .utf8))
+
+        let reader = CredentialsFileReader(filePath: filePath)
+        #expect(reader.readToken() == nil)
+    }
+
+    // MARK: - tokenExists
+
+    @Test("tokenExists returns true when file exists")
+    func tokenExistsReturnsTrueWhenFileExists() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let filePath = tempDir.appendingPathComponent(".credentials.json").path
+        FileManager.default.createFile(atPath: filePath, contents: "{}".data(using: .utf8))
+
+        let reader = CredentialsFileReader(filePath: filePath)
+        #expect(reader.tokenExists() == true)
+    }
+
+    @Test("tokenExists returns false when file does not exist")
+    func tokenExistsReturnsFalseWhenFileDoesNotExist() {
+        let reader = CredentialsFileReader(filePath: "/nonexistent/path/.credentials.json")
+        #expect(reader.tokenExists() == false)
+    }
+}

--- a/TokenEaterTests/KeychainServiceTests.swift
+++ b/TokenEaterTests/KeychainServiceTests.swift
@@ -1,0 +1,81 @@
+import Testing
+import Foundation
+
+@Suite("KeychainService – file-first strategy")
+struct KeychainServiceTests {
+
+    // MARK: - readOAuthToken
+
+    @Test("readOAuthToken returns file token when available")
+    func readOAuthTokenReturnsFileToken() {
+        let fileReader = MockCredentialsFileReader()
+        fileReader.storedToken = "file-token"
+        let sut = KeychainService(credentialsFileReader: fileReader)
+
+        #expect(sut.readOAuthToken() == "file-token")
+    }
+
+    @Test("readOAuthToken prefers file token over keychain")
+    func readOAuthTokenPrefersFileOverKeychain() {
+        let fileReader = MockCredentialsFileReader()
+        fileReader.storedToken = "file-wins"
+        let sut = KeychainService(credentialsFileReader: fileReader)
+
+        // Even if keychain has a real token, file token takes priority
+        #expect(sut.readOAuthToken() == "file-wins")
+    }
+
+    @Test("readOAuthToken consults keychain when file has no token")
+    func readOAuthTokenConsultsKeychain() {
+        let fileReader = MockCredentialsFileReader()
+        fileReader.storedToken = nil
+        let sut = KeychainService(credentialsFileReader: fileReader)
+
+        // Result is environment-dependent (nil in CI, real token on dev machine)
+        // Verify fallback path executes without error
+        let result = sut.readOAuthToken()
+        if let result { #expect(!result.isEmpty) }
+    }
+
+    // MARK: - readOAuthTokenSilently
+
+    @Test("readOAuthTokenSilently returns file token when available")
+    func readOAuthTokenSilentlyReturnsFileToken() {
+        let fileReader = MockCredentialsFileReader()
+        fileReader.storedToken = "silent-file-token"
+        let sut = KeychainService(credentialsFileReader: fileReader)
+
+        #expect(sut.readOAuthTokenSilently() == "silent-file-token")
+    }
+
+    @Test("readOAuthTokenSilently consults keychain when file has no token")
+    func readOAuthTokenSilentlyConsultsKeychain() {
+        let fileReader = MockCredentialsFileReader()
+        fileReader.storedToken = nil
+        let sut = KeychainService(credentialsFileReader: fileReader)
+
+        let result = sut.readOAuthTokenSilently()
+        if let result { #expect(!result.isEmpty) }
+    }
+
+    // MARK: - tokenExists
+
+    @Test("tokenExists returns true when credentials file exists")
+    func tokenExistsReturnsTrueWhenFileExists() {
+        let fileReader = MockCredentialsFileReader()
+        fileReader.fileExists = true
+        let sut = KeychainService(credentialsFileReader: fileReader)
+
+        #expect(sut.tokenExists() == true)
+    }
+
+    @Test("tokenExists consults keychain when file does not exist")
+    func tokenExistsConsultsKeychain() {
+        let fileReader = MockCredentialsFileReader()
+        fileReader.fileExists = false
+        let sut = KeychainService(credentialsFileReader: fileReader)
+
+        // Environment-dependent: true if dev machine has keychain token, false in CI
+        _ = sut.tokenExists()
+    }
+}

--- a/TokenEaterTests/Mocks/MockCredentialsFileReader.swift
+++ b/TokenEaterTests/Mocks/MockCredentialsFileReader.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+final class MockCredentialsFileReader: CredentialsFileReaderProtocol, @unchecked Sendable {
+    var storedToken: String?
+    var fileExists: Bool = false
+
+    func readToken() -> String? { storedToken }
+    func tokenExists() -> Bool { fileExists }
+}


### PR DESCRIPTION
## Summary

The macOS Keychain authorization dialog keeps appearing because:
- The ACL uses a `cdhash` (binary hash) — every app update invalidates "Always Allow"
- Claude Code recreates the Keychain item on each `/login`, resetting the ACL
- The `partition_id` is `apple-tool:` only

Claude Code stores the same OAuth token in `~/.claude/.credentials.json`. This PR reads that file first and only falls back to Keychain when the file is missing or has no token.

## Changes

- **Entitlement**: add sandbox read-only exception for `~/.claude/`
- **CredentialsFileReader**: new protocol-based service that reads `~/.claude/.credentials.json` and parses `claudeAiOauth.accessToken` (uses `getpwuid` for real home path)
- **KeychainService**: inject `CredentialsFileReader`, try file first in all 3 public methods (`readOAuthToken`, `readOAuthTokenSilently`, `tokenExists`), fall back to Keychain
- **Tests**: 14 new tests (7 for CredentialsFileReader, 7 for KeychainService file-first strategy)

## Test plan

- [x] 94 unit tests pass (80 existing + 14 new)
- [ ] Build + nuke + install — no more Keychain dialog
- [ ] Verify widget still reads shared JSON correctly