### PR TITLE
feat: add refresh button to menu bar popover with success/error feedback

### DIFF
--- a/Shared/Repositories/UsageRepository.swift
+++ b/Shared/Repositories/UsageRepository.swift
@@ -35,6 +35,10 @@ final class UsageRepository: UsageRepositoryProtocol {
         }
     }
 
+    func updateRefreshError(_ error: String) {
+        sharedFileService.updateAfterError(error)
+    }
+
     var isConfigured: Bool {
         sharedFileService.isConfigured
     }

--- a/Shared/Repositories/UsageRepositoryProtocol.swift
+++ b/Shared/Repositories/UsageRepositoryProtocol.swift
@@ -10,6 +10,7 @@ protocol UsageRepositoryProtocol {
     func syncKeychainTokenSilently()
     /// Credentials file sync — no Keychain access at all.
     func syncCredentialsFile()
+    func updateRefreshError(_ error: String)
     var isConfigured: Bool { get }
     var cachedUsage: CachedUsage? { get }
     var currentToken: String? { get }

--- a/Shared/Services/Protocols/SharedFileServiceProtocol.swift
+++ b/Shared/Services/Protocols/SharedFileServiceProtocol.swift
@@ -5,10 +5,12 @@ protocol SharedFileServiceProtocol: Sendable {
     var oauthToken: String? { get nonmutating set }
     var cachedUsage: CachedUsage? { get }
     var lastSyncDate: Date? { get }
+    var lastRefreshError: String? { get }
     var theme: ThemeColors { get }
     var thresholds: UsageThresholds { get }
 
     func updateAfterSync(usage: CachedUsage, syncDate: Date)
+    func updateAfterError(_ error: String)
     func updateTheme(_ theme: ThemeColors, thresholds: UsageThresholds)
     func clear()
 }

--- a/Shared/Services/SharedFileService.swift
+++ b/Shared/Services/SharedFileService.swift
@@ -55,6 +55,7 @@ final class SharedFileService: SharedFileServiceProtocol, @unchecked Sendable {
         var oauthToken: String?
         var cachedUsage: CachedUsage?
         var lastSyncDate: Date?
+        var lastRefreshError: String?
         var theme: ThemeColors?
         var thresholds: UsageThresholds?
     }
@@ -93,6 +94,10 @@ final class SharedFileService: SharedFileServiceProtocol, @unchecked Sendable {
         load().lastSyncDate
     }
 
+    var lastRefreshError: String? {
+        load().lastRefreshError
+    }
+
     var theme: ThemeColors {
         load().theme ?? .default
     }
@@ -105,6 +110,13 @@ final class SharedFileService: SharedFileServiceProtocol, @unchecked Sendable {
         var data = load()
         data.cachedUsage = usage
         data.lastSyncDate = syncDate
+        data.lastRefreshError = nil
+        save(data)
+    }
+
+    func updateAfterError(_ error: String) {
+        var data = load()
+        data.lastRefreshError = error
         save(data)
     }
 

--- a/Shared/Stores/UsageStore.swift
+++ b/Shared/Stores/UsageStore.swift
@@ -124,11 +124,14 @@ final class UsageStore: ObservableObject {
                 last429Date = Date()
                 retryAfterInterval = retryAfter
                 errorState = .apiUnavailable
+                repository.updateRefreshError(String(localized: "error.ratelimited"))
             default:
                 errorState = .networkError(error.localizedDescription)
+                repository.updateRefreshError(error.localizedDescription)
             }
         } catch {
             errorState = .networkError(error.localizedDescription)
+            repository.updateRefreshError(error.localizedDescription)
         }
     }
 

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -27,6 +27,7 @@
 "widget.updated" = "Upd. %@";
 "widget.refresh.interval" = "15 min";
 "widget.refresh.button" = "Refresh";
+"widget.refreshed" = "✓ Refreshed";
 "widget.description.usage" = "Monitor your Claude usage in real time";
 "widget.description.pacing" = "Your Claude usage pace";
 

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -27,6 +27,7 @@
 "widget.updated" = "Maj %@";
 "widget.refresh.interval" = "15 min";
 "widget.refresh.button" = "Rafraîchir";
