### PR TITLE
feat: add watcher display mode setting

### DIFF
--- a/Shared/Models/SessionModels.swift
+++ b/Shared/Models/SessionModels.swift
@@ -28,6 +28,11 @@ struct ClaudeSession: Identifiable, Sendable {
               branch != "main", branch != "master", branch != "HEAD" else { return nil }
         return branch
     }
+
+    /// Title for branch-priority mode: shows branch when non-default, otherwise project name
+    var displayName: String {
+        visibleBranch ?? projectName
+    }
     var model: String?
     var state: SessionState
     var lastUpdate: Date

--- a/Shared/Models/WatcherDisplayMode.swift
+++ b/Shared/Models/WatcherDisplayMode.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+enum WatcherDisplayMode: String, CaseIterable {
+    case branchPriority
+    case projectAndBranch
+
+    var label: String {
+        switch self {
+        case .branchPriority: return String(localized: "settings.watchers.display.branchPriority")
+        case .projectAndBranch: return String(localized: "settings.watchers.display.projectAndBranch")
+        }
+    }
+}

--- a/Shared/Stores/SettingsStore.swift
+++ b/Shared/Stores/SettingsStore.swift
@@ -47,6 +47,9 @@ final class SettingsStore: ObservableObject {
     @Published var watcherStyle: WatcherStyle {
         didSet { UserDefaults.standard.set(watcherStyle.rawValue, forKey: "watcherStyle") }
     }
+    @Published var watcherDisplayMode: WatcherDisplayMode {
+        didSet { UserDefaults.standard.set(watcherDisplayMode.rawValue, forKey: "watcherDisplayMode") }
+    }
 
     // Performance
     @Published var particlesEnabled: Bool {
@@ -139,6 +142,9 @@ final class SettingsStore: ObservableObject {
         self.watcherStyle = WatcherStyle(
             rawValue: UserDefaults.standard.string(forKey: "watcherStyle") ?? "frost"
         ) ?? .frost
+        self.watcherDisplayMode = WatcherDisplayMode(
+            rawValue: UserDefaults.standard.string(forKey: "watcherDisplayMode") ?? "branchPriority"
+        ) ?? .branchPriority
         self.particlesEnabled = UserDefaults.standard.object(forKey: "particlesEnabled") as? Bool ?? true
         self.animatedGradientEnabled = UserDefaults.standard.object(forKey: "animatedGradientEnabled") as? Bool ?? true
         self.watcherAnimationsEnabled = UserDefaults.standard.object(forKey: "watcherAnimationsEnabled") as? Bool ?? true

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -307,6 +307,11 @@
 "settings.watchers.style" = "Overlay style";
 "settings.watchers.style.frost" = "Frost";
 "settings.watchers.style.neon" = "Neon";
+"settings.watchers.display" = "Display mode";
+"settings.watchers.display.branchPriority" = "Branch priority";
+"settings.watchers.display.projectAndBranch" = "Project + Branch";
+"settings.watchers.display.branchPriority.hint" = "Shows the git branch as the title when on a non-default branch, otherwise the project name.";
+"settings.watchers.display.projectAndBranch.hint" = "Always shows the project name as the title, with the branch displayed next to the status.";
 
 /* Onboarding - Agent Watchers */
 "onboarding.watchers.title" = "Agent Watchers";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -307,6 +307,11 @@
 "settings.watchers.style" = "Style de l'overlay";
 "settings.watchers.style.frost" = "Frost";
 "settings.watchers.style.neon" = "Neon";
+"settings.watchers.display" = "Mode d'affichage";
+"settings.watchers.display.branchPriority" = "Branche prioritaire";
+"settings.watchers.display.projectAndBranch" = "Projet + Branche";
+"settings.watchers.display.branchPriority.hint" = "Affiche la branche git en titre quand elle n'est pas par défaut, sinon le nom du projet.";
+"settings.watchers.display.projectAndBranch.hint" = "Affiche toujours le nom du projet en titre, avec la branche à côté du statut.";
 
 /* Onboarding - Agent Watchers */
 "onboarding.watchers.title" = "Agent Watchers";

--- a/TokenEaterApp/AgentWatchersSectionView.swift
+++ b/TokenEaterApp/AgentWatchersSectionView.swift
@@ -50,6 +50,29 @@ struct AgentWatchersSectionView: View {
                 }
             }
 
+            // Display mode picker
+            glassCard {
+                VStack(alignment: .leading, spacing: 10) {
+                    cardLabel(String(localized: "settings.watchers.display"))
+
+                    Picker("", selection: $settingsStore.watcherDisplayMode) {
+                        ForEach(WatcherDisplayMode.allCases, id: \.self) { mode in
+                            Text(mode.label).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+
+                    Text(settingsStore.watcherDisplayMode == .branchPriority
+                        ? "settings.watchers.display.branchPriority.hint"
+                        : "settings.watchers.display.projectAndBranch.hint"
+                    )
+                    .font(.system(size: 12))
+                    .foregroundStyle(.white.opacity(0.5))
+                    .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
             // Behavior
             glassCard {
                 VStack(alignment: .leading, spacing: 12) {

--- a/TokenEaterApp/SessionTraitView.swift
+++ b/TokenEaterApp/SessionTraitView.swift
@@ -20,6 +20,7 @@ struct SessionTraitView: View {
 
     private var isDetailed: Bool { settingsStore.watchersDetailedMode }
     private var style: WatcherStyle { settingsStore.watcherStyle }
+    private var displayMode: WatcherDisplayMode { settingsStore.watcherDisplayMode }
 
     private var needsAttention: Bool {
         session.state == .idle || session.state == .waiting
@@ -323,26 +324,41 @@ struct SessionTraitView: View {
             }
 
             VStack(alignment: leftSide ? .trailing : .leading, spacing: 2 * scale) {
-                Text(session.projectName)
-                    .font(.system(size: 11.5 * scale, weight: .semibold, design: fontDesign))
-                    .foregroundStyle(.white)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
+                switch displayMode {
+                case .branchPriority:
+                    Text(session.displayName)
+                        .font(.system(size: 11.5 * scale, weight: .semibold, design: fontDesign))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
 
-                HStack(spacing: 4 * scale) {
                     Text(stateLabel)
                         .font(.system(size: 9 * scale, weight: .medium, design: fontDesign))
                         .foregroundStyle(activeColor.opacity(0.85))
 
-                    if let branch = session.visibleBranch {
-                        Text("·")
-                            .font(.system(size: 9 * scale, weight: .bold, design: fontDesign))
-                            .foregroundStyle(.white.opacity(0.3))
-                        Text(branch)
-                            .font(.system(size: 9 * scale, weight: .regular, design: fontDesign))
-                            .foregroundStyle(.white.opacity(0.5))
-                            .lineLimit(1)
-                            .truncationMode(.tail)
+                case .projectAndBranch:
+                    Text(session.projectName)
+                        .font(.system(size: 11.5 * scale, weight: .semibold, design: fontDesign))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+
+                    HStack(spacing: 4 * scale) {
+                        Text(stateLabel)
+                            .font(.system(size: 9 * scale, weight: .medium, design: fontDesign))
+                            .foregroundStyle(activeColor.opacity(0.85))
+                            .layoutPriority(1)
+
+                        if let branch = session.visibleBranch {
+                            Text("·")
+                                .font(.system(size: 9 * scale, weight: .bold, design: fontDesign))
+                                .foregroundStyle(.white.opacity(0.3))
+                            Text(branch)
+                                .font(.system(size: 9 * scale, weight: .regular, design: fontDesign))
+                                .foregroundStyle(.white.opacity(0.5))
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Closes #110

## Summary

- Add a **Display mode** setting in the Agent Watchers section with two modes:
  - **Branch priority** (default): shows the git branch as the title when on a non-default branch, otherwise the project name (original behavior)
  - **Project + Branch**: always shows the project name as the title, with the branch displayed next to the status indicator
- New `WatcherDisplayMode` enum, persisted in UserDefaults
- Segmented picker in settings with contextual hint text
- Localized in English and French

## Credits

Built on top of @lemotw's work in #110 — the `visibleBranch` extraction and "Project + Branch" layout come from their PR. This PR extends it by making the display mode user-configurable instead of replacing the existing behavior.