### PR TITLE
feat: add WezTerm native support for agent watcher teleport

### DIFF
--- a/Shared/Helpers/ProcessResolver.swift
+++ b/Shared/Helpers/ProcessResolver.swift
@@ -103,6 +103,11 @@ enum ProcessResolver {
         case "net.kovidgoyal.kitty":
             focusKittyTab(pid: process.parentPid)
             handled = true
+        case "com.github.wez.wezterm", "io.wezfurlong.wezterm":
+            if let tty {
+                switchWezTermPane(tty: tty)
+                handled = true
+            }
         default:
             break
         }
@@ -421,6 +426,73 @@ enum ProcessResolver {
         process.executableURL = URL(fileURLWithPath: kittenPath)
         process.arguments = ["@", "focus-tab", "--match", "pid:\(pid)"]
         try? process.run()
+    }
+
+    // MARK: - WezTerm trigger file
+
+    /// Write a trigger file with the target TTY so the WezTerm watcher script can
+    /// activate the correct tab/pane. Same approach as tmux — the app sandbox blocks
+    /// direct unix socket access, so a watcher script running outside the sandbox
+    /// (started via wezterm.lua) polls for trigger files and runs wezterm cli.
+    private static func switchWezTermPane(tty: String) {
+        installWezTermWatcherIfNeeded()
+        let triggerPath = "\(sharedDir)/wezterm-switch.trigger"
+        try? FileManager.default.createDirectory(atPath: sharedDir, withIntermediateDirectories: true)
+        try? tty.write(toFile: triggerPath, atomically: true, encoding: .utf8)
+    }
+
+    /// Install the WezTerm watcher script (polling loop, started via wezterm.lua).
+    /// Re-installs automatically when the embedded version changes.
+    static func installWezTermWatcherIfNeeded() {
+        let scriptPath = "\(sharedDir)/wezterm-watcher.sh"
+        let version = "# tokeneater-wezterm-v1"
+
+        if FileManager.default.fileExists(atPath: scriptPath),
+           let content = try? String(contentsOfFile: scriptPath, encoding: .utf8),
+           content.contains(version) {
+            return
+        }
+
+        let script = """
+        #!/bin/bash
+        \(version)
+        # TokenEater WezTerm pane switcher — started by WezTerm via wezterm.lua.
+        # Polls for a trigger file written by the app and switches to the target pane.
+        export PATH="/opt/homebrew/bin:/usr/local/bin:/Applications/WezTerm.app/Contents/MacOS:$PATH"
+        TRIGGER="$HOME/Library/Application Support/com.tokeneater.shared/wezterm-switch.trigger"
+        WEZTERM_BIN=$(command -v wezterm 2>/dev/null)
+        [ -z "$WEZTERM_BIN" ] && exit 1
+
+        while true; do
+            if [ -f "$TRIGGER" ]; then
+                TARGET_TTY=$(cat "$TRIGGER" 2>/dev/null)
+                rm -f "$TRIGGER"
+                if [ -n "$TARGET_TTY" ]; then
+                    PANE_INFO=$("$WEZTERM_BIN" cli list --format json 2>/dev/null | \\
+                        python3 -c "
+        import json, sys
+        try:
+            panes = json.load(sys.stdin)
+            for p in panes:
+                if p.get('tty_name') == '$TARGET_TTY':
+                    print(f'{p[\"pane_id\"]} {p[\"tab_id\"]}')
+                    break
+        except: pass
+        " 2>/dev/null)
+                    if [ -n "$PANE_INFO" ]; then
+                        PANE_ID=$(echo "$PANE_INFO" | awk '{print $1}')
+                        TAB_ID=$(echo "$PANE_INFO" | awk '{print $2}')
+                        [ -n "$TAB_ID" ] && "$WEZTERM_BIN" cli activate-tab --tab-id "$TAB_ID" 2>/dev/null
+                        [ -n "$PANE_ID" ] && "$WEZTERM_BIN" cli activate-pane --pane-id "$PANE_ID" 2>/dev/null
+                    fi
+                fi
+            fi
+            sleep 0.3
+        done
+        """
+
+        try? FileManager.default.createDirectory(atPath: sharedDir, withIntermediateDirectories: true)
+        try? script.write(toFile: scriptPath, atomically: true, encoding: .utf8)
     }
 
     /// Activate via LaunchServices — reliably switches spaces/fullscreen.

--- a/Shared/Services/SessionMonitorService.swift
+++ b/Shared/Services/SessionMonitorService.swift
@@ -154,7 +154,12 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
             }
         }
 
-        activeSessions.sort { $0.startedAt < $1.startedAt }
+        // Stable sort: by startedAt, then by session id as tiebreaker
+        // to prevent watchers from jumping around on each scan cycle.
+        activeSessions.sort {
+            if $0.startedAt != $1.startedAt { return $0.startedAt < $1.startedAt }
+            return $0.id < $1.id
+        }
         sessionsSubject.send(activeSessions)
     }
 

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -301,6 +301,9 @@
 "settings.watchers.kitty.title" = "Kitty setup";
 "settings.watchers.kitty.hint" = "If you use Kitty, add this line to your kitty.conf so TokenEater can switch to the right tab on click:";
 "settings.watchers.kitty.copy" = "Copy";
