### PR TITLE
chore: show project name and git branch separately in session overlay

### DIFF
--- a/Shared/Models/SessionModels.swift
+++ b/Shared/Models/SessionModels.swift
@@ -20,13 +20,14 @@ struct ClaudeSession: Identifiable, Sendable {
     let projectPath: String
     var projectName: String { URL(fileURLWithPath: projectPath).lastPathComponent }
 
-    var displayName: String {
-        if let branch = gitBranch, branch != "main", branch != "master", branch != "HEAD" {
-            return branch
-        }
-        return projectName
-    }
     var gitBranch: String?
+
+    /// Branch to display in the UI — nil for default branches (main/master/HEAD)
+    var visibleBranch: String? {
+        guard let branch = gitBranch,
+              branch != "main", branch != "master", branch != "HEAD" else { return nil }
+        return branch
+    }
     var model: String?
     var state: SessionState
     var lastUpdate: Date

--- a/TokenEaterApp/SessionTraitView.swift
+++ b/TokenEaterApp/SessionTraitView.swift
@@ -323,15 +323,28 @@ struct SessionTraitView: View {
             }
 
             VStack(alignment: leftSide ? .trailing : .leading, spacing: 2 * scale) {
-                Text(session.displayName)
+                Text(session.projectName)
                     .font(.system(size: 11.5 * scale, weight: .semibold, design: fontDesign))
                     .foregroundStyle(.white)
                     .lineLimit(1)
                     .truncationMode(.tail)
 
-                Text(stateLabel)
-                    .font(.system(size: 9 * scale, weight: .medium, design: fontDesign))
-                    .foregroundStyle(activeColor.opacity(0.85))
+                HStack(spacing: 4 * scale) {
+                    Text(stateLabel)
+                        .font(.system(size: 9 * scale, weight: .medium, design: fontDesign))
+                        .foregroundStyle(activeColor.opacity(0.85))
+
+                    if let branch = session.visibleBranch {
+                        Text("·")
+                            .font(.system(size: 9 * scale, weight: .bold, design: fontDesign))
+                            .foregroundStyle(.white.opacity(0.3))
+                        Text(branch)
+                            .font(.system(size: 9 * scale, weight: .regular, design: fontDesign))
+                            .foregroundStyle(.white.opacity(0.5))
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                }
             }
             .opacity(textOpacity)
 


### PR DESCRIPTION
  ## Summary
  - Show project name as the title instead of the combined `displayName` (which picked branch over project name)
  - Show non-default git branch (not main/master/HEAD) as secondary label next to the state indicator
  - Extract branch filtering into `ClaudeSession.visibleBranch` computed property, removing duplicated logic and the now-unused `displayName`

  ## Motivation
  Previously the overlay showed either the branch name or the project name via `displayName`, but not both. Claude Code and other AI coding agents display both the working directory and git branch side by side — this change aligns the widget with that convention for better context at a glance.