### PR TITLE
fix: eliminate 429 backoff oscillation and reduce disk I/O

### DIFF
--- a/Shared/Repositories/UsageRepository.swift
+++ b/Shared/Repositories/UsageRepository.swift
@@ -16,21 +16,21 @@ final class UsageRepository: UsageRepositoryProtocol {
     }
 
     func syncKeychainToken() {
-        if let token = keychainService.readOAuthToken() {
+        if let token = keychainService.readOAuthToken(), token != sharedFileService.oauthToken {
             sharedFileService.oauthToken = token
         }
     }
 
     /// Silent keychain sync — never triggers macOS dialog.
     func syncKeychainTokenSilently() {
-        if let token = keychainService.readOAuthTokenSilently() {
+        if let token = keychainService.readOAuthTokenSilently(), token != sharedFileService.oauthToken {
             sharedFileService.oauthToken = token
         }
     }
 
     /// Credentials file sync — no Keychain access at all.
     func syncCredentialsFile() {
-        if let token = keychainService.readCredentialsFileToken() {
+        if let token = keychainService.readCredentialsFileToken(), token != sharedFileService.oauthToken {
             sharedFileService.oauthToken = token
         }
     }

--- a/Shared/Services/SharedFileService.swift
+++ b/Shared/Services/SharedFileService.swift
@@ -59,17 +59,25 @@ final class SharedFileService: SharedFileServiceProtocol, @unchecked Sendable {
         var thresholds: UsageThresholds?
     }
 
+    /// In-memory cache — avoids redundant disk reads within the same process.
+    /// Each process (app, widget) has its own SharedFileService instance, so no cross-process staleness.
+    private var cachedData: SharedData?
+
     private func load() -> SharedData {
+        if let cached = cachedData { return cached }
         guard let data = try? Data(contentsOf: sharedFileURL) else {
             return SharedData()
         }
-        return (try? JSONDecoder().decode(SharedData.self, from: data)) ?? SharedData()
+        let result = (try? JSONDecoder().decode(SharedData.self, from: data)) ?? SharedData()
+        cachedData = result
+        return result
     }
 
     private func save(_ shared: SharedData) {
         let dir = sharedFileURL.deletingLastPathComponent()
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         try? JSONEncoder().encode(shared).write(to: sharedFileURL, options: .atomic)
+        cachedData = shared
     }
 
     // MARK: - SharedFileServiceProtocol
@@ -116,6 +124,7 @@ final class SharedFileService: SharedFileServiceProtocol, @unchecked Sendable {
     }
 
     func clear() {
-        save(SharedData())
+        let empty = SharedData()
+        save(empty)
     }
 }

--- a/Shared/Stores/UsageStore.swift
+++ b/Shared/Stores/UsageStore.swift
@@ -46,7 +46,7 @@ final class UsageStore: ObservableObject {
     private var consecutive429Count: Int = 0
     private var last429Date: Date?
     private var retryAfterInterval: TimeInterval?
-    private static let backoffBase: TimeInterval = 120
+    private static let normalInterval: TimeInterval = 300
     private static let backoffMax: TimeInterval = 600
 
     var proxyConfig: ProxyConfig?
@@ -68,9 +68,9 @@ final class UsageStore: ObservableObject {
             return
         }
 
-        // Back off: skip non-forced refreshes for 60s after a 429
+        // Back off: skip non-forced refreshes while in 429 backoff window
         if !force, consecutive429Count > 0, let last = last429Date,
-           Date().timeIntervalSince(last) < 60 {
+           Date().timeIntervalSince(last) < currentBackoff {
             return
         }
 
@@ -167,20 +167,20 @@ final class UsageStore: ObservableObject {
             while !Task.isCancelled {
                 guard let self else { return }
                 await self.refresh(thresholds: thresholds)
-                let delay = self.currentBackoffInterval(base: interval)
+                let delay = self.currentBackoff
                 try? await Task.sleep(for: .seconds(delay))
             }
         }
     }
 
-    /// Returns the polling interval: normal when API is healthy, Retry-After or exponential backoff on 429s.
-    private func currentBackoffInterval(base: TimeInterval) -> TimeInterval {
-        guard consecutive429Count > 0 else { return base }
+    /// Current backoff duration based on 429 state. Always >= normalInterval to never retry faster than normal.
+    private var currentBackoff: TimeInterval {
+        guard consecutive429Count > 0 else { return Self.normalInterval }
         if let retryAfter = retryAfterInterval, retryAfter > 0 {
-            return retryAfter
+            return max(retryAfter, Self.normalInterval)
         }
-        let backoff = Self.backoffBase * pow(2.0, Double(consecutive429Count - 1))
-        return min(backoff, Self.backoffMax)
+        let exponential = Self.normalInterval * pow(2.0, Double(consecutive429Count - 1))
+        return min(exponential, Self.backoffMax)
     }
 
     func stopAutoRefresh() {


### PR DESCRIPTION
## Summary

The backoff base was 120s while the normal polling interval is 300s. After a 429, the timer would fire at 120s, but the 60s guard in `refresh()` would reject it — then the next normal tick at 300s would get through, hit another 429, and the cycle would repeat indefinitely.

### Root cause

- `backoffBase` (120s) < normal interval (300s) → backoff was actually *faster* than normal polling
- The 429 guard in `refresh()` used a hardcoded 60s window, disconnected from the actual backoff duration
- Token sync methods wrote to disk on every call even when the token hadn't changed
- `SharedFileService.load()` hit disk on every property access (~10 reads per refresh cycle)

### Fixes

1. **Backoff floor = normal interval (300s):** `normalInterval` replaces `backoffBase`. Exponential backoff starts at 300s and doubles up to 600s max. `Retry-After` headers are clamped to `max(retryAfter, 300s)` so the API hint is respected but never faster than normal.

2. **429 guard uses actual backoff duration:** `refresh()` now checks `currentBackoff` (the computed property) instead of a hardcoded 60s, so the guard and the timer agree.

3. **Idempotent token sync:** `syncKeychainToken()`, `syncKeychainTokenSilently()`, and `syncCredentialsFile()` now skip the write when the token is unchanged, avoiding unnecessary disk I/O during token recovery.

4. **SharedFileService memory cache:** Added an in-memory `cachedData` property that avoids redundant `Data(contentsOf:)` + JSON decode on every property read. Each process (app, widget) has its own instance so there's no cross-process staleness risk.

## Test plan

- [x] 208 unit tests pass (includes existing 429 backoff tests)
- [ ] Manual test: trigger 429 via rapid refresh, verify no oscillation in Console.app logs
- [ ] Manual test: verify widget still reads fresh data after app refresh

> Independent of #93 (refresh button in widget) — can be merged separately.