### PR TITLE
fix: replace xattr -cr with Gatekeeper approval to fix widget malware warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,13 @@ See all features in detail on the [website](https://tokeneater.vercel.app).
 
 **[Download TokenEater.dmg](https://github.com/AThevon/TokenEater/releases/latest/download/TokenEater.dmg)**
 
-Open the DMG, drag TokenEater to Applications, then run:
-```bash
-xattr -cr /Applications/TokenEater.app
-```
+Open the DMG, drag TokenEater to Applications, then:
+
+1. Double-click TokenEater in Applications — macOS will block it
+2. Open **System Settings → Privacy & Security** — scroll down to find the message about TokenEater
+3. Click **Open Anyway** and confirm
+
+> **Important:** Do not use `xattr -cr` to bypass this step — it prevents macOS from approving the widget extension, which will then be flagged as malware in the widget gallery.
 
 ### Homebrew
 
@@ -91,6 +94,7 @@ plutil -insert NSExtension -json '{"NSExtensionPointIdentifier":"com.apple.widge
 xcodebuild -project TokenEater.xcodeproj -scheme TokenEaterApp \
   -configuration Release -derivedDataPath build build
 cp -R "build/Build/Products/Release/TokenEater.app" /Applications/
+# Then approve via System Settings → Privacy & Security → Open Anyway
 ```
 
 ## Architecture

--- a/SETUP.md
+++ b/SETUP.md
@@ -43,9 +43,15 @@ xcodebuild -project TokenEater.xcodeproj \
 
 ```bash
 cp -R "build/Build/Products/Release/TokenEater.app" /Applications/
-xattr -cr /Applications/TokenEater.app
-open "/Applications/TokenEater.app"
 ```
+
+Then approve the app through macOS Gatekeeper:
+
+1. Double-click **TokenEater.app** in Applications — macOS will block it
+2. Open **System Settings → Privacy & Security** — scroll down to the message about TokenEater
+3. Click **Open Anyway** and confirm
+
+> **Do not** use `xattr -cr` to skip this — it bypasses Gatekeeper approval, which means the widget extension won't be authorized and macOS will flag it as malware in the widget gallery.
 
 ## Configuration
 
@@ -98,4 +104,5 @@ The OAuth token is managed by Claude Code and refreshes automatically.
 | Widget shows error | Reopen the app and check connection in Settings |
 | Widget shows "Open app" | Launch the app and complete onboarding |
 | Build fails | Verify `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer` points to Xcode.app |
+| Widget flagged as malware | You likely used `xattr -cr` to install. Reinstall: delete the app, copy it again from the DMG, and approve via System Settings → Privacy & Security → Open Anyway |
 | Widget not visible | Disconnect/reconnect your session or restart |


### PR DESCRIPTION
## Summary

- Replace `xattr -cr` with proper Gatekeeper approval instructions in README and SETUP docs
- Add troubleshooting entry for users who already installed with `xattr -cr`

## Root cause

Using `xattr -cr` removes the quarantine attribute, which bypasses Gatekeeper entirely. The main app works fine because the user opens it directly, but the widget extension is loaded by the system (NotificationCenter/chronod) which checks its own approval list. Since Gatekeeper was never invoked, the widget extension was never formally approved → macOS flags it as malware.

With Homebrew Cask, this wasn't an issue because brew preserves the quarantine attribute, forcing users through the normal Gatekeeper flow which approves the entire `.app` bundle (including embedded extensions).

## What changed

- **README.md**: DMG install instructions now guide through System Settings → Privacy & Security → Open Anyway. Added warning against `xattr -cr`.
- **SETUP.md**: Same change for build-from-source install. Added troubleshooting entry.
- **No code changes**: `xattr -cr` in `UpdateStore.swift` (auto-update script) is kept — it's correct for updates since the app was already Gatekeeper-approved at first install.

## Test plan

- [ ] Fresh install from DMG without `xattr -cr` — approve via System Settings → Privacy & Security
- [ ] Open widget gallery → widgets should appear without malware warning
- [ ] Verify auto-update still works (xattr -cr in update script is preserved)

Closes #89