### PR TITLE
feat: smart tab focus + fix Cursor activation

### DIFF
--- a/Shared/Helpers/ProcessResolver.swift
+++ b/Shared/Helpers/ProcessResolver.swift
@@ -32,8 +32,35 @@ enum ProcessResolver {
         DispatchQueue.global(qos: .userInitiated).async {
             switchTmuxPane(parentPid: process.parentPid)
         }
-        // Activate terminal app immediately (don't wait for tmux)
-        activateParentApp(pid: process.parentPid)
+
+        // Resolve the real host app (skipping Electron helpers)
+        guard let app = resolveHostApp(startingFrom: process.parentPid) else { return }
+        let bundleID = app.bundleIdentifier ?? ""
+
+        // Try smart tab focus first (handles both activation + tab selection).
+        let tty = resolveProcessTTY(startingFrom: process.pid)
+
+        var handled = false
+        switch bundleID {
+        case "com.apple.Terminal":
+            if let tty {
+                handled = focusTerminalTab(tty: tty)
+            }
+        case "com.googlecode.iterm2":
+            if let tty {
+                handled = focusITerm2Tab(tty: tty)
+            }
+        case "net.kovidgoyal.kitty":
+            focusKittyTab(pid: process.parentPid)
+            handled = true
+        default:
+            break
+        }
+
+        // Fallback: generic app activation (brings to front, no tab selection)
+        if !handled {
+            activateApp(app)
+        }
     }
 
     // MARK: - tmux trigger file
@@ -154,32 +181,181 @@ enum ProcessResolver {
         return ppid > 0 ? ppid : nil
     }
 
-    // MARK: - Terminal Activation
+    /// Get the controlling terminal (TTY) for a process.
+    /// Constructs the path directly from the device number to avoid `devname()`,
+    /// which reads `/dev` and fails silently inside the app sandbox.
+    static func getProcessTTY(pid: Int32) -> String? {
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, pid]
+        var info = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.size
+        guard sysctl(&mib, UInt32(mib.count), &info, &size, nil, 0) == 0, size > 0 else { return nil }
+        let tdev = info.kp_eproc.e_tdev
+        guard tdev > 0 else { return nil }
+        // macOS device number: major = (dev >> 24) & 0xff, minor = dev & 0xffffff
+        // Pseudo-terminal slaves have major 16 → /dev/ttysNNN
+        let major = (Int(tdev) >> 24) & 0xff
+        let minor = Int(tdev) & 0xffffff
+        guard major == 16 else { return nil }
+        return String(format: "/dev/ttys%03d", minor)
+    }
 
