### PR TITLE
fix: eliminate repeated Keychain password prompts

### DIFF
--- a/Shared/Models/MetricModels.swift
+++ b/Shared/Models/MetricModels.swift
@@ -35,5 +35,6 @@ enum AppErrorState: Equatable {
     case none
     case tokenExpired
     case keychainLocked
+    case needsReauth
     case networkError(String)
 }

--- a/Shared/Repositories/UsageRepository.swift
+++ b/Shared/Repositories/UsageRepository.swift
@@ -28,6 +28,13 @@ final class UsageRepository: UsageRepositoryProtocol {
         }
     }
 
+    /// Credentials file sync — no Keychain access at all.
+    func syncCredentialsFile() {
+        if let token = keychainService.readCredentialsFileToken() {
+            sharedFileService.oauthToken = token
+        }
+    }
+
     var isConfigured: Bool {
         sharedFileService.isConfigured
     }

--- a/Shared/Repositories/UsageRepositoryProtocol.swift
+++ b/Shared/Repositories/UsageRepositoryProtocol.swift
@@ -8,6 +8,8 @@ protocol UsageRepositoryProtocol {
     func syncKeychainToken()
     /// Silent keychain read — never triggers dialog.
     func syncKeychainTokenSilently()
+    /// Credentials file sync — no Keychain access at all.
+    func syncCredentialsFile()
     var isConfigured: Bool { get }
     var cachedUsage: CachedUsage? { get }
     var currentToken: String? { get }

--- a/Shared/Services/KeychainService.swift
+++ b/Shared/Services/KeychainService.swift
@@ -19,6 +19,11 @@ final class KeychainService: KeychainServiceProtocol, @unchecked Sendable {
         credentialsFileReader.readToken() ?? readKeychainToken(allowUI: false)
     }
 
+    /// Read token from credentials file only — no Keychain access at all.
+    func readCredentialsFileToken() -> String? {
+        credentialsFileReader.readToken()
+    }
+
     func tokenExists() -> Bool {
         if credentialsFileReader.tokenExists() { return true }
 

--- a/Shared/Services/Protocols/KeychainServiceProtocol.swift
+++ b/Shared/Services/Protocols/KeychainServiceProtocol.swift
@@ -5,5 +5,7 @@ protocol KeychainServiceProtocol: Sendable {
     func readOAuthToken() -> String?
     /// Silent read — never triggers dialog. Returns nil if auth is needed.
     func readOAuthTokenSilently() -> String?
+    /// Read token from credentials file only — no Keychain access at all.
+    func readCredentialsFileToken() -> String?
     func tokenExists() -> Bool
 }

--- a/Shared/Stores/UsageStore.swift
+++ b/Shared/Stores/UsageStore.swift
@@ -53,10 +53,10 @@ final class UsageStore: ObservableObject {
             return
         }
 
-        // Silent keychain read — try to recover token if not configured
+        // Credentials file read — try to recover token if not configured
         // or if the current one already failed (auto-recovery from Claude Code refresh).
         if !repository.isConfigured || lastFailedToken == repository.currentToken {
-            repository.syncKeychainTokenSilently()
+            repository.syncCredentialsFile()
             if let currentToken = repository.currentToken, currentToken != lastFailedToken {
                 lastFailedToken = nil
                 errorState = .none
@@ -91,7 +91,7 @@ final class UsageStore: ObservableObject {
                 lastFailedToken = repository.currentToken
                 errorState = .tokenExpired
             case .keychainLocked:
-                errorState = .keychainLocked
+                errorState = .needsReauth
             case .httpError(429):
                 // Rate limited — silently skip, auto-refresh will retry later
                 break
@@ -111,8 +111,8 @@ final class UsageStore: ObservableObject {
     }
 
     func reloadConfig(thresholds: UsageThresholds = .default) {
-        // Silent keychain read — never triggers macOS password dialog
-        repository.syncKeychainTokenSilently()
+        // Credentials file read — never triggers macOS password dialog
+        repository.syncCredentialsFile()
         lastFailedToken = nil
         errorState = .none
         hasConfig = repository.isConfigured
@@ -145,12 +145,22 @@ final class UsageStore: ObservableObject {
         refreshTask?.cancel()
     }
 
+    func reauthenticate() async {
+        repository.syncKeychainToken()  // interactive — 1 prompt
+        if repository.isConfigured, repository.currentToken != lastFailedToken {
+            lastFailedToken = nil
+            errorState = .none
+            hasConfig = true
+            await refresh(force: true)
+        }
+    }
+
     func testConnection() async -> ConnectionTestResult {
         await repository.testConnection(proxyConfig: proxyConfig)
     }
 
     func connectAutoDetect() async -> ConnectionTestResult {
-        repository.syncKeychainTokenSilently()
+        repository.syncCredentialsFile()
         let result = await repository.testConnection(proxyConfig: proxyConfig)
         if result.success {
             hasConfig = true

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -90,6 +90,9 @@
 "error.banner.expired.hint" = "Run /login in Claude Code — TokenEater will pick it up automatically";
 "error.banner.keychain" = "Keychain locked";
 "error.banner.keychain.hint" = "Will retry automatically — or open Settings to re-authorize";
+"error.banner.reauth" = "Authorization needed";
+"error.banner.reauth.hint" = "Token expired and automatic recovery failed";
+"error.banner.reauth.button" = "Re-authorize";
 
 /* Connection Test */
 "test.success" = "Connected — Session: %d%%";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -90,6 +90,9 @@
 "error.banner.expired.hint" = "Lancez /login dans Claude Code — TokenEater le récupérera automatiquement";
 "error.banner.keychain" = "Keychain verrouillé";
 "error.banner.keychain.hint" = "Nouvelle tentative automatique — ou ouvrez les Réglages pour ré-autoriser";
+"error.banner.reauth" = "Autorisation requise";
+"error.banner.reauth.hint" = "Token expiré et la récupération automatique a échoué";
+"error.banner.reauth.button" = "Ré-autoriser";
 
 /* Connection Test */
 "test.success" = "Connexion OK — Session : %d%%";

--- a/TokenEaterApp/MenuBarView.swift
+++ b/TokenEaterApp/MenuBarView.swift
@@ -335,6 +335,26 @@ struct MenuBarPopoverView: View {
                 Text(String(localized: "error.banner.keychain.hint"))
                     .font(.system(size: 10))
                     .foregroundStyle(.white.opacity(0.5))
+            case .needsReauth:
+                Label(String(localized: "error.banner.reauth"), systemImage: "key.fill")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.orange)
+                Text(String(localized: "error.banner.reauth.hint"))
+                    .font(.system(size: 10))
+                    .foregroundStyle(.white.opacity(0.5))
+                Button {
+                    Task { await usageStore.reauthenticate() }
+                } label: {
+                    Text(String(localized: "error.banner.reauth.button"))
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 4)
+                        .background(.orange.opacity(0.3))
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .padding(.top, 2)
             case .networkError(let message):
                 Label(message, systemImage: "wifi.slash")
                     .font(.system(size: 11, weight: .semibold))

--- a/TokenEaterApp/OnboardingViewModel.swift
+++ b/TokenEaterApp/OnboardingViewModel.swift
@@ -54,7 +54,11 @@ final class OnboardingViewModel: ObservableObject {
     func checkClaudeCode() {
         claudeCodeStatus = .checking
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            self?.claudeCodeStatus = self?.keychainService.tokenExists() == true ? .detected : .notFound
+            guard let self else { return }
+            let hasToken = self.repository.isConfigured
+                || self.keychainService.readCredentialsFileToken() != nil
+                || self.keychainService.tokenExists()
+            self.claudeCodeStatus = hasToken ? .detected : .notFound
         }
     }
 
@@ -87,7 +91,15 @@ final class OnboardingViewModel: ObservableObject {
 
     func connect() {
         connectionStatus = .connecting
-        repository.syncKeychainToken()
+        // 1. Check stored token (survives DMG upgrades)
+        if !repository.isConfigured {
+            // 2. Check credentials file (~/.claude/.credentials.json)
+            repository.syncCredentialsFile()
+        }
+        if !repository.isConfigured {
+            // 3. Last resort: interactive Keychain read (1 prompt max)
+            repository.syncKeychainToken()
+        }
         guard repository.isConfigured else {
             connectionStatus = .failed(String(localized: "onboarding.connection.failed.notoken"))
             NSApp.activate(ignoringOtherApps: true)

--- a/TokenEaterTests/Mocks/MockKeychainService.swift
+++ b/TokenEaterTests/Mocks/MockKeychainService.swift
@@ -5,5 +5,6 @@ final class MockKeychainService: KeychainServiceProtocol, @unchecked Sendable {
 
     func readOAuthToken() -> String? { storedToken }
     func readOAuthTokenSilently() -> String? { storedToken }
+    func readCredentialsFileToken() -> String? { storedToken }
     func tokenExists() -> Bool { storedToken != nil }
 }

--- a/TokenEaterTests/Mocks/MockUsageRepository.swift
+++ b/TokenEaterTests/Mocks/MockUsageRepository.swift
@@ -11,6 +11,7 @@ final class MockUsageRepository: UsageRepositoryProtocol {
 
     var syncCallCount = 0
     var syncSilentCallCount = 0
+    var syncCredentialsFileCallCount = 0
 
     var isConfigured: Bool { isConfiguredValue }
     var cachedUsage: CachedUsage? { cachedValue }
@@ -18,6 +19,7 @@ final class MockUsageRepository: UsageRepositoryProtocol {
 
     func syncKeychainToken() { syncCallCount += 1 }
     func syncKeychainTokenSilently() { syncSilentCallCount += 1 }
+    func syncCredentialsFile() { syncCredentialsFileCallCount += 1 }
 
     func refreshUsage(proxyConfig: ProxyConfig?) async throws -> UsageResponse {
         if let error = stubbedError { throw error }

--- a/TokenEaterTests/UsageRepositoryTests.swift
+++ b/TokenEaterTests/UsageRepositoryTests.swift
@@ -65,6 +65,27 @@ struct UsageRepositoryTests {
         #expect(sharedFile._oauthToken == nil)
     }
 
+    // MARK: - syncCredentialsFile
+
+    @Test("syncCredentialsFile copies credentials file token to shared file")
+    func syncCredentialsFileCopiesToSharedFile() {
+        let (repo, _, keychain, sharedFile) = makeSUT()
+        keychain.storedToken = "cred-tok"
+
+        repo.syncCredentialsFile()
+
+        #expect(sharedFile._oauthToken == "cred-tok")
+    }
+
+    @Test("syncCredentialsFile does nothing when no credentials file token")
+    func syncCredentialsFileDoesNothingWhenNoToken() {
+        let (repo, _, _, sharedFile) = makeSUT()
+
+        repo.syncCredentialsFile()
+
+        #expect(sharedFile._oauthToken == nil)
+    }
+
     // MARK: - currentToken
 
     @Test("currentToken delegates to shared file oauthToken")

--- a/TokenEaterTests/UsageStoreTests.swift
+++ b/TokenEaterTests/UsageStoreTests.swift
@@ -57,13 +57,13 @@ struct UsageStoreTests {
         #expect(store.isLoading == false)
     }
 
-    @Test("refresh calls syncKeychainTokenSilently when not configured")
-    func refreshCallsSyncSilentlyWhenNotConfigured() async {
+    @Test("refresh calls syncCredentialsFile when not configured")
+    func refreshCallsSyncCredentialsFileWhenNotConfigured() async {
         let (store, repo, _) = makeSUT(isConfigured: false)
 
         await store.refresh()
 
-        #expect(repo.syncSilentCallCount == 1)
+        #expect(repo.syncCredentialsFileCallCount == 1)
         #expect(repo.syncCallCount == 0)
     }
 
@@ -110,13 +110,13 @@ struct UsageStoreTests {
         #expect(store.hasError == true)
     }
 
-    @Test("refresh sets keychainLocked error")
-    func refreshSetsKeychainLockedError() async {
+    @Test("refresh sets needsReauth error on keychainLocked")
+    func refreshSetsNeedsReauthError() async {
         let (store, _, _) = makeSUT(shouldFail: true, failWith: .keychainLocked)
 
         await store.refresh()
 
-        #expect(store.errorState == .keychainLocked)
+        #expect(store.errorState == .needsReauth)
     }
 
     @Test("refresh sets networkError on generic API error")


### PR DESCRIPTION
Check shared.json and credentials file before Keychain access. Read Keychain at most once during onboarding, and only as last resort. Replace silent Keychain reads in refresh/reload with credentials-file-only reads. Add "Re-authorize" UI for manual token recovery when all automatic recovery fails.

see issue https://github.com/AThevon/TokenEater/issues/65