### PR TITLE
fix: restore silent Keychain fallback for token recovery

### DIFF
--- a/Shared/Repositories/UsageRepository.swift
+++ b/Shared/Repositories/UsageRepository.swift
@@ -79,8 +79,13 @@ final class UsageRepository: UsageRepositoryProtocol {
     private func attemptTokenRecovery(proxyConfig: ProxyConfig?) async throws -> UsageResponse {
         let currentToken = sharedFileService.oauthToken
 
-        guard let freshToken = keychainService.readToken() else {
-            // Credentials file unavailable. Keep current token, retry next cycle.
+        // Try credentials file first, then silent Keychain fallback
+        let freshToken: String
+        if let fileToken = keychainService.readToken() {
+            freshToken = fileToken
+        } else if let keychainToken = keychainService.readKeychainTokenSilently() {
+            freshToken = keychainToken
+        } else {
             throw APIError.keychainLocked
         }
 

--- a/Shared/Stores/UsageStore.swift
+++ b/Shared/Stores/UsageStore.swift
@@ -74,10 +74,13 @@ final class UsageStore: ObservableObject {
             return
         }
 
-        // Token recovery — credentials file only (no Keychain access).
-        // Avoids macOS Keychain popups after sleep. Keychain is only read at boot/onboarding.
+        // Token recovery — credentials file first, then silent Keychain fallback.
+        // Covers all Claude Code install methods (some only write to Keychain, not credentials file).
         if !repository.isConfigured || lastFailedToken == repository.currentToken {
             repository.syncCredentialsFile()
+            if !repository.isConfigured || lastFailedToken == repository.currentToken {
+                repository.syncKeychainSilently()
+            }
             if let currentToken = repository.currentToken, currentToken != lastFailedToken {
                 lastFailedToken = nil
                 errorState = .none


### PR DESCRIPTION
## Problem

PR #92 removed Keychain reads from the auto-refresh cycle to prevent popup dialogs after sleep. But `~/.claude/.credentials.json` doesn't exist on all Claude Code installations (older npm versions, after `/login`). This left the app stuck with a stale token, unable to recover.

## Fix

Restore `syncKeychainSilently()` as a fallback in `refresh()` token recovery, after `syncCredentialsFile()`. The `kSecUseAuthenticationUISkip` flag ensures no popup dialog is ever shown — if the Keychain is locked after sleep, the read returns nil silently.

## Token storage by Claude Code install method

| Install method | credentials file | Keychain |
|---|---|---|
| npm (recent) | Yes | Yes |
| npm (older) | No | Yes |
| After `/login` | No | Yes |

The Keychain is the only reliable storage across all methods.

## Changes

- `UsageStore.refresh()`: restore Keychain silent fallback in token recovery block
- `UsageRepository.attemptTokenRecovery()`: try credentials file first, then Keychain silently