-    private static func activateParentApp(pid: Int32) {
-        let runningApps = NSWorkspace.shared.runningApplications
+    /// Walk up the PID tree to find the controlling TTY.
+    private static func resolveProcessTTY(startingFrom pid: Int32) -> String? {
         var currentPid = pid
-
         for _ in 0..<10 {
-            if let app = runningApps.first(where: { $0.processIdentifier == currentPid }) {
-                activateApp(app)
-                return
+            if let tty = getProcessTTY(pid: currentPid) {
+                return tty
             }
             guard let ppid = getParentPid(currentPid), ppid > 1 else { break }
             currentPid = ppid
         }
+        return nil
+    }
 
-        let terminalBundles = [
-            "com.github.wez.wezterm", "io.wezfurlong.wezterm",
-            "com.googlecode.iterm2", "com.apple.Terminal",
-            "dev.warp.Warp-Stable", "com.microsoft.VSCode"
-        ]
+    /// Check if a bundle URL is an Electron helper (nested inside /Contents/Frameworks/).
+    static func isElectronHelper(bundleURL: URL?) -> Bool {
+        guard let path = bundleURL?.path else { return false }
+        return path.contains("/Contents/Frameworks/")
+    }
+
+    // MARK: - Terminal Activation
+
+    static let terminalBundles = [
+        "com.github.wez.wezterm", "io.wezfurlong.wezterm",
+        "com.googlecode.iterm2", "com.apple.Terminal",
+        "dev.warp.Warp-Stable", "com.microsoft.VSCode",
+        "com.todesktop.230313mzl4w4u92",  // Cursor
+        "net.kovidgoyal.kitty",
+    ]
+
+    /// Map non-GUI ancestor process paths to their parent GUI app bundle ID.
+    /// Some terminals (iTerm2, Kitty) spawn shells via helper services that
+    /// are not in NSWorkspace.runningApplications.
+    private static let serviceToAppBundle: [(pathContains: String, bundleID: String)] = [
+        ("iTerm2/iTermServer", "com.googlecode.iterm2"),
+        ("kitty", "net.kovidgoyal.kitty"),
+    ]
+
+    /// Walk the PID tree to find the host app, skipping Electron helper processes.
+    /// Also detects non-GUI service processes (e.g. iTermServer) and maps them
+    /// to their parent GUI app.
+    private static func resolveHostApp(startingFrom pid: Int32) -> NSRunningApplication? {
+        let runningApps = NSWorkspace.shared.runningApplications
+        var currentPid = pid
+
+        for _ in 0..<10 {
+            // Check if this PID is a GUI app
+            if let app = runningApps.first(where: { $0.processIdentifier == currentPid }) {
+                if !isElectronHelper(bundleURL: app.bundleURL) {
+                    return app
+                }
+            }
+
+            // Check if this PID is a known non-GUI service (e.g. iTermServer)
+            var pathBuffer = [CChar](repeating: 0, count: Int(MAXPATHLEN))
+            if proc_pidpath(currentPid, &pathBuffer, UInt32(MAXPATHLEN)) > 0 {
+                let path = String(cString: pathBuffer)
+                for mapping in serviceToAppBundle {
+                    if path.contains(mapping.pathContains),
+                       let app = runningApps.first(where: { $0.bundleIdentifier == mapping.bundleID }) {
+                        return app
+                    }
+                }
+            }
+
+            guard let ppid = getParentPid(currentPid), ppid > 1 else { break }
+            currentPid = ppid
+        }
+
+        // Fallback: find any known terminal that's running
         for bundle in terminalBundles {
             if let app = runningApps.first(where: { $0.bundleIdentifier == bundle }) {
-                activateApp(app)
-                return
+                return app
             }
         }
+        return nil
+    }
+
+    // MARK: - Smart Tab Focus
+
+    /// Run AppleScript in-process via NSAppleScript.
+    /// If TCC blocks it (-1743), falls back to osascript which triggers the
+    /// macOS permission prompt as a side effect. The next click will then work.
+    @discardableResult
+    private static func runAppleScript(_ source: String, targetBundleID: String) -> Bool {
+        // Try NSAppleScript first (works if TCC already approved)
+        var error: NSDictionary?
+        NSAppleScript(source: source)?.executeAndReturnError(&error)
+        if error == nil { return true }
+
+        let errorCode = (error?["NSAppleScriptErrorNumber"] as? Int) ?? 0
+
+        // Error -1743 = TCC not approved. Run via osascript to trigger the
+        // macOS permission prompt. osascript itself will fail (-10004, sandbox)
+        // but the TCC prompt appears. Next click will succeed via NSAppleScript.
+        if errorCode == -1743 {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+            process.arguments = ["-e", source]
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+            try? process.run()
+            process.waitUntilExit()
+        }
+
+        return false
+    }
+
+    /// Select the tab matching a TTY in Terminal.app via AppleScript.
+    @discardableResult
+    private static func focusTerminalTab(tty: String) -> Bool {
+        let source = """
+        tell application "Terminal"
+            activate
+            repeat with w in windows
+                repeat with t from 1 to count of tabs of w
+                    if tty of tab t of w is "\(tty)" then
+                        set selected tab of w to tab t of w
+                        set index of w to 1
+                        return
+                    end if
+                end repeat
+            end repeat
+        end tell
+        """
+        return runAppleScript(source, targetBundleID: "com.apple.Terminal")
+    }
+
+    /// Select the tab matching a TTY in iTerm2 via AppleScript.
+    @discardableResult
+    private static func focusITerm2Tab(tty: String) -> Bool {
+        let source = """
+        tell application "iTerm2"
+            activate
+            repeat with w in windows
+                repeat with t in tabs of w
+                    repeat with s in sessions of t
+                        if tty of s is "\(tty)" then
+                            select t
+                            select w
+                            return
+                        end if
+                    end repeat
+                end repeat
+            end repeat
+        end tell
+        """
+        return runAppleScript(source, targetBundleID: "com.googlecode.iterm2")
+    }
+
+    /// Focus the tab running a process in Kitty via remote control CLI.
+    private static func focusKittyTab(pid: Int32) {
+        let kittenPaths = ["/opt/homebrew/bin/kitten", "/usr/local/bin/kitten", "/usr/bin/kitten"]
+        guard let kittenPath = kittenPaths.first(where: { FileManager.default.fileExists(atPath: $0) }) else { return }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: kittenPath)
+        process.arguments = ["@", "focus-tab", "--match", "pid:\(pid)"]
+        try? process.run()
     }
 
     /// Activate via LaunchServices — reliably switches spaces/fullscreen.

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -277,11 +277,15 @@
 "settings.watchers.tmux.title" = "tmux setup";
 "settings.watchers.tmux.hint" = "If you use tmux, add this line to your ~/.tmux.conf so TokenEater can switch to the right pane on click:";
 "settings.watchers.tmux.copy" = "Copy";
+"settings.watchers.kitty.title" = "Kitty setup";
+"settings.watchers.kitty.hint" = "If you use Kitty, add this line to your kitty.conf so TokenEater can switch to the right tab on click:";
+"settings.watchers.kitty.copy" = "Copy";
 
 /* Onboarding - Agent Watchers */
 "onboarding.watchers.title" = "Agent Watchers";
 "onboarding.watchers.description" = "A floating overlay that shows your active Claude Code sessions at a glance. Hover to expand, click to jump straight to a session.";
 "onboarding.watchers.tmux.hint" = "If you use tmux, add this line to your config to enable click-to-switch:";
+"onboarding.watchers.kitty.hint" = "If you use Kitty, add to your kitty.conf:";
 "onboarding.watchers.settings.hint" = "You can switch to a simplified view in Settings.";
 
 /* Performance */

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -277,11 +277,15 @@
 "settings.watchers.tmux.title" = "Configuration tmux";
 "settings.watchers.tmux.hint" = "Si vous utilisez tmux, ajoutez cette ligne à votre ~/.tmux.conf pour que TokenEater puisse basculer vers le bon pane au clic :";
 "settings.watchers.tmux.copy" = "Copier";
+"settings.watchers.kitty.title" = "Configuration Kitty";
+"settings.watchers.kitty.hint" = "Si vous utilisez Kitty, ajoutez cette ligne à votre kitty.conf pour que TokenEater puisse basculer vers le bon onglet au clic :";
+"settings.watchers.kitty.copy" = "Copier";
 
 /* Onboarding - Agent Watchers */
 "onboarding.watchers.title" = "Agent Watchers";
 "onboarding.watchers.description" = "Un overlay flottant qui montre vos sessions Claude Code actives d'un coup d'œil. Survolez pour agrandir, cliquez pour basculer vers une session.";
 "onboarding.watchers.tmux.hint" = "Si vous utilisez tmux, ajoutez cette ligne à votre config pour activer le switch au clic :";
+"onboarding.watchers.kitty.hint" = "Si vous utilisez Kitty, ajoutez à votre kitty.conf :";
 "onboarding.watchers.settings.hint" = "Vous pouvez simplifier l'affichage dans les Réglages.";
 
 /* Performance */

--- a/TokenEaterApp/AgentWatchersSectionView.swift
+++ b/TokenEaterApp/AgentWatchersSectionView.swift
@@ -5,10 +5,12 @@ struct AgentWatchersSectionView: View {
     @EnvironmentObject private var sessionStore: SessionStore
 
     @State private var tmuxCopied = false
+    @State private var kittyCopied = false
 
     private let tmuxLine = """
     set-option -g update-environment "TERM_PROGRAM"
     """
+    private let kittyLine = "allow_remote_control yes"
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
@@ -159,6 +161,50 @@ struct AgentWatchersSectionView: View {
                         }
                         .buttonStyle(.plain)
                         .help(String(localized: "settings.watchers.tmux.copy"))
+                    }
+                }
+            }
+
+            // Kitty setup
+            glassCard {
+                VStack(alignment: .leading, spacing: 8) {
+                    cardLabel(String(localized: "settings.watchers.kitty.title"))
+
+                    Text("settings.watchers.kitty.hint")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.white.opacity(0.5))
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    HStack {
+                        Text(kittyLine)
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundStyle(.white.opacity(0.8))
+                            .padding(8)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .fill(.black.opacity(0.3))
+                            )
+
+                        Button {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(kittyLine, forType: .string)
+                            kittyCopied = true
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                kittyCopied = false
+                            }
+                        } label: {
+                            Image(systemName: kittyCopied ? "checkmark" : "doc.on.doc")
+                                .font(.system(size: 12))
+                                .foregroundStyle(.white.opacity(0.6))
+                                .frame(width: 28, height: 28)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .fill(.white.opacity(0.08))
+                                )
+                        }
+                        .buttonStyle(.plain)
+                        .help(String(localized: "settings.watchers.kitty.copy"))
                     }
                 }
             }