+"widget.refreshed" = "✓ Actualisé";
 "widget.description.usage" = "Affiche votre consommation Claude en temps réel";
 "widget.description.pacing" = "Votre rythme de consommation Claude";
 

--- a/TokenEaterApp/MenuBarView.swift
+++ b/TokenEaterApp/MenuBarView.swift
@@ -8,6 +8,7 @@ struct MenuBarPopoverView: View {
     @EnvironmentObject private var settingsStore: SettingsStore
 
     @State private var lastUpdateText = ""
+    @State private var showRefreshed = false
 
     private let updateTimer = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
 
@@ -29,11 +30,33 @@ struct MenuBarPopoverView: View {
                     ProgressView()
                         .scaleEffect(0.5)
                         .frame(width: 16, height: 16)
+                } else if showRefreshed {
+                    Text(String(localized: "widget.refreshed"))
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(.green.opacity(0.8))
+                } else {
+                    Button {
+                        Task { await usageStore.refresh(force: true) }
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.4))
+                    }
+                    .buttonStyle(.plain)
+                    .help(Text(String(localized: "menubar.refresh")))
                 }
             }
             .padding(.horizontal, 16)
             .padding(.top, 12)
             .padding(.bottom, 14)
+            .onChange(of: usageStore.lastUpdate) { _, _ in
+                guard !usageStore.hasError else { return }
+                showRefreshed = true
+                Task {
+                    try? await Task.sleep(for: .seconds(3))
+                    showRefreshed = false
+                }
+            }
 
             // Error banner
             if usageStore.hasError {

--- a/TokenEaterApp/TokenEaterApp.swift
+++ b/TokenEaterApp/TokenEaterApp.swift
@@ -17,7 +17,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func handleGetURL(_ event: NSAppleEventDescriptor, withReplyEvent reply: NSAppleEventDescriptor) {
-        NotificationCenter.default.post(name: .openDashboard, object: nil)
+        let urlString = event.paramDescriptor(forKeyword: keyDirectObject)?.stringValue ?? ""
+        if urlString.hasPrefix("tokeneater://refresh") {
+            Task { await usageStore.refresh(force: true) }
+        } else {
+            NotificationCenter.default.post(name: .openDashboard, object: nil)
+        }
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {

--- a/TokenEaterTests/Mocks/MockSharedFileService.swift
+++ b/TokenEaterTests/Mocks/MockSharedFileService.swift
@@ -4,9 +4,11 @@ final class MockSharedFileService: SharedFileServiceProtocol, @unchecked Sendabl
     var _oauthToken: String?
     var _cachedUsage: CachedUsage?
     var _lastSyncDate: Date?
+    var _lastRefreshError: String?
     var _theme: ThemeColors = .default
     var _thresholds: UsageThresholds = .default
     var updateAfterSyncCallCount = 0
+    var updateAfterErrorCallCount = 0
     var updateThemeCallCount = 0
 
     var isConfigured: Bool { _oauthToken != nil }
@@ -18,6 +20,7 @@ final class MockSharedFileService: SharedFileServiceProtocol, @unchecked Sendabl
 
     var cachedUsage: CachedUsage? { _cachedUsage }
     var lastSyncDate: Date? { _lastSyncDate }
+    var lastRefreshError: String? { _lastRefreshError }
     var theme: ThemeColors { _theme }
     var thresholds: UsageThresholds { _thresholds }
 
@@ -25,6 +28,12 @@ final class MockSharedFileService: SharedFileServiceProtocol, @unchecked Sendabl
         updateAfterSyncCallCount += 1
         _cachedUsage = usage
         _lastSyncDate = syncDate
+        _lastRefreshError = nil
+    }
+
+    func updateAfterError(_ error: String) {
+        updateAfterErrorCallCount += 1
+        _lastRefreshError = error
     }
 
     func updateTheme(_ theme: ThemeColors, thresholds: UsageThresholds) {
@@ -37,5 +46,6 @@ final class MockSharedFileService: SharedFileServiceProtocol, @unchecked Sendabl
         _oauthToken = nil
         _cachedUsage = nil
         _lastSyncDate = nil
+        _lastRefreshError = nil
     }
 }

--- a/TokenEaterTests/Mocks/MockUsageRepository.swift
+++ b/TokenEaterTests/Mocks/MockUsageRepository.swift
@@ -20,6 +20,7 @@ final class MockUsageRepository: UsageRepositoryProtocol {
     func syncKeychainToken() { syncCallCount += 1 }
     func syncKeychainTokenSilently() { syncSilentCallCount += 1 }
     func syncCredentialsFile() { syncCredentialsFileCallCount += 1 }
+    func updateRefreshError(_ error: String) {}
 
     func refreshUsage(proxyConfig: ProxyConfig?) async throws -> UsageResponse {
         if let error = stubbedError { throw error }

--- a/TokenEaterWidget/Provider.swift
+++ b/TokenEaterWidget/Provider.swift
@@ -19,7 +19,20 @@ struct Provider: TimelineProvider {
     func getTimeline(in context: Context, completion: @escaping (Timeline<UsageEntry>) -> Void) {
         let entry = fetchEntry()
         let nextUpdate = Calendar.current.date(byAdding: .minute, value: 5, to: Date()) ?? Date().addingTimeInterval(300)
-        completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
+
+        if entry.wasJustRefreshed {
+            // Show "Refreshed" for 10 seconds, then switch to normal display
+            let normalEntry = UsageEntry(
+                date: Date().addingTimeInterval(10),
+                usage: entry.usage,
+                error: entry.error,
+                isStale: entry.isStale,
+                wasJustRefreshed: false
+            )
+            completion(Timeline(entries: [entry, normalEntry], policy: .after(nextUpdate)))
+        } else {
+            completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
+        }
     }
 
     private func fetchEntry() -> UsageEntry {
@@ -27,20 +40,27 @@ struct Provider: TimelineProvider {
             return .unconfigured
         }
 
+        let lastRefreshError = sharedFile.lastRefreshError
+
         if let cached = sharedFile.cachedUsage {
             let isStale: Bool
+            let wasJustRefreshed: Bool
             if let lastSync = sharedFile.lastSyncDate {
                 isStale = Date().timeIntervalSince(lastSync) > 120
+                wasJustRefreshed = lastRefreshError == nil && Date().timeIntervalSince(lastSync) < 15
             } else {
                 isStale = true
+                wasJustRefreshed = false
             }
             return UsageEntry(
                 date: Date(),
                 usage: cached.usage,
-                isStale: isStale
+                error: lastRefreshError,
+                isStale: isStale,
+                wasJustRefreshed: wasJustRefreshed
             )
         }
 
-        return UsageEntry(date: Date(), usage: nil, error: String(localized: "error.nodata"))
+        return UsageEntry(date: Date(), usage: nil, error: lastRefreshError ?? String(localized: "error.nodata"))
     }
 }

--- a/TokenEaterWidget/UsageEntry.swift
+++ b/TokenEaterWidget/UsageEntry.swift
@@ -6,12 +6,14 @@ struct UsageEntry: TimelineEntry {
     let usage: UsageResponse?
     let error: String?
     let isStale: Bool
+    let wasJustRefreshed: Bool
 
-    init(date: Date, usage: UsageResponse?, error: String? = nil, isStale: Bool = false) {
+    init(date: Date, usage: UsageResponse?, error: String? = nil, isStale: Bool = false, wasJustRefreshed: Bool = false) {
         self.date = date
         self.usage = usage
         self.error = error
         self.isStale = isStale
+        self.wasJustRefreshed = wasJustRefreshed
     }
 
     private static let iso8601Formatter: ISO8601DateFormatter = {

--- a/TokenEaterWidget/UsageWidgetView.swift
+++ b/TokenEaterWidget/UsageWidgetView.swift
@@ -65,6 +65,12 @@ struct UsageWidgetView: View {
                         .font(.system(size: 8))
                         .foregroundStyle(Color(hex: theme.widgetText).opacity(0.4))
                 }
+                Link(destination: URL(string: "tokeneater://refresh")!) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundStyle(Color(hex: theme.widgetText).opacity(0.4))
+                }
+                .buttonStyle(.plain)
             }
             .padding(.bottom, 16)
 
@@ -93,9 +99,20 @@ struct UsageWidgetView: View {
 
             // Footer
             HStack {
-                Text(String(format: String(localized: "widget.updated"), entry.date.relativeFormatted))
-                    .font(.system(size: 8, design: .rounded))
-                    .foregroundStyle(Color(hex: theme.widgetText).opacity(0.3))
+                if entry.wasJustRefreshed {
+                    Text(String(localized: "widget.refreshed"))
+                        .font(.system(size: 8, design: .rounded))
+                        .foregroundStyle(.green.opacity(0.7))
+                } else if let error = entry.error {
+                    Text(error)
+                        .font(.system(size: 8, design: .rounded))
+                        .foregroundStyle(.orange.opacity(0.8))
+                        .lineLimit(1)
+                } else {
+                    Text(String(format: String(localized: "widget.updated"), entry.date.relativeFormatted))
+                        .font(.system(size: 8, design: .rounded))
+                        .foregroundStyle(Color(hex: theme.widgetText).opacity(0.3))
+                }
                 Spacer()
                 if entry.isStale {
                     Image(systemName: "wifi.slash")
@@ -130,6 +147,12 @@ struct UsageWidgetView: View {
                     }
                     .foregroundStyle(Color(hex: theme.widgetText).opacity(0.4))
                 }
+                Link(destination: URL(string: "tokeneater://refresh")!) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(Color(hex: theme.widgetText).opacity(0.35))
+                }
+                .buttonStyle(.plain)
             }
             .padding(.bottom, 8)
 
@@ -193,9 +216,20 @@ struct UsageWidgetView: View {
                 .padding(.bottom, 4)
 
             HStack {
-                Text(String(format: String(localized: "widget.updated"), entry.date.relativeFormatted))
-                    .font(.system(size: 9, design: .rounded))
-                    .foregroundStyle(Color(hex: theme.widgetText).opacity(0.3))
+                if entry.wasJustRefreshed {
+                    Text(String(localized: "widget.refreshed"))
+                        .font(.system(size: 9, design: .rounded))
+                        .foregroundStyle(.green.opacity(0.7))
+                } else if let error = entry.error {
+                    Text(error)
+                        .font(.system(size: 9, design: .rounded))
+                        .foregroundStyle(.orange.opacity(0.8))
+                        .lineLimit(1)
+                } else {
+                    Text(String(format: String(localized: "widget.updated"), entry.date.relativeFormatted))
+                        .font(.system(size: 9, design: .rounded))
+                        .foregroundStyle(Color(hex: theme.widgetText).opacity(0.3))
+                }
                 Spacer()
                 if entry.isStale {
                     HStack(spacing: 3) {
@@ -205,7 +239,7 @@ struct UsageWidgetView: View {
                             .font(.system(size: 9, design: .rounded))
                     }
                     .foregroundStyle(Color(hex: theme.widgetText).opacity(0.4))
-                } else {
+                } else if !entry.wasJustRefreshed && entry.error == nil {
                     HStack(spacing: 3) {
                         Circle()
                             .fill(.green.opacity(0.6))


### PR DESCRIPTION
Adds a ↻ button in the popover header that triggers a force refresh. Shows a 3s "✓ Refreshed" flash on success; existing error banner handles failures.

Also persists network errors to the shared file so the desktop widget can display them in the footer alongside cached data.

Persistent API errors made it frustrating to tell whether anything was happening at all.
The refresh button gives direct control and immediate visual confirmation either way. 