### PR TITLE
fix: initialize display toggles from store to prevent silent reset

### DIFF
--- a/TokenEaterApp/DisplaySectionView.swift
+++ b/TokenEaterApp/DisplaySectionView.swift
@@ -8,10 +8,23 @@ struct DisplaySectionView: View {
     // Binding to computed properties via $store.computedProp creates
     // unstable LocationProjections that the AttributeGraph can never
     // memoize, causing an infinite re-evaluation loop in Release builds.
-    @State private var showFiveHour = true
-    @State private var showSevenDay = true
-    @State private var showSonnet = false
-    @State private var showPacing = false
+    //
+    // Initialized from the store via init(initialMetrics:) to avoid a
+    // race condition: the switch in MainAppView destroys/recreates this
+    // view on every tab change — hardcoded defaults + .task correction
+    // triggered .onChange handlers whose at-least-one revert guard would
+    // silently re-add metrics the user had removed.
+    @State private var showFiveHour: Bool
+    @State private var showSevenDay: Bool
+    @State private var showSonnet: Bool
+    @State private var showPacing: Bool
+
+    init(initialMetrics: Set<MetricID>) {
+        _showFiveHour = State(initialValue: initialMetrics.contains(.fiveHour))
+        _showSevenDay = State(initialValue: initialMetrics.contains(.sevenDay))
+        _showSonnet = State(initialValue: initialMetrics.contains(.sonnet))
+        _showPacing = State(initialValue: initialMetrics.contains(.pacing))
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -44,13 +57,6 @@ struct DisplaySectionView: View {
             Spacer()
         }
         .padding(24)
-        // Initialize local state from stores
-        .task {
-            showFiveHour = settingsStore.pinnedMetrics.contains(.fiveHour)
-            showSevenDay = settingsStore.pinnedMetrics.contains(.sevenDay)
-            showSonnet = settingsStore.pinnedMetrics.contains(.sonnet)
-            showPacing = settingsStore.pinnedMetrics.contains(.pacing)
-        }
         // Sync: local toggle -> store (with at-least-one guard)
         .onChange(of: showFiveHour) { _, new in syncMetric(.fiveHour, on: new, revert: { showFiveHour = true }) }
         .onChange(of: showSevenDay) { _, new in syncMetric(.sevenDay, on: new, revert: { showSevenDay = true }) }

--- a/TokenEaterApp/MainAppView.swift
+++ b/TokenEaterApp/MainAppView.swift
@@ -29,7 +29,7 @@ struct MainAppView: View {
                 case .dashboard:
                     DashboardView()
                 case .display:
-                    DisplaySectionView()
+                    DisplaySectionView(initialMetrics: settingsStore.pinnedMetrics)
                 case .themes:
                     ThemesSectionView()
                 case .settings:


### PR DESCRIPTION
## Summary

- Fix pinned metric toggles in the Display tab silently reverting to defaults on tab switch, window reopen, and app update
- Initialize `@State` from the store's current `pinnedMetrics` via `init(initialMetrics:)` instead of hardcoded defaults + async `.task` correction
- Remove the `.task` initialization block entirely — no more race condition between `.task` and `.onChange` handlers

## Root cause

The `switch` in `MainAppView` destroys/recreates `DisplaySectionView` on every tab change. The `@State` toggles had hardcoded defaults (`fiveHour=true`, `sevenDay=true`, `sonnet=false`, `pacing=false`) corrected asynchronously via `.task` — but `.onChange` handlers fired during that correction and the at-least-one revert guard could re-insert metrics the user had removed, silently corrupting the store and persisting the corruption to UserDefaults.

## Test plan

- [x] 131 unit tests pass
- [ ] Build + nuke + install: toggle only Sonnet ON (disable Session + Weekly), switch tabs, come back → Sonnet should stay the only one ON
- [ ] Same test after closing and reopening the window
- [ ] Toggle metrics from the popover while Display tab is open → toggles should stay in sync

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)