### PR TITLE
fix: single-timer refresh to prevent 429 rate limit spirals

### DIFF
--- a/Shared/Services/APIClient.swift
+++ b/Shared/Services/APIClient.swift
@@ -44,6 +44,10 @@ final class APIClient: APIClientProtocol, @unchecked Sendable {
             return try JSONDecoder().decode(UsageResponse.self, from: data)
         case 401, 403:
             throw APIError.tokenExpired
+        case 429:
+            let retryAfter = httpResponse.value(forHTTPHeaderField: "Retry-After")
+                .flatMap(TimeInterval.init)
+            throw APIError.rateLimited(retryAfter: retryAfter)
         default:
             throw APIError.httpError(httpResponse.statusCode)
         }

--- a/Shared/Services/Protocols/APIClientProtocol.swift
+++ b/Shared/Services/Protocols/APIClientProtocol.swift
@@ -6,6 +6,7 @@ enum APIError: LocalizedError {
     case tokenExpired
     case keychainLocked
     case unsupportedPlan
+    case rateLimited(retryAfter: TimeInterval?)
     case httpError(Int)
 
     var errorDescription: String? {
@@ -20,6 +21,8 @@ enum APIError: LocalizedError {
             return String(localized: "error.keychainlocked")
         case .unsupportedPlan:
             return String(localized: "error.unsupportedplan")
+        case .rateLimited:
+            return String(localized: "error.ratelimited")
         case .httpError(let code):
             return String(format: String(localized: "error.http"), code)
         }

--- a/Shared/Stores/UsageStore.swift
+++ b/Shared/Stores/UsageStore.swift
@@ -42,9 +42,10 @@ final class UsageStore: ObservableObject {
     private var refreshTask: Task<Void, Never>?
     private var autoRefreshTask: Task<Void, Never>?
 
-    /// Exponential backoff for 429 responses: consecutive count drives the delay.
+    /// Backoff for 429 responses: uses Retry-After header when available, otherwise exponential.
     private var consecutive429Count: Int = 0
     private var last429Date: Date?
+    private var retryAfterInterval: TimeInterval?
     private static let backoffBase: TimeInterval = 120
     private static let backoffMax: TimeInterval = 600
 
@@ -101,6 +102,7 @@ final class UsageStore: ObservableObject {
             lastFailedToken = nil
             consecutive429Count = 0
             last429Date = nil
+            retryAfterInterval = nil
             lastUpdate = Date()
             WidgetReloader.scheduleReload()
             notificationService.checkThresholds(
@@ -117,9 +119,10 @@ final class UsageStore: ObservableObject {
                 errorState = .tokenExpired
             case .keychainLocked:
                 errorState = .needsReauth
-            case .httpError(429):
+            case .rateLimited(let retryAfter):
                 consecutive429Count += 1
                 last429Date = Date()
+                retryAfterInterval = retryAfter
                 errorState = .apiUnavailable
             default:
                 errorState = .networkError(error.localizedDescription)
@@ -170,9 +173,12 @@ final class UsageStore: ObservableObject {
         }
     }
 
-    /// Returns the polling interval: normal when API is healthy, exponential backoff on consecutive 429s.
+    /// Returns the polling interval: normal when API is healthy, Retry-After or exponential backoff on 429s.
     private func currentBackoffInterval(base: TimeInterval) -> TimeInterval {
         guard consecutive429Count > 0 else { return base }
+        if let retryAfter = retryAfterInterval, retryAfter > 0 {
+            return retryAfter
+        }
         let backoff = Self.backoffBase * pow(2.0, Double(consecutive429Count - 1))
         return min(backoff, Self.backoffMax)
     }

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -82,6 +82,7 @@
 "error.invalidurl" = "Invalid URL";
 "error.invalidresponse" = "Invalid server response";
 "error.http" = "HTTP error %d";
+"error.ratelimited" = "Rate limited";
 "error.network" = "Network error: %@";
 "error.invalidresponse.short" = "Invalid response";
 "error.keychainlocked" = "Keychain locked — will retry automatically";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -82,6 +82,7 @@
 "error.invalidurl" = "URL invalide";
 "error.invalidresponse" = "Réponse invalide du serveur";
 "error.http" = "Erreur HTTP %d";
+"error.ratelimited" = "Limite de requêtes atteinte";
 "error.network" = "Erreur réseau : %@";
 "error.invalidresponse.short" = "Réponse invalide";
 "error.keychainlocked" = "Keychain verrouillé — nouvelle tentative automatique";

--- a/TokenEaterApp/DashboardView.swift
+++ b/TokenEaterApp/DashboardView.swift
@@ -38,9 +38,6 @@ struct DashboardView: View {
         }
         .task {
             refreshLastUpdateText()
-            if settingsStore.hasCompletedOnboarding {
-                await usageStore.refresh(thresholds: themeStore.thresholds)
-            }
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(30))
                 refreshLastUpdateText()
@@ -156,15 +153,6 @@ struct DashboardView: View {
                     .font(.system(size: 10))
                     .foregroundStyle(.white.opacity(0.3))
             }
-
-            Button {
-                Task { await usageStore.refresh(thresholds: themeStore.thresholds, force: true) }
-            } label: {
-                Image(systemName: "arrow.clockwise")
-                    .font(.system(size: 12))
-                    .foregroundStyle(.white.opacity(0.5))
-            }
-            .buttonStyle(.plain)
         }
     }
 

--- a/TokenEaterApp/MainAppView.swift
+++ b/TokenEaterApp/MainAppView.swift
@@ -57,10 +57,6 @@ struct MainAppView: View {
             }
         }
         .padding(4)
-        .task {
-            // Refresh on appear — throttled by UsageStore (10s debounce)
-            await usageStore.refresh(thresholds: themeStore.thresholds)
-        }
         .onReceive(NotificationCenter.default.publisher(for: .navigateToSection)) { notification in
             if let section = notification.userInfo?["section"] as? String,
                let target = AppSection(rawValue: section) {

--- a/TokenEaterApp/MenuBarView.swift
+++ b/TokenEaterApp/MenuBarView.swift
@@ -130,26 +130,12 @@ struct MenuBarPopoverView: View {
                 }
                 .buttonStyle(.plain)
 
-                // Refresh · Quit
-                HStack(spacing: 4) {
-                    Button(String(localized: "menubar.refresh")) {
-                        Task { await usageStore.refresh(thresholds: themeStore.thresholds, force: true) }
-                    }
-                    .buttonStyle(.plain)
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.4))
-
-                    Text("·")
-                        .font(.system(size: 10))
-                        .foregroundStyle(.white.opacity(0.25))
-
-                    Button(String(localized: "menubar.quit")) {
-                        NSApplication.shared.terminate(nil)
-                    }
-                    .buttonStyle(.plain)
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.4))
+                Button(String(localized: "menubar.quit")) {
+                    NSApplication.shared.terminate(nil)
                 }
+                .buttonStyle(.plain)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.white.opacity(0.4))
             }
             .padding(.horizontal, 16)
             .padding(.top, 12)