+"settings.watchers.wezterm.title" = "WezTerm setup";
+"settings.watchers.wezterm.hint" = "If you use WezTerm, add this line to your ~/.wezterm.lua so TokenEater can switch to the right pane on click:";
+"settings.watchers.wezterm.copy" = "Copy";
 "settings.watchers.style" = "Overlay style";
 "settings.watchers.style.frost" = "Frost";
 "settings.watchers.style.neon" = "Neon";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -301,6 +301,9 @@
 "settings.watchers.kitty.title" = "Configuration Kitty";
 "settings.watchers.kitty.hint" = "Si vous utilisez Kitty, ajoutez cette ligne à votre kitty.conf pour que TokenEater puisse basculer vers le bon onglet au clic :";
 "settings.watchers.kitty.copy" = "Copier";
+"settings.watchers.wezterm.title" = "Configuration WezTerm";
+"settings.watchers.wezterm.hint" = "Si vous utilisez WezTerm, ajoutez cette ligne à votre ~/.wezterm.lua pour que TokenEater puisse basculer vers le bon pane au clic :";
+"settings.watchers.wezterm.copy" = "Copier";
 "settings.watchers.style" = "Style de l'overlay";
 "settings.watchers.style.frost" = "Frost";
 "settings.watchers.style.neon" = "Neon";

--- a/TokenEaterApp/AgentWatchersSectionView.swift
+++ b/TokenEaterApp/AgentWatchersSectionView.swift
@@ -6,11 +6,19 @@ struct AgentWatchersSectionView: View {
 
     @State private var tmuxCopied = false
     @State private var kittyCopied = false
+    @State private var weztermCopied = false
 
     private let tmuxLine = """
     set-option -g update-environment "TERM_PROGRAM"
     """
     private let kittyLine = "allow_remote_control yes"
+    private let weztermLine = """
+    wezterm.on('gui-startup', function()
+      local script = os.getenv('HOME') .. '/Library/Application Support/com.tokeneater.shared/wezterm-watcher.sh'
+      local f = io.open(script, 'r')
+      if f then f:close(); io.popen('nohup bash "' .. script .. '" >/dev/null 2>&1 &') end
+    end)
+    """
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
@@ -173,6 +181,51 @@ struct AgentWatchersSectionView: View {
                         }
                         .buttonStyle(.plain)
                         .help(String(localized: "settings.watchers.tmux.copy"))
+                    }
+                }
+            }
+
+            // WezTerm setup
+            glassCard {
+                VStack(alignment: .leading, spacing: 8) {
+                    cardLabel(String(localized: "settings.watchers.wezterm.title"))
+
+                    Text("settings.watchers.wezterm.hint")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.white.opacity(0.5))
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    HStack {
+                        Text(weztermLine)
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundStyle(.white.opacity(0.8))
+                            .padding(8)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .fill(.black.opacity(0.3))
+                            )
+                            .lineLimit(3)
+
+                        Button {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(weztermLine, forType: .string)
+                            weztermCopied = true
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                weztermCopied = false
+                            }
+                        } label: {
+                            Image(systemName: weztermCopied ? "checkmark" : "doc.on.doc")
+                                .font(.system(size: 12))
+                                .foregroundStyle(.white.opacity(0.6))
+                                .frame(width: 28, height: 28)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 6)
+                                        .fill(.white.opacity(0.08))
+                                )
+                        }
+                        .buttonStyle(.plain)
+                        .help(String(localized: "settings.watchers.wezterm.copy"))
                     }
                 }
             }

--- a/TokenEaterWidget/Info.plist
+++ b/TokenEaterWidget/Info.plist
@@ -18,5 +18,10 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Add click-to-focus support for WezTerm panes/tabs in agent watchers, using a trigger-file + watcher-script approach (same pattern as tmux) to work around the app sandbox blocking direct unix socket access
- Add WezTerm setup section in Agent Watchers settings with the Lua snippet to copy into `~/.wezterm.lua`
- Stabilize agent watcher ordering by adding session ID as a tiebreaker when `startedAt` timestamps are equal, preventing watchers from randomly jumping around

## How it works
1. **App** writes the target TTY to `~/Library/Application Support/com.tokeneater.shared/wezterm-switch.trigger`
2. **Watcher script** (`wezterm-watcher.sh`, started by WezTerm via `gui-startup` hook) polls every 300ms, matches TTY → pane via `wezterm cli list --format json`, then runs `activate-tab` + `activate-pane`
3. **Fallback**: if watcher isn't running, generic `activateApp()` still brings WezTerm to front

## Test plan
- [ ] Launch Claude Code in multiple WezTerm tabs/panes
- [ ] Click agent watchers → should teleport to the correct tab and pane
- [ ] Verify watcher ordering stays stable across scan cycles
- [ ] Verify tmux/kitty/Terminal.app/iTerm2 teleport still works (no regression)
- [ ] Verify WezTerm setup section appears in Agent Watchers settings (EN + FR)