--- a/TokenEaterApp/OnboardingSteps/AgentWatchersStep.swift
+++ b/TokenEaterApp/OnboardingSteps/AgentWatchersStep.swift
@@ -4,8 +4,10 @@ struct AgentWatchersStep: View {
     @ObservedObject var viewModel: OnboardingViewModel
 
     @State private var tmuxCopied = false
+    @State private var kittyCopied = false
 
     private let tmuxLine = "set-option -g update-environment \"TERM_PROGRAM\""
+    private let kittyLine = "allow_remote_control yes"
 
     var body: some View {
         VStack(spacing: 24) {
@@ -80,6 +82,47 @@ struct AgentWatchersStep: View {
                         }
                     } label: {
                         Image(systemName: tmuxCopied ? "checkmark" : "doc.on.doc")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.white.opacity(0.6))
+                            .frame(width: 28, height: 28)
+                            .background(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .fill(.white.opacity(0.08))
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+                .frame(maxWidth: 380)
+            }
+
+            // Kitty hint
+            VStack(spacing: 8) {
+                Text("onboarding.watchers.kitty.hint")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.white.opacity(0.4))
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 380)
+
+                HStack(spacing: 8) {
+                    Text(kittyLine)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundStyle(.white.opacity(0.8))
+                        .padding(8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(.black.opacity(0.3))
+                        )
+
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(kittyLine, forType: .string)
+                        kittyCopied = true
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                            kittyCopied = false
+                        }
+                    } label: {
+                        Image(systemName: kittyCopied ? "checkmark" : "doc.on.doc")
                             .font(.system(size: 12))
                             .foregroundStyle(.white.opacity(0.6))
                             .frame(width: 28, height: 28)

--- a/TokenEaterApp/TokenEaterApp.entitlements
+++ b/TokenEaterApp/TokenEaterApp.entitlements
@@ -18,6 +18,7 @@
     <key>com.apple.security.temporary-exception.apple-events</key>
     <array>
         <string>com.apple.Terminal</string>
+        <string>com.googlecode.iterm2</string>
     </array>
 </dict>
 </plist>

--- a/TokenEaterTests/ProcessResolverTests.swift
+++ b/TokenEaterTests/ProcessResolverTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 
 @Suite("ProcessResolver")
 struct ProcessResolverTests {
@@ -36,5 +37,57 @@ struct ProcessResolverTests {
     @Test("rejects empty path")
     func rejectsEmpty() {
         #expect(!ProcessResolver.isClaudePath(""))
+    }
+
+    // MARK: - TTY resolution
+
+    @Test("getProcessTTY returns a valid TTY for the current process")
+    func ttyForCurrentProcess() {
+        let tty = ProcessResolver.getProcessTTY(pid: ProcessInfo.processInfo.processIdentifier)
+        // In CI or Xcode, the test runner may not have a TTY — that's fine
+        if let tty {
+            #expect(tty.hasPrefix("/dev/tty"))
+        }
+    }
+
+    @Test("getProcessTTY returns nil for invalid PID")
+    func ttyForInvalidPid() {
+        #expect(ProcessResolver.getProcessTTY(pid: -1) == nil)
+    }
+
+    // MARK: - Electron helper detection
+
+    @Test("detects Electron helper bundle URL")
+    func detectsElectronHelper() {
+        let helperURL = URL(fileURLWithPath: "/Applications/Cursor.app/Contents/Frameworks/Cursor Helper (Plugin).app")
+        #expect(ProcessResolver.isElectronHelper(bundleURL: helperURL))
+    }
+
+    @Test("does not flag main app as Electron helper")
+    func doesNotFlagMainApp() {
+        let mainURL = URL(fileURLWithPath: "/Applications/Cursor.app")
+        #expect(!ProcessResolver.isElectronHelper(bundleURL: mainURL))
+    }
+
+    @Test("handles nil bundle URL")
+    func handlesNilBundleURL() {
+        #expect(!ProcessResolver.isElectronHelper(bundleURL: nil))
+    }
+
+    // MARK: - Terminal bundles
+
+    @Test("terminalBundles includes Cursor")
+    func includesCursor() {
+        #expect(ProcessResolver.terminalBundles.contains("com.todesktop.230313mzl4w4u92"))
+    }
+
+    @Test("terminalBundles includes Kitty")
+    func includesKitty() {
+        #expect(ProcessResolver.terminalBundles.contains("net.kovidgoyal.kitty"))
+    }
+
+    @Test("terminalBundles includes iTerm2")
+    func includesITerm2() {
+        #expect(ProcessResolver.terminalBundles.contains("com.googlecode.iterm2"))
     }
 }


### PR DESCRIPTION
## Summary

- **Cursor fix**: skip Electron helper processes (`Cursor Helper (Plugin).app`) in PID walk → activates the real Cursor.app instead of erroring
- **Terminal.app / iTerm2**: AppleScript tab switching by TTY — clicks now jump to the exact tab running Claude, not just the app
- **iTerm2 iTermServer**: detect iTerm2's daemon process in PID walk (not in NSRunningApplications)
- **Kitty**: remote control tab focus via `kitten @ focus-tab`
- **TCC handling**: NSAppleScript first, osascript fallback to trigger macOS permission prompt on first use
- **UI**: Kitty config hint (`allow_remote_control yes`) in onboarding + settings, matching the existing tmux pattern

## Files changed

| File | Change |
|------|--------|
| `Shared/Helpers/ProcessResolver.swift` | TTY resolution, Electron helper skip, AppleScript tab switching, Kitty CLI, iTermServer detection, refactored activation flow |
| `TokenEaterApp/TokenEaterApp.entitlements` | Add iTerm2 to apple-events exception |
| `TokenEaterApp/OnboardingSteps/AgentWatchersStep.swift` | Kitty config hint in onboarding |
| `TokenEaterApp/AgentWatchersSectionView.swift` | Kitty config card in settings |
| `Shared/en.lproj/Localizable.strings` | Kitty localization keys (EN) |
| `Shared/fr.lproj/Localizable.strings` | Kitty localization keys (FR) |
| `TokenEaterTests/ProcessResolverTests.swift` | Tests for TTY, Electron helper detection, terminal bundles |

## Test plan

- [x] 185 unit tests pass
- [ ] Click session card → Cursor activates (not helper error)
- [ ] Click session card → Terminal.app switches to exact tab
- [ ] Click session card → iTerm2 switches to exact tab
- [ ] Click session card → Kitty switches to correct tab (if installed)
- [ ] tmux pane switching still works (regression)
- [ ] Generic activation works for VSCode/Warp/WezTerm

Closes #72