### PR TITLE
fix : cpu and memory usage on popover from the task bar

### DIFF
--- a/Shared/Extensions/Extensions.swift
+++ b/Shared/Extensions/Extensions.swift
@@ -18,18 +18,25 @@ extension Color {
 }
 
 extension Color {
+    private static var lighterCache: [String: Color] = [:]
+
     /// Returns a lighter version of this color by the given factor (0.0 – 1.0).
     func lighter(by amount: Double = 0.15) -> Color {
+        let key = "\(self.description)|\(amount)"
+        if let cached = Self.lighterCache[key] { return cached }
+
         let nsColor = NSColor(self)
         var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
         let converted = nsColor.usingColorSpace(.sRGB) ?? nsColor
         converted.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
-        return Color(
+        let result = Color(
             hue: Double(h),
             saturation: Double(max(s - CGFloat(amount) * 0.3, 0)),
             brightness: Double(min(b + CGFloat(amount), 1.0)),
             opacity: Double(a)
         )
+        Self.lighterCache[key] = result
+        return result
     }
 }
 
@@ -49,9 +56,13 @@ extension NSColor {
 // MARK: - Date Relative Format
 
 extension Date {
-    var relativeFormatted: String {
+    private static let relativeFormatter: RelativeDateTimeFormatter = {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated
-        return formatter.localizedString(for: self, relativeTo: Date())
+        return formatter
+    }()
+
+    var relativeFormatted: String {
+        Self.relativeFormatter.localizedString(for: self, relativeTo: Date())
     }
 }

--- a/Shared/Helpers/NotificationBodyFormatter.swift
+++ b/Shared/Helpers/NotificationBodyFormatter.swift
@@ -93,21 +93,29 @@ enum NotificationBodyFormatter {
         }
     }
 
-    static func formatTime(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .none
-        formatter.timeStyle = .short
-        return formatter.string(from: date)
-    }
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .none
+        f.timeStyle = .short
+        return f
+    }()
 
-    static func formatDateTime(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = DateFormatter.dateFormat(
+    private static let dateTimeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = DateFormatter.dateFormat(
             fromTemplate: "EEE MMM d, h:mm a",
             options: 0,
             locale: .current
         )
-        return formatter.string(from: date)
+        return f
+    }()
+
+    static func formatTime(_ date: Date) -> String {
+        timeFormatter.string(from: date)
+    }
+
+    static func formatDateTime(_ date: Date) -> String {
+        dateTimeFormatter.string(from: date)
     }
 
     // MARK: - Fallback

--- a/Shared/Models/UsageModels.swift
+++ b/Shared/Models/UsageModels.swift
@@ -50,16 +50,22 @@ struct UsageBucket: Codable {
         case resetsAt = "resets_at"
     }
 
+    private static let iso8601WithFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static let iso8601WithoutFractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
     var resetsAtDate: Date? {
         guard let resetsAt else { return nil }
-        let withFractional = ISO8601DateFormatter()
-        withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        if let date = withFractional.date(from: resetsAt) {
-            return date
-        }
-        let withoutFractional = ISO8601DateFormatter()
-        withoutFractional.formatOptions = [.withInternetDateTime]
-        return withoutFractional.date(from: resetsAt)
+        return Self.iso8601WithFractional.date(from: resetsAt)
+            ?? Self.iso8601WithoutFractional.date(from: resetsAt)
     }
 }
 

--- a/Shared/Services/SharedFileService.swift
+++ b/Shared/Services/SharedFileService.swift
@@ -59,14 +59,20 @@ final class SharedFileService: SharedFileServiceProtocol, @unchecked Sendable {
         var thresholds: UsageThresholds?
     }
 
+    private var cache: SharedData?
+
     private func load() -> SharedData {
+        if let cache { return cache }
         guard let data = try? Data(contentsOf: sharedFileURL) else {
             return SharedData()
         }
-        return (try? JSONDecoder().decode(SharedData.self, from: data)) ?? SharedData()
+        let decoded = (try? JSONDecoder().decode(SharedData.self, from: data)) ?? SharedData()
+        cache = decoded
+        return decoded
     }
 
     private func save(_ shared: SharedData) {
+        cache = shared
         let dir = sharedFileURL.deletingLastPathComponent()
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         try? JSONEncoder().encode(shared).write(to: sharedFileURL, options: .atomic)

--- a/TokenEaterApp/DashboardView.swift
+++ b/TokenEaterApp/DashboardView.swift
@@ -8,8 +8,6 @@ struct DashboardView: View {
     @State private var isVisible = false
     @State private var lastUpdateText = ""
 
-    private let updateTimer = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
-
     var body: some View {
         ZStack {
             // Animated background
@@ -29,17 +27,20 @@ struct DashboardView: View {
         }
         .onAppear {
             isVisible = true
-            refreshLastUpdateText()
-            // Single refresh on appear — auto-refresh lifecycle is owned by StatusBarController
-            if settingsStore.hasCompletedOnboarding {
-                Task { await usageStore.refresh(thresholds: themeStore.thresholds) }
-            }
         }
         .onDisappear {
             isVisible = false
         }
-        .onReceive(updateTimer) { _ in
+        .task {
             refreshLastUpdateText()
+            // Single refresh on appear — auto-refresh lifecycle is owned by StatusBarController
+            if settingsStore.hasCompletedOnboarding {
+                await usageStore.refresh(thresholds: themeStore.thresholds)
+            }
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(30))
+                refreshLastUpdateText()
+            }
         }
         .onChange(of: usageStore.lastUpdate) { _, _ in
             refreshLastUpdateText()

--- a/TokenEaterApp/MenuBarView.swift
+++ b/TokenEaterApp/MenuBarView.swift
@@ -9,8 +9,6 @@ struct MenuBarPopoverView: View {
 
     @State private var lastUpdateText = ""
 
-    private let updateTimer = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
-
     var body: some View {
         VStack(spacing: 0) {
             // Header
@@ -152,15 +150,16 @@ struct MenuBarPopoverView: View {
         }
         .frame(width: 300)
         .background(Color(nsColor: NSColor(red: 0.08, green: 0.08, blue: 0.09, alpha: 1)))
-        .onAppear {
+        .task {
             refreshLastUpdateText()
             // Single refresh on appear — auto-refresh lifecycle is owned by StatusBarController
             if settingsStore.hasCompletedOnboarding {
-                Task { await usageStore.refresh(thresholds: themeStore.thresholds) }
+                await usageStore.refresh(thresholds: themeStore.thresholds)
             }
-        }
-        .onReceive(updateTimer) { _ in
-            refreshLastUpdateText()
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(30))
+                refreshLastUpdateText()
+            }
         }
         .onChange(of: usageStore.lastUpdate) { _, _ in
             refreshLastUpdateText()

--- a/TokenEaterApp/StatusBarController.swift
+++ b/TokenEaterApp/StatusBarController.swift
@@ -56,9 +56,6 @@ final class StatusBarController: NSObject {
 
     private func setupPopover() {
         popover.behavior = .transient
-    }
-
-    private func installPopoverContent() {
         let popoverView = MenuBarPopoverView()
             .environmentObject(usageStore)
             .environmentObject(themeStore)
@@ -147,11 +144,9 @@ final class StatusBarController: NSObject {
     private func togglePopover() {
         if popover.isShown {
             popover.performClose(nil)
-            popover.contentViewController = nil
             stopEventMonitor()
         } else {
             guard let button = statusItem.button else { return }
-            installPopoverContent()
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
             startEventMonitor()
         }
@@ -159,7 +154,6 @@ final class StatusBarController: NSObject {
 
     func showDashboard() {
         popover.performClose(nil)
-        popover.contentViewController = nil
         stopEventMonitor()
 
         if let window = dashboardWindow {
@@ -243,7 +237,6 @@ final class StatusBarController: NSObject {
     private func startEventMonitor() {
         eventMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] _ in
             self?.popover.performClose(nil)
-            self?.popover.contentViewController = nil
             self?.stopEventMonitor()
         }
     }

--- a/TokenEaterWidget/UsageEntry.swift
+++ b/TokenEaterWidget/UsageEntry.swift
@@ -14,10 +14,14 @@ struct UsageEntry: TimelineEntry {
         self.isStale = isStale
     }
 
+    private static let iso8601Formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
     private static func iso8601String(from date: Date) -> String {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return formatter.string(from: date)
+        iso8601Formatter.string(from: date)
     }
 
     static var placeholder: UsageEntry {

--- a/TokenEaterWidget/UsageWidgetView.swift
+++ b/TokenEaterWidget/UsageWidgetView.swift
@@ -269,11 +269,15 @@ struct UsageWidgetView: View {
         }
     }
 
+    private static let resetDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "EEE HH:mm"
+        return f
+    }()
+
     private func formatResetDate(_ date: Date?) -> String {
         guard let date = date else { return "" }
-        let formatter = DateFormatter()
-        formatter.dateFormat = "EEE HH:mm"
-        return formatter.string(from: date)
+        return Self.resetDateFormatter.string(from: date)
     }
 }
 


### PR DESCRIPTION
The results are massive drops in both memory footprint and CPU overhead:
* **Memory Usage:** Reduced by ~70% (from ~180MB down to ~50MB).
* **CPU Usage:** Dropped from ~48% down to ~5% during active use.

---

### Benchmarks & Proofs

#### Before
*Memory was hovering around 180MB, and CPU spiked heavily during Popover and Dashboard interactions.*

* **Memory Usage:**
  ![Pasted Graphic](https://github.com/user-attachments/assets/ac4f2bff-de44-4c28-879b-85ba79943e55)
* **CPU Usage (Popover from taskbar):**
  ![My Mac](https://github.com/user-attachments/assets/80939794-e32f-4603-82ad-4858a35bd089)
* **CPU Usage (Dashboard opened):**
  ![Open Quickly](https://github.com/user-attachments/assets/1a05c54a-5e68-4577-be03-e186bd60baa4)

#### After
*Memory is now stable around 50MB, and CPU usage is minimal (~5%).*

* **Memory Usage:**
<img width="736" height="511" alt="image" src="https://github.com/user-attachments/assets/e04deae4-6e48-45cb-b918-e5a55b029d50" />

* **CPU Usage:**
<img width="634" height="530" alt="image" src="https://github.com/user-attachments/assets/7e82d7bf-4048-44e0-86ae-991bc73c46a9" />


---

### What Changed

1: Popover Reusability** (`StatusBarController.swift`)
    Created `NSHostingController` only once in `setupPopover()`.
    Removed `installPopoverContent()` and stopped nullifying `contentViewController` on close, preventing heavy UI re-renders.
2: Refactored Timers to Tasks** (`MenuBarView.swift`, `DashboardView.swift`)
    Replaced `Timer.publish(...).autoconnect()` and `.onReceive` with `.task { while !Task.isCancelled }`. 
    This ensures timers are automatically and cleanly cancelled when the view disappears.
3: SharedFile Caching** (`SharedFileService.swift`)
    Added a `private var cache: SharedData?`. 
    `load()` now returns the cache if populated, and `save()` updates the memory cache before writing to disk to reduce I/O bottlenecks.
4: Color Calculation Caching** (`Extensions.swift`)
    Added a `private static var lighterCache` dictionary (keyed by color description + amount) to cache the results of the `lighter()` function, saving expensive redundant calculations.
5: Static Date Formatters** (`Extensions.swift`, `UsageModels.swift`, `NotificationBodyFormatter.swift`)
    Date formatters are notoriously expensive to initialize. Converted all `DateFormatter`, `ISO8601DateFormatter`, and `RelativeDateTimeFormatter` instances to `private static let` so they are instantiated only once.