### PR TITLE
feat: add smart gauge color mode for 5h session

### DIFF
--- a/Shared/Helpers/MenuBarRenderer.swift
+++ b/Shared/Helpers/MenuBarRenderer.swift
@@ -24,6 +24,8 @@ enum MenuBarRenderer {
         let menuBarMonochrome: Bool
         let fiveHourReset: String
         let showSessionReset: Bool
+        let gaugeColorMode: GaugeColorMode
+        let fiveHourResetDate: Date?
     }
 
     private static var cachedImage: NSImage?
@@ -51,6 +53,17 @@ enum MenuBarRenderer {
     private static func colorForPct(_ pct: Int, data: RenderData) -> NSColor {
         if data.menuBarMonochrome { return .labelColor }
         return data.themeColors.gaugeNSColor(for: Double(pct), thresholds: data.thresholds)
+    }
+
+    private static func colorForFiveHour(_ data: RenderData) -> NSColor {
+        if data.menuBarMonochrome { return .labelColor }
+        guard data.gaugeColorMode == .smart else {
+            return data.themeColors.gaugeNSColor(for: Double(data.fiveHourPct), thresholds: data.thresholds)
+        }
+        return data.themeColors.smartGaugeNSColor(
+            utilization: Double(data.fiveHourPct),
+            resetDate: data.fiveHourResetDate
+        )
     }
 
     private static func colorForZone(_ zone: PacingZone, data: RenderData) -> NSColor {
@@ -133,9 +146,15 @@ enum MenuBarRenderer {
                     str.append(NSAttributedString(string: "  ", attributes: labelAttrs))
                 }
                 str.append(NSAttributedString(string: "\(metric.shortLabel) ", attributes: labelAttrs))
+                let color: NSColor
+                if metric == .fiveHour {
+                    color = colorForFiveHour(data)
+                } else {
+                    color = colorForPct(value, data: data)
+                }
                 let pctAttrs: [NSAttributedString.Key: Any] = [
                     .font: NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .bold),
-                    .foregroundColor: colorForPct(value, data: data),
+                    .foregroundColor: color,
                 ]
                 str.append(NSAttributedString(string: "\(value)%", attributes: pctAttrs))
             }

--- a/Shared/Models/MetricModels.swift
+++ b/Shared/Models/MetricModels.swift
@@ -37,6 +37,11 @@ enum PacingDisplayMode: String, CaseIterable {
     case delta
 }
 