@@ -159,10 +145,6 @@ struct MenuBarPopoverView: View {
         .background(Color(nsColor: NSColor(red: 0.08, green: 0.08, blue: 0.09, alpha: 1)))
         .onAppear {
             refreshLastUpdateText()
-            // Single refresh on appear — auto-refresh lifecycle is owned by StatusBarController
-            if settingsStore.hasCompletedOnboarding {
-                Task { await usageStore.refresh(thresholds: themeStore.thresholds) }
-            }
         }
         .onReceive(updateTimer) { _ in
             refreshLastUpdateText()

--- a/TokenEaterTests/UsageStoreTests.swift
+++ b/TokenEaterTests/UsageStoreTests.swift
@@ -417,7 +417,7 @@ struct UsageStoreTests {
 
     @Test("refresh sets apiUnavailable and increments backoff on 429")
     func refreshIncrementsBackoffOn429() async {
-        let (store, _, _) = makeSUT(shouldFail: true, failWith: .httpError(429))
+        let (store, _, _) = makeSUT(shouldFail: true, failWith: .rateLimited(retryAfter: nil))
 
         await store.refresh()
 
@@ -426,7 +426,7 @@ struct UsageStoreTests {
 
     @Test("refresh resets backoff on success after 429")
     func refreshResetsBackoffOnSuccess() async {
-        let (store, repo, _) = makeSUT(shouldFail: true, failWith: .httpError(429))
+        let (store, repo, _) = makeSUT(shouldFail: true, failWith: .rateLimited(retryAfter: nil))
 
         // First call: 429
         await store.refresh()


### PR DESCRIPTION
## Summary

- Remove all opportunistic API calls from UI lifecycle (popover open, dashboard appear, main window appear) and manual refresh buttons
- Only the auto-refresh timer (5min) and initial boot trigger API calls — no other code path can hit the usage endpoint
- Parse `Retry-After` header on 429 responses for smarter backoff instead of guessing
- New `APIError.rateLimited(retryAfter:)` case replaces `httpError(429)` for explicit handling

## Context

Issue #87: users report usage stuck at "Updated X hours ago" with 429 errors even at 5min refresh intervals. Root cause: multiple independent code paths (popover open, dashboard tab, window appear, manual refresh buttons) each triggered API calls. After a 429, `lastUpdate` wasn't set, so the throttle stopped protecting — next UI trigger fired another call, creating a 429 spiral.

## What changed

| File | Change |
|------|--------|
| `MenuBarView.swift` | Remove refresh button + onAppear API call |
| `DashboardView.swift` | Remove refresh button + task API call |
| `MainAppView.swift` | Remove task API call |
| `APIClientProtocol.swift` | Add `rateLimited(retryAfter:)` case |
| `APIClient.swift` | Parse `Retry-After` header on 429 |
| `UsageStore.swift` | Handle `rateLimited`, use `retryAfter` for backoff |
| Localizable.strings | Add `error.ratelimited` key (en/fr) |
| Tests | Update 429 tests to use `rateLimited` |

## Test plan

- [x] 208 unit tests pass
- [ ] Build + nuke + install, verify usage updates every 5min with no 429
- [ ] Open/close popover and dashboard repeatedly — confirm no extra API calls
- [ ] Trigger a 429 manually (if possible) — confirm backoff uses Retry-After

Closes #87