### PR TITLE
fix: fall back to silent Keychain read when credentials file missing

### DIFF
--- a/Shared/Stores/UsageStore.swift
+++ b/Shared/Stores/UsageStore.swift
@@ -33,6 +33,7 @@ final class UsageStore: ObservableObject {
     private let repository: UsageRepositoryProtocol
     private let notificationService: NotificationServiceProtocol
     private var refreshTask: Task<Void, Never>?
+    private var autoRefreshTask: Task<Void, Never>?
 
     var proxyConfig: ProxyConfig?
 
@@ -53,10 +54,13 @@ final class UsageStore: ObservableObject {
             return
         }
 
-        // Credentials file read — try to recover token if not configured
-        // or if the current one already failed (auto-recovery from Claude Code refresh).
+        // Token recovery — try credentials file first, then silent Keychain read.
+        // Covers Claude Code versions that only store in Keychain (no .credentials.json).
         if !repository.isConfigured || lastFailedToken == repository.currentToken {
             repository.syncCredentialsFile()
+            if !repository.isConfigured || lastFailedToken == repository.currentToken {
+                repository.syncKeychainTokenSilently()
+            }
             if let currentToken = repository.currentToken, currentToken != lastFailedToken {
                 lastFailedToken = nil
                 errorState = .none
@@ -111,8 +115,11 @@ final class UsageStore: ObservableObject {
     }
 
     func reloadConfig(thresholds: UsageThresholds = .default) {
-        // Credentials file read — never triggers macOS password dialog
+        // Token sync — credentials file first, then silent Keychain fallback
         repository.syncCredentialsFile()
+        if !repository.isConfigured {
+            repository.syncKeychainTokenSilently()
+        }
         lastFailedToken = nil
         errorState = .none
         hasConfig = repository.isConfigured
@@ -129,8 +136,8 @@ final class UsageStore: ObservableObject {
     }
 
     func startAutoRefresh(interval: TimeInterval = 30, thresholds: UsageThresholds = .default) {
-        refreshTask?.cancel()
-        refreshTask = Task { [weak self] in
+        autoRefreshTask?.cancel()
+        autoRefreshTask = Task { [weak self] in
             // Wait first — reloadConfig already triggers an initial refresh
             try? await Task.sleep(for: .seconds(interval))
             while !Task.isCancelled {
@@ -142,7 +149,7 @@ final class UsageStore: ObservableObject {
     }
 
     func stopAutoRefresh() {
-        refreshTask?.cancel()
+        autoRefreshTask?.cancel()
     }
 
     func reauthenticate() async {
@@ -161,6 +168,9 @@ final class UsageStore: ObservableObject {
 
     func connectAutoDetect() async -> ConnectionTestResult {
         repository.syncCredentialsFile()
+        if !repository.isConfigured {
+            repository.syncKeychainTokenSilently()
+        }
         let result = await repository.testConnection(proxyConfig: proxyConfig)
         if result.success {
             hasConfig = true

--- a/TokenEaterTests/UsageStoreTests.swift
+++ b/TokenEaterTests/UsageStoreTests.swift
@@ -57,14 +57,25 @@ struct UsageStoreTests {
         #expect(store.isLoading == false)
     }
 
-    @Test("refresh calls syncCredentialsFile when not configured")
-    func refreshCallsSyncCredentialsFileWhenNotConfigured() async {
+    @Test("refresh calls syncCredentialsFile then syncKeychainTokenSilently when not configured")
+    func refreshFallsBackToKeychainWhenNotConfigured() async {
         let (store, repo, _) = makeSUT(isConfigured: false)
 
         await store.refresh()
 
         #expect(repo.syncCredentialsFileCallCount == 1)
+        #expect(repo.syncSilentCallCount == 1)
         #expect(repo.syncCallCount == 0)
+    }
+
+    @Test("refresh skips Keychain fallback when credentials file provides token")
+    func refreshSkipsKeychainWhenCredentialsFileWorks() async {
+        let (store, repo, _) = makeSUT(isConfigured: true)
+
+        await store.refresh()
+
+        #expect(repo.syncCredentialsFileCallCount == 0)
+        #expect(repo.syncSilentCallCount == 0)
     }
 
     @Test("refresh checks notification thresholds on success")
@@ -299,6 +310,16 @@ struct UsageStoreTests {
         #expect(notif.permissionRequested == true)
     }
 
+    @Test("reloadConfig falls back to Keychain when credentials file unavailable")
+    func reloadConfigFallsBackToKeychain() {
+        let (store, repo, _) = makeSUT(isConfigured: false)
+
+        store.reloadConfig()
+
+        #expect(repo.syncCredentialsFileCallCount == 1)
+        #expect(repo.syncSilentCallCount == 1)
+    }
+
     @Test("reloadConfig loads cached data")
     func reloadConfigLoadsCached() {
         let (store, repo, _) = makeSUT()
@@ -348,6 +369,16 @@ struct UsageStoreTests {
         let result = await store.connectAutoDetect()
 
         #expect(result.success == false)
+    }
+
+    @Test("connectAutoDetect falls back to Keychain when credentials file unavailable")
+    func connectAutoDetectFallsBackToKeychain() async {
+        let (store, repo, _) = makeSUT(isConfigured: false)
+
+        _ = await store.connectAutoDetect()
+
+        #expect(repo.syncCredentialsFileCallCount == 1)
+        #expect(repo.syncSilentCallCount == 1)
     }
 
     // MARK: - refresh — new buckets (opus, cowork)


### PR DESCRIPTION
## Summary

- **Keychain fallback**: `refresh()`, `reloadConfig()`, and `connectAutoDetect()` now fall back to `syncKeychainTokenSilently()` when `~/.claude/.credentials.json` doesn't exist. Some Claude Code versions only store the OAuth token in the macOS Keychain, and without this fallback the token was never acquired during normal operation.
- **Race condition fix**: `startAutoRefresh()` no longer cancels the initial refresh task from `reloadConfig()`. They now use separate task variables (`refreshTask` for one-shot refreshes, `autoRefreshTask` for the auto-refresh loop), preventing the URLSession request from being cancelled via cooperative cancellation at startup.

## Test plan

- [x] All 192 existing tests pass
- [x] Added tests for Keychain fallback in `refresh()`, `reloadConfig()`, and `connectAutoDetect()`
- [ ] Manual test: delete `~/.claude/.credentials.json`, verify TokenEater still refreshes via Keychain
- [ ] Manual test: launch app and verify data loads immediately (no 30s delay from race condition)

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)