+enum GaugeColorMode: String, CaseIterable {
+    case `static`
+    case smart
+}
+
 enum AppErrorState: Equatable {
     case none
     case tokenUnavailable

--- a/Shared/Models/ThemeModels.swift
+++ b/Shared/Models/ThemeModels.swift
@@ -101,6 +101,37 @@ struct ThemeColors: Codable, Equatable {
         return NSColor(hex: gaugeNormal)
     }
 
+    // MARK: - Smart Gauge Color (risk-based for 5h window)
+
+    /// Risk score = utilization × remaining_minutes / 100.
+    /// Maps to: green (< 70), orange (70-100), red (> 100).
+    private func riskScore(utilization: Double, resetDate: Date, now: Date) -> Double {
+        let remainingSeconds = max(resetDate.timeIntervalSince(now), 0)
+        let remainingMinutes = remainingSeconds / 60
+        return utilization * remainingMinutes / 100
+    }
+
+    func smartGaugeColor(utilization: Double, resetDate: Date?, now: Date = Date()) -> Color {
+        guard let resetDate else { return Color(hex: gaugeNormal) }
+        let risk = riskScore(utilization: utilization, resetDate: resetDate, now: now)
+        if risk > 100 { return Color(hex: gaugeCritical) }
+        if risk > 70 { return Color(hex: gaugeWarning) }
+        return Color(hex: gaugeNormal)
+    }
+
+    func smartGaugeGradient(utilization: Double, resetDate: Date?, now: Date = Date(), startPoint: UnitPoint = .topLeading, endPoint: UnitPoint = .bottomTrailing) -> LinearGradient {
+        let base = smartGaugeColor(utilization: utilization, resetDate: resetDate, now: now)
+        return LinearGradient(colors: [base, base.lighter()], startPoint: startPoint, endPoint: endPoint)
+    }
+
+    func smartGaugeNSColor(utilization: Double, resetDate: Date?, now: Date = Date()) -> NSColor {
+        guard let resetDate else { return NSColor(hex: gaugeNormal) }
+        let risk = riskScore(utilization: utilization, resetDate: resetDate, now: now)
+        if risk > 100 { return NSColor(hex: gaugeCritical) }
+        if risk > 70 { return NSColor(hex: gaugeWarning) }
+        return NSColor(hex: gaugeNormal)
+    }
+
     func pacingNSColor(for zone: PacingZone) -> NSColor {
         switch zone {
         case .chill: return NSColor(hex: pacingChill)

--- a/Shared/Services/Protocols/SharedFileServiceProtocol.swift
+++ b/Shared/Services/Protocols/SharedFileServiceProtocol.swift
@@ -7,9 +7,10 @@ protocol SharedFileServiceProtocol: Sendable {
     var lastSyncDate: Date? { get }
     var theme: ThemeColors { get }
     var thresholds: UsageThresholds { get }
+    var gaugeColorMode: GaugeColorMode { get }
 
     func invalidateCache()
     func updateAfterSync(usage: CachedUsage, syncDate: Date)
-    func updateTheme(_ theme: ThemeColors, thresholds: UsageThresholds)
+    func updateTheme(_ theme: ThemeColors, thresholds: UsageThresholds, gaugeColorMode: GaugeColorMode)
     func clear()
 }

--- a/Shared/Services/SharedFileService.swift
+++ b/Shared/Services/SharedFileService.swift
@@ -56,6 +56,7 @@ final class SharedFileService: SharedFileServiceProtocol, @unchecked Sendable {
         var lastSyncDate: Date?
         var theme: ThemeColors?
         var thresholds: UsageThresholds?
+        var gaugeColorMode: String?
     }
 
     /// In-memory cache — avoids redundant disk reads within the same process.
@@ -116,6 +117,10 @@ final class SharedFileService: SharedFileServiceProtocol, @unchecked Sendable {
         load().thresholds ?? .default
     }
 
+    var gaugeColorMode: GaugeColorMode {
+        GaugeColorMode(rawValue: load().gaugeColorMode ?? "static") ?? .static
+    }
+
     func updateAfterSync(usage: CachedUsage, syncDate: Date) {
         var data = load()
         data.cachedUsage = usage
@@ -123,10 +128,11 @@ final class SharedFileService: SharedFileServiceProtocol, @unchecked Sendable {
         save(data)
     }
 
-    func updateTheme(_ theme: ThemeColors, thresholds: UsageThresholds) {
+    func updateTheme(_ theme: ThemeColors, thresholds: UsageThresholds, gaugeColorMode: GaugeColorMode) {
         var data = load()
         data.theme = theme
         data.thresholds = thresholds
+        data.gaugeColorMode = gaugeColorMode.rawValue
         save(data)
     }
 

--- a/Shared/Stores/ThemeStore.swift
+++ b/Shared/Stores/ThemeStore.swift
@@ -39,6 +39,13 @@ final class ThemeStore: ObservableObject {
         }
     }
 
+    @Published var gaugeColorMode: GaugeColorMode {
+        didSet {
+            UserDefaults.standard.set(gaugeColorMode.rawValue, forKey: "gaugeColorMode")
+            scheduleSync()
+        }
+    }
+
     private let sharedFileService: SharedFileServiceProtocol
 
     init(sharedFileService: SharedFileServiceProtocol = SharedFileService()) {
@@ -54,6 +61,9 @@ final class ThemeStore: ObservableObject {
             return val > 0 ? val : 85
         }()
         self.menuBarMonochrome = UserDefaults.standard.bool(forKey: "menuBarMonochrome")
+        self.gaugeColorMode = GaugeColorMode(
+            rawValue: UserDefaults.standard.string(forKey: "gaugeColorMode") ?? "static"
+        ) ?? .static
 
         if let json = UserDefaults.standard.string(forKey: "customThemeJSON"),
            let data = json.data(using: .utf8),
@@ -95,6 +105,7 @@ final class ThemeStore: ObservableObject {
         warningThreshold = 60
         criticalThreshold = 85
         menuBarMonochrome = false
+        gaugeColorMode = .static
         syncToSharedFile()
     }
 
@@ -112,7 +123,7 @@ final class ThemeStore: ObservableObject {
     }
 
     func syncToSharedFile() {
-        sharedFileService.updateTheme(current, thresholds: thresholds)
+        sharedFileService.updateTheme(current, thresholds: thresholds, gaugeColorMode: gaugeColorMode)
         WidgetReloader.scheduleReload()
     }
 }

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -200,6 +200,13 @@
 "settings.theme.preview.normal" = "Normal";
 "settings.theme.preview.warning" = "Warning";
 "settings.theme.preview.critical" = "Critical";
+/* Gauge Color Mode */
+"settings.gauge.colormode" = "Session color mode";
+"settings.gauge.colormode.static" = "Thresholds";
+"settings.gauge.colormode.smart" = "Smart";
+"settings.gauge.colormode.static.hint" = "Color changes at fixed usage thresholds (warning / critical).";
+"settings.gauge.colormode.smart.hint" = "Color factors in time remaining - high usage near reset stays green.";
+
 "settings.theme.reset" = "Reset to Defaults";
 "settings.theme.reset.confirm" = "Reset all theming settings?";
 "settings.theme.reset.cancel" = "Cancel";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -200,6 +200,13 @@
 "settings.theme.preview.normal" = "Normal";
 "settings.theme.preview.warning" = "Attention";
 "settings.theme.preview.critical" = "Critique";
+/* Mode couleur jauge */
+"settings.gauge.colormode" = "Couleur session";
+"settings.gauge.colormode.static" = "Seuils";
+"settings.gauge.colormode.smart" = "Smart";
+"settings.gauge.colormode.static.hint" = "La couleur change à des seuils d'usage fixes (attention / critique).";
+"settings.gauge.colormode.smart.hint" = "La couleur tient compte du temps restant - un usage élevé proche du reset reste vert.";
+
 "settings.theme.reset" = "Réinitialiser";
 "settings.theme.reset.confirm" = "Réinitialiser tous les réglages d'apparence ?";
 "settings.theme.reset.cancel" = "Annuler";

--- a/TokenEaterApp/DashboardView.swift
+++ b/TokenEaterApp/DashboardView.swift
@@ -58,10 +58,7 @@ struct DashboardView: View {
 
     private var backgroundColors: [Color] {
         let base = Color(red: 0.10, green: 0.10, blue: 0.12)
-        let stateColor = themeStore.current.gaugeColor(
-            for: Double(usageStore.fiveHourPct),
-            thresholds: themeStore.thresholds
-        )
+        let stateColor = fiveHourColor()
         let tinted = blend(stateColor, into: base, amount: 0.15)
         return [base, tinted]
     }
@@ -183,7 +180,7 @@ struct DashboardView: View {
                 ParticleField(
                     particleCount: 25,
                     speed: Double(usageStore.fiveHourPct) / 100.0,
-                    color: gaugeColor(for: usageStore.fiveHourPct),
+                    color: fiveHourColor(),
                     radius: 130,
                     isActive: isVisible
                 )
@@ -192,9 +189,9 @@ struct DashboardView: View {
 
             RingGauge(
                 percentage: usageStore.fiveHourPct,
-                gradient: gaugeGradient(for: usageStore.fiveHourPct),
+                gradient: fiveHourGradient(),
                 size: 200,
-                glowColor: gaugeColor(for: usageStore.fiveHourPct),
+                glowColor: fiveHourColor(),
                 glowRadius: 8
             )
             .overlay {
@@ -202,7 +199,7 @@ struct DashboardView: View {
                     GlowText(
                         "\(usageStore.fiveHourPct)%",
                         font: .system(size: 42, weight: .black, design: .rounded),
-                        color: gaugeColor(for: usageStore.fiveHourPct),
+                        color: fiveHourColor(),
                         glowRadius: 6
                     )
                     Text(String(localized: "metric.session"))
@@ -347,5 +344,27 @@ struct DashboardView: View {
 
     private func gaugeGradient(for pct: Int) -> LinearGradient {
         themeStore.current.gaugeGradient(for: Double(pct), thresholds: themeStore.thresholds, startPoint: .leading, endPoint: .trailing)
+    }
+
+    private func fiveHourColor() -> Color {
+        guard themeStore.gaugeColorMode == .smart else {
+            return gaugeColor(for: usageStore.fiveHourPct)
+        }
+        return themeStore.current.smartGaugeColor(
+            utilization: Double(usageStore.fiveHourPct),
+            resetDate: usageStore.lastUsage?.fiveHour?.resetsAtDate
+        )
+    }
+
+    private func fiveHourGradient() -> LinearGradient {
+        guard themeStore.gaugeColorMode == .smart else {
+            return gaugeGradient(for: usageStore.fiveHourPct)
+        }
+        return themeStore.current.smartGaugeGradient(
+            utilization: Double(usageStore.fiveHourPct),
+            resetDate: usageStore.lastUsage?.fiveHour?.resetsAtDate,
+            startPoint: .leading,
+            endPoint: .trailing
+        )
     }
 }

--- a/TokenEaterApp/MenuBarView.swift
+++ b/TokenEaterApp/MenuBarView.swift
@@ -166,9 +166,9 @@ struct MenuBarPopoverView: View {
                 ZStack {
                     RingGauge(
                         percentage: pct,
-                        gradient: gradientForPct(pct),
+                        gradient: fiveHourGradient(),
                         size: 100,
-                        glowColor: colorForPct(pct),
+                        glowColor: fiveHourColor(),
                         glowRadius: 6
                     )
 
@@ -176,7 +176,7 @@ struct MenuBarPopoverView: View {
                         GlowText(
                             "\(pct)%",
                             font: .system(size: 24, weight: .black, design: .rounded),
-                            color: colorForPct(pct),
+                            color: fiveHourColor(),
                             glowRadius: 4
                         )
                         Text(String(localized: "metric.session"))
@@ -188,7 +188,7 @@ struct MenuBarPopoverView: View {
                 HStack(spacing: 3) {
                     Image(systemName: isPinned ? "pin.fill" : "pin")
                         .font(.system(size: 7))
-                        .foregroundStyle(isPinned ? colorForPct(pct) : .white.opacity(0.2))
+                        .foregroundStyle(isPinned ? fiveHourColor() : .white.opacity(0.2))
                         .rotationEffect(.degrees(isPinned ? 0 : 45))
                     if !usageStore.fiveHourReset.isEmpty {
                         Text(String(format: String(localized: "metric.reset"), usageStore.fiveHourReset))
@@ -512,5 +512,27 @@ struct MenuBarPopoverView: View {
 
     private func gradientForPct(_ pct: Int) -> LinearGradient {
         themeStore.current.gaugeGradient(for: Double(pct), thresholds: themeStore.thresholds, startPoint: .leading, endPoint: .trailing)
+    }
+
+    private func fiveHourColor() -> Color {
+        guard themeStore.gaugeColorMode == .smart else {
+            return colorForPct(usageStore.fiveHourPct)
+        }
+        return themeStore.current.smartGaugeColor(
+            utilization: Double(usageStore.fiveHourPct),
+            resetDate: usageStore.lastUsage?.fiveHour?.resetsAtDate
+        )
+    }
+
+    private func fiveHourGradient() -> LinearGradient {
+        guard themeStore.gaugeColorMode == .smart else {
+            return gradientForPct(usageStore.fiveHourPct)
+        }
+        return themeStore.current.smartGaugeGradient(
+            utilization: Double(usageStore.fiveHourPct),
+            resetDate: usageStore.lastUsage?.fiveHour?.resetsAtDate,
+            startPoint: .leading,
+            endPoint: .trailing
+        )
     }
 }

--- a/TokenEaterApp/StatusBarController.swift
+++ b/TokenEaterApp/StatusBarController.swift
@@ -221,7 +221,9 @@ final class StatusBarController: NSObject {
             thresholds: themeStore.thresholds,
             menuBarMonochrome: themeStore.menuBarMonochrome,
             fiveHourReset: usageStore.fiveHourReset,
-            showSessionReset: settingsStore.showSessionReset
+            showSessionReset: settingsStore.showSessionReset,
+            gaugeColorMode: themeStore.gaugeColorMode,
+            fiveHourResetDate: usageStore.lastUsage?.fiveHour?.resetsAtDate
         ))
         statusItem.button?.image = image
     }

--- a/TokenEaterApp/ThemesSectionView.swift
+++ b/TokenEaterApp/ThemesSectionView.swift
@@ -52,18 +52,43 @@ struct ThemesSectionView: View {
             glassCard {
                 VStack(alignment: .leading, spacing: 8) {
                     cardLabel(String(localized: "settings.theme.thresholds"))
-                    thresholdSlider(label: String(localized: "settings.theme.warning"), value: $warningSlider, range: 10...90)
-                    thresholdSlider(label: String(localized: "settings.theme.critical"), value: $criticalSlider, range: 15...95)
 
-                    // Preview gauges
-                    HStack(spacing: 24) {
+                    // Gauge color mode picker
+                    HStack {
+                        Text(String(localized: "settings.gauge.colormode"))
+                            .font(.system(size: 12))
+                            .foregroundStyle(.white.opacity(0.7))
                         Spacer()
-                        themePreviewGauge(pct: Double(max(themeStore.warningThreshold - 15, 5)), label: "Normal")
-                        themePreviewGauge(pct: Double(themeStore.warningThreshold + themeStore.criticalThreshold) / 2.0, label: "Warning")
-                        themePreviewGauge(pct: Double(min(themeStore.criticalThreshold + 5, 100)), label: "Critical")
-                        Spacer()
+                        Picker("", selection: $themeStore.gaugeColorMode) {
+                            Text(String(localized: "settings.gauge.colormode.static"))
+                                .tag(GaugeColorMode.static)
+                            Text(String(localized: "settings.gauge.colormode.smart"))
+                                .tag(GaugeColorMode.smart)
+                        }
+                        .pickerStyle(.segmented)
+                        .frame(width: 180)
                     }
-                    .padding(.top, 8)
+
+                    Text(themeStore.gaugeColorMode == .smart
+                        ? String(localized: "settings.gauge.colormode.smart.hint")
+                        : String(localized: "settings.gauge.colormode.static.hint"))
+                        .font(.system(size: 11))
+                        .foregroundStyle(.white.opacity(0.4))
+
+                    if themeStore.gaugeColorMode == .static {
+                        thresholdSlider(label: String(localized: "settings.theme.warning"), value: $warningSlider, range: 10...90)
+                        thresholdSlider(label: String(localized: "settings.theme.critical"), value: $criticalSlider, range: 15...95)
+
+                        // Preview gauges
+                        HStack(spacing: 24) {
+                            Spacer()
+                            themePreviewGauge(pct: Double(max(themeStore.warningThreshold - 15, 5)), label: "Normal")
+                            themePreviewGauge(pct: Double(themeStore.warningThreshold + themeStore.criticalThreshold) / 2.0, label: "Warning")
+                            themePreviewGauge(pct: Double(min(themeStore.criticalThreshold + 5, 100)), label: "Critical")
+                            Spacer()
+                        }
+                        .padding(.top, 8)
+                    }
                 }
             }
 

--- a/TokenEaterTests/Mocks/MockSharedFileService.swift
+++ b/TokenEaterTests/Mocks/MockSharedFileService.swift
@@ -7,6 +7,7 @@ final class MockSharedFileService: SharedFileServiceProtocol, @unchecked Sendabl
     var _lastSyncDate: Date?
     var _theme: ThemeColors = .default
     var _thresholds: UsageThresholds = .default
+    var _gaugeColorMode: GaugeColorMode = .static
     var updateAfterSyncCallCount = 0
     var updateThemeCallCount = 0
 
@@ -16,6 +17,7 @@ final class MockSharedFileService: SharedFileServiceProtocol, @unchecked Sendabl
     var lastSyncDate: Date? { _lastSyncDate }
     var theme: ThemeColors { _theme }
     var thresholds: UsageThresholds { _thresholds }
+    var gaugeColorMode: GaugeColorMode { _gaugeColorMode }
 
     func updateAfterSync(usage: CachedUsage, syncDate: Date) {
         updateAfterSyncCallCount += 1
@@ -23,10 +25,11 @@ final class MockSharedFileService: SharedFileServiceProtocol, @unchecked Sendabl
         _lastSyncDate = syncDate
     }
 
-    func updateTheme(_ theme: ThemeColors, thresholds: UsageThresholds) {
+    func updateTheme(_ theme: ThemeColors, thresholds: UsageThresholds, gaugeColorMode: GaugeColorMode) {
         updateThemeCallCount += 1
         _theme = theme
         _thresholds = thresholds
+        _gaugeColorMode = gaugeColorMode
     }
 
     func invalidateCache() {}

--- a/TokenEaterWidget/UsageWidgetView.swift
+++ b/TokenEaterWidget/UsageWidgetView.swift
@@ -8,6 +8,7 @@ enum WidgetTheme {
 
     static var theme: ThemeColors { shared.theme }
     static var thresholds: UsageThresholds { shared.thresholds }
+    static var gaugeColorMode: GaugeColorMode { shared.gaugeColorMode }
 }
 
 // MARK: - Widget Background (macOS 13 compat)
@@ -78,7 +79,8 @@ struct UsageWidgetView: View {
                     CircularUsageView(
                         label: String(localized: "widget.session"),
                         resetInfo: formatResetTime(fiveHour.resetsAtDate),
-                        utilization: fiveHour.utilization
+                        utilization: fiveHour.utilization,
+                        resetDate: fiveHour.resetsAtDate
                     )
                 }
                 if let sevenDay = usage.sevenDay {
@@ -141,7 +143,8 @@ struct UsageWidgetView: View {
                     label: String(localized: "widget.session"),
                     subtitle: String(localized: "widget.session.subtitle"),
                     resetInfo: formatResetTime(fiveHour.resetsAtDate),
-                    utilization: fiveHour.utilization
+                    utilization: fiveHour.utilization,
+                    resetDate: fiveHour.resetsAtDate
                 )
             }
 
@@ -293,11 +296,16 @@ struct CircularUsageView: View {
     let label: String
     let resetInfo: String
     let utilization: Double
+    var resetDate: Date? = nil
     var theme: ThemeColors = WidgetTheme.theme
     var thresholds: UsageThresholds = WidgetTheme.thresholds
+    var gaugeColorMode: GaugeColorMode = WidgetTheme.gaugeColorMode
 
     private var ringGradient: LinearGradient {
-        theme.gaugeGradient(for: utilization, thresholds: thresholds)
+        guard gaugeColorMode == .smart, resetDate != nil else {
+            return theme.gaugeGradient(for: utilization, thresholds: thresholds)
+        }
+        return theme.smartGaugeGradient(utilization: utilization, resetDate: resetDate)
     }
 
     var body: some View {
@@ -397,18 +405,26 @@ struct LargeUsageBarView: View {
     let utilization: Double
     var colorOverride: Color? = nil
     var displayText: String? = nil
+    var resetDate: Date? = nil
     var theme: ThemeColors = WidgetTheme.theme
     var thresholds: UsageThresholds = WidgetTheme.thresholds
+    var gaugeColorMode: GaugeColorMode = WidgetTheme.gaugeColorMode
 
     private var barGradient: LinearGradient {
         if let color = colorOverride {
             return LinearGradient(colors: [color, color.opacity(0.8)], startPoint: .leading, endPoint: .trailing)
+        }
+        if gaugeColorMode == .smart, resetDate != nil {
+            return theme.smartGaugeGradient(utilization: utilization, resetDate: resetDate, startPoint: .leading, endPoint: .trailing)
         }
         return theme.gaugeGradient(for: utilization, thresholds: thresholds, startPoint: .leading, endPoint: .trailing)
     }
 
     private var accentColor: Color {
         if let color = colorOverride { return color }
+        if gaugeColorMode == .smart, resetDate != nil {
+            return theme.smartGaugeColor(utilization: utilization, resetDate: resetDate)
+        }
         return theme.gaugeColor(for: utilization, thresholds: thresholds)
     }
 


### PR DESCRIPTION
## Summary

Adds a **Smart** color mode for the 5-hour session gauge. Instead of fixed thresholds (60%/85%), the color factors in time remaining using a risk score:

```
risk = utilization × remaining_minutes / 100
```

- **Green**: risk < 70 (low usage, or high usage but reset is imminent)
- **Orange**: risk 70-100
- **Red**: risk > 100 (high usage with lots of time left)

This means 80% usage with 5 minutes until reset stays **green** (risk = 4), while 50% usage with 2.5 hours left shows **orange** (risk = 75).

### Settings

New **Session color mode** picker in Themes > Thresholds:
- **Thresholds** (default): current behavior, fixed warning/critical percentages
- **Smart**: risk-based coloring that adapts to time remaining

When Smart is selected, the threshold sliders and preview gauges are hidden (they don't apply).

### Scope

Smart mode applies only to the **5-hour session** gauge across:
- Dashboard (hero ring, background tint, particles)
- Menu bar popover (hero ring)
- Menu bar icon (5h metric)
- Widget (medium circular + large bar)

Other gauges (weekly, sonnet, opus) keep using static thresholds.

The setting syncs to the widget via the shared JSON file.