### PR TITLE
Add per-bucket pacing, session pacing metric, and reset countdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,9 @@
-# TokenEater - Instructions projet
+# TokenEater - Project Instructions
 
-## Langue
+## Language
 
-- **GitHub (issues, PRs, commits, branches) : toujours en anglais**
-- Conversations avec l'utilisateur : en français (cf. instructions globales)
+- **GitHub (issues, PRs, commits, branches): always in English**
+- Conversations with the user: in English
 
 ## Build & Test local
 

--- a/Shared/Helpers/MenuBarRenderer.swift
+++ b/Shared/Helpers/MenuBarRenderer.swift
@@ -92,13 +92,12 @@ enum MenuBarRenderer {
                     let sign = data.sessionPacingDelta >= 0 ? "+" : ""
                     switch data.pacingDisplayMode {
                     case .dot:
-                        str.append(NSAttributedString(string: "5h\u{25CF}", attributes: dotAttrs))
+                        str.append(NSAttributedString(string: "\u{25CF}", attributes: dotAttrs))
                     case .dotDelta:
-                        str.append(NSAttributedString(string: "5h\u{25CF}", attributes: dotAttrs))
+                        str.append(NSAttributedString(string: "\u{25CF}", attributes: dotAttrs))
                         str.append(NSAttributedString(string: " \(sign)\(data.sessionPacingDelta)%", attributes: deltaAttrs))
                     case .delta:
-                        str.append(NSAttributedString(string: "5h", attributes: labelAttrs))
-                        str.append(NSAttributedString(string: " \(sign)\(data.sessionPacingDelta)%", attributes: deltaAttrs))
+                        str.append(NSAttributedString(string: "\(sign)\(data.sessionPacingDelta)%", attributes: deltaAttrs))
                     }
             } else if metric == .pacing {
                 let dotColor = colorForZone(data.pacingZone, data: data)
@@ -129,11 +128,16 @@ enum MenuBarRenderer {
                 case .pacing, .sessionPacing: value = 0
                 }
                 if metric == .fiveHour && data.showSessionReset && !data.fiveHourReset.isEmpty {
-                    let resetAttrs: [NSAttributedString.Key: Any] = [
+                    let resetLabelAttrs: [NSAttributedString.Key: Any] = [
+                        .font: NSFont.monospacedDigitSystemFont(ofSize: 9, weight: .medium),
+                        .foregroundColor: NSColor.tertiaryLabelColor,
+                    ]
+                    let resetValueAttrs: [NSAttributedString.Key: Any] = [
                         .font: NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .bold),
                         .foregroundColor: NSColor.labelColor,
                     ]
-                    str.append(NSAttributedString(string: data.fiveHourReset, attributes: resetAttrs))
+                    str.append(NSAttributedString(string: "5h ", attributes: resetLabelAttrs))
+                    str.append(NSAttributedString(string: data.fiveHourReset, attributes: resetValueAttrs))
                     str.append(NSAttributedString(string: "  ", attributes: labelAttrs))
                 }
                 str.append(NSAttributedString(string: "\(metric.shortLabel) ", attributes: labelAttrs))

--- a/Shared/Helpers/MenuBarRenderer.swift
+++ b/Shared/Helpers/MenuBarRenderer.swift
@@ -15,6 +15,11 @@ enum MenuBarRenderer {
         let themeColors: ThemeColors
         let thresholds: UsageThresholds
         let menuBarMonochrome: Bool
+        let fiveHourReset: String
+        let showSessionReset: Bool
+        let sessionPacingDelta: Int
+        let sessionPacingZone: PacingZone
+        let hasSessionPacing: Bool
     }
 
     // FIX 1: Static cache — returns same NSImage when data unchanged
@@ -65,12 +70,37 @@ enum MenuBarRenderer {
             .foregroundColor: NSColor.tertiaryLabelColor,
         ]
 
-        let ordered: [MetricID] = [.fiveHour, .sevenDay, .sonnet, .pacing].filter { data.pinnedMetrics.contains($0) }
+        let ordered: [MetricID] = [.fiveHour, .sessionPacing, .sevenDay, .sonnet, .pacing].filter {
+            guard data.pinnedMetrics.contains($0) else { return false }
+            if $0 == .sessionPacing { return data.hasSessionPacing }
+            return true
+        }
         for (i, metric) in ordered.enumerated() {
             if i > 0 {
                 str.append(NSAttributedString(string: "  ", attributes: sepAttrs))
             }
-            if metric == .pacing {
+            if metric == .sessionPacing {
+                let dotColor = colorForZone(data.sessionPacingZone, data: data)
+                    let dotAttrs: [NSAttributedString.Key: Any] = [
+                        .font: NSFont.systemFont(ofSize: 11, weight: .bold),
+                        .foregroundColor: dotColor,
+                    ]
+                    let deltaAttrs: [NSAttributedString.Key: Any] = [
+                        .font: NSFont.monospacedDigitSystemFont(ofSize: 10, weight: .bold),
+                        .foregroundColor: dotColor,
+                    ]
+                    let sign = data.sessionPacingDelta >= 0 ? "+" : ""
+                    switch data.pacingDisplayMode {
+                    case .dot:
+                        str.append(NSAttributedString(string: "5h\u{25CF}", attributes: dotAttrs))
+                    case .dotDelta:
+                        str.append(NSAttributedString(string: "5h\u{25CF}", attributes: dotAttrs))
+                        str.append(NSAttributedString(string: " \(sign)\(data.sessionPacingDelta)%", attributes: deltaAttrs))
+                    case .delta:
+                        str.append(NSAttributedString(string: "5h", attributes: labelAttrs))
+                        str.append(NSAttributedString(string: " \(sign)\(data.sessionPacingDelta)%", attributes: deltaAttrs))
+                    }
+            } else if metric == .pacing {
                 let dotColor = colorForZone(data.pacingZone, data: data)
                 let dotAttrs: [NSAttributedString.Key: Any] = [
                     .font: NSFont.systemFont(ofSize: 11, weight: .bold),
@@ -96,7 +126,15 @@ enum MenuBarRenderer {
                 case .fiveHour: value = data.fiveHourPct
                 case .sevenDay: value = data.sevenDayPct
                 case .sonnet: value = data.sonnetPct
-                case .pacing: value = 0
+                case .pacing, .sessionPacing: value = 0
+                }
+                if metric == .fiveHour && data.showSessionReset && !data.fiveHourReset.isEmpty {
+                    let resetAttrs: [NSAttributedString.Key: Any] = [
+                        .font: NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .bold),
+                        .foregroundColor: NSColor.labelColor,
+                    ]
+                    str.append(NSAttributedString(string: data.fiveHourReset, attributes: resetAttrs))
+                    str.append(NSAttributedString(string: "  ", attributes: labelAttrs))
                 }
                 str.append(NSAttributedString(string: "\(metric.shortLabel) ", attributes: labelAttrs))
                 let pctAttrs: [NSAttributedString.Key: Any] = [

--- a/Shared/Helpers/PacingCalculator.swift
+++ b/Shared/Helpers/PacingCalculator.swift
@@ -12,13 +12,34 @@ enum PacingCalculator {
     ]
 
     static func calculate(from usage: UsageResponse, margin: Double = 10, now: Date = Date()) -> PacingResult? {
-        guard let bucket = usage.sevenDay,
-              let resetsAt = bucket.resetsAtDate
-        else { return nil }
+        calculateForBucket(usage.sevenDay, duration: PacingBucket.sevenDay.periodDuration, margin: margin, now: now)
+    }
 
-        let totalDuration: TimeInterval = 7 * 24 * 3600
-        let startOfPeriod = resetsAt.addingTimeInterval(-totalDuration)
-        let elapsed = now.timeIntervalSince(startOfPeriod) / totalDuration
+    static func calculate(from usage: UsageResponse, bucket: PacingBucket, margin: Double = 10, now: Date = Date()) -> PacingResult? {
+        let usageBucket: UsageBucket?
+        switch bucket {
+        case .fiveHour: usageBucket = usage.fiveHour
+        case .sevenDay: usageBucket = usage.sevenDay
+        case .sonnet: usageBucket = usage.sevenDaySonnet
+        }
+        return calculateForBucket(usageBucket, duration: bucket.periodDuration, margin: margin, now: now)
+    }
+
+    static func calculateAll(from usage: UsageResponse, margin: Double = 10, now: Date = Date()) -> [PacingBucket: PacingResult] {
+        var results: [PacingBucket: PacingResult] = [:]
+        for bucket in PacingBucket.allCases {
+            if let result = calculate(from: usage, bucket: bucket, margin: margin, now: now) {
+                results[bucket] = result
+            }
+        }
+        return results
+    }
+
+    private static func calculateForBucket(_ bucket: UsageBucket?, duration: TimeInterval, margin: Double = 10, now: Date = Date()) -> PacingResult? {
+        guard let bucket, let resetsAt = bucket.resetsAtDate else { return nil }
+
+        let startOfPeriod = resetsAt.addingTimeInterval(-duration)
+        let elapsed = now.timeIntervalSince(startOfPeriod) / duration
         let clampedElapsed = min(max(elapsed, 0), 1)
 
         let expectedUsage = clampedElapsed * 100
@@ -37,7 +58,8 @@ enum PacingCalculator {
             messages = onTrackMessages
         }
 
-        let messageKey = messages.randomElement() ?? messages[0]
+        let index = abs(Int(delta)) % messages.count
+        let messageKey = messages[index]
         let message = String(localized: String.LocalizationValue(messageKey))
 
         return PacingResult(

--- a/Shared/Models/MetricModels.swift
+++ b/Shared/Models/MetricModels.swift
@@ -5,6 +5,7 @@ enum MetricID: String, CaseIterable {
     case sevenDay = "sevenDay"
     case sonnet = "sonnet"
     case pacing = "pacing"
+    case sessionPacing = "sessionPacing"
 
     var label: String {
         switch self {
@@ -12,6 +13,7 @@ enum MetricID: String, CaseIterable {
         case .sevenDay: return String(localized: "metric.weekly")
         case .sonnet: return String(localized: "metric.sonnet")
         case .pacing: return String(localized: "pacing.label")
+        case .sessionPacing: return String(localized: "pacing.session.label")
         }
     }
 
@@ -21,6 +23,7 @@ enum MetricID: String, CaseIterable {
         case .sevenDay: return "7d"
         case .sonnet: return "S"
         case .pacing: return "P"
+        case .sessionPacing: return "5hP"
         }
     }
 }

--- a/Shared/Models/PacingModels.swift
+++ b/Shared/Models/PacingModels.swift
@@ -6,6 +6,27 @@ enum PacingZone: String {
     case hot
 }
 
+enum PacingBucket: String, CaseIterable {
+    case fiveHour
+    case sevenDay
+    case sonnet
+
+    var periodDuration: TimeInterval {
+        switch self {
+        case .fiveHour: return 5 * 3600
+        case .sevenDay, .sonnet: return 7 * 24 * 3600
+        }
+    }
+
+    var metricID: MetricID {
+        switch self {
+        case .fiveHour: return .fiveHour
+        case .sevenDay: return .sevenDay
+        case .sonnet: return .sonnet
+        }
+    }
+}
+
 struct PacingResult {
     let delta: Double
     let expectedUsage: Double

--- a/Shared/Stores/SettingsStore.swift
+++ b/Shared/Stores/SettingsStore.swift
@@ -13,6 +13,9 @@ final class SettingsStore: ObservableObject {
     @Published var pacingDisplayMode: PacingDisplayMode {
         didSet { UserDefaults.standard.set(pacingDisplayMode.rawValue, forKey: "pacingDisplayMode") }
     }
+    @Published var showSessionReset: Bool {
+        didSet { UserDefaults.standard.set(showSessionReset, forKey: "showSessionReset") }
+    }
     @Published var hasCompletedOnboarding: Bool {
         didSet { UserDefaults.standard.set(hasCompletedOnboarding, forKey: "hasCompletedOnboarding") }
     }
@@ -105,6 +108,14 @@ final class SettingsStore: ObservableObject {
         }
     }
 
+    var showSessionPacing: Bool {
+        get { pinnedMetrics.contains(.sessionPacing) }
+        set {
+            if newValue { pinnedMetrics.insert(.sessionPacing) }
+            else if pinnedMetrics.count > 1 { pinnedMetrics.remove(.sessionPacing) }
+        }
+    }
+
     var showPacing: Bool {
         get { pinnedMetrics.contains(.pacing) }
         set {
@@ -160,6 +171,7 @@ final class SettingsStore: ObservableObject {
         self.pacingDisplayMode = PacingDisplayMode(
             rawValue: UserDefaults.standard.string(forKey: "pacingDisplayMode") ?? "dotDelta"
         ) ?? .dotDelta
+        self.showSessionReset = UserDefaults.standard.bool(forKey: "showSessionReset")
         if let saved = UserDefaults.standard.stringArray(forKey: "pinnedMetrics") {
             self.pinnedMetrics = Set(saved.compactMap { MetricID(rawValue: $0) })
         } else {

--- a/Shared/Stores/UsageStore.swift
+++ b/Shared/Stores/UsageStore.swift
@@ -15,6 +15,8 @@ final class UsageStore: ObservableObject {
     @Published var pacingDelta: Int = 0
     @Published var pacingZone: PacingZone = .onTrack
     @Published var pacingResult: PacingResult?
+    @Published var fiveHourPacing: PacingResult?
+    @Published var sonnetPacing: PacingResult?
     @Published var lastUpdate: Date?
     @Published var isLoading = false
     @Published var errorState: AppErrorState = .none
@@ -300,32 +302,42 @@ final class UsageStore: ObservableObject {
         hasOpus = usage.sevenDayOpus != nil
         hasCowork = usage.sevenDayCowork != nil
 
-        if let reset = usage.fiveHour?.resetsAtDate {
-            let diff = reset.timeIntervalSinceNow
-            if diff > 0 {
-                let h = Int(diff) / 3600
-                let m = (Int(diff) % 3600) / 60
-                fiveHourReset = h > 0 ? "\(h)h \(m)min" : "\(m)min"
-            } else {
-                fiveHourReset = String(localized: "relative.now")
-            }
-        } else {
-            fiveHourReset = ""
-        }
+        refreshResetCountdown()
 
-        if let pacing = PacingCalculator.calculate(from: usage, margin: Double(pacingMargin)) {
-            pacingDelta = Int(pacing.delta)
-            pacingZone = pacing.zone
-            pacingResult = pacing
+        applyPacing(PacingCalculator.calculateAll(from: usage, margin: Double(pacingMargin)))
+    }
+
+    func refreshResetCountdown() {
+        guard let reset = lastUsage?.fiveHour?.resetsAtDate else {
+            fiveHourReset = ""
+            return
+        }
+        let diff = reset.timeIntervalSinceNow
+        if diff > 0 {
+            let h = Int(diff) / 3600
+            let m = (Int(diff) % 3600) / 60
+            fiveHourReset = h > 0 ? "\(h)h \(m)min" : "\(m)min"
+        } else {
+            fiveHourReset = String(localized: "relative.now")
         }
     }
 
     func recalculatePacing() {
         guard let usage = lastUsage else { return }
-        if let pacing = PacingCalculator.calculate(from: usage, margin: Double(pacingMargin)) {
+        applyPacing(PacingCalculator.calculateAll(from: usage, margin: Double(pacingMargin)))
+    }
+
+    private func applyPacing(_ allPacing: [PacingBucket: PacingResult]) {
+        if let pacing = allPacing[.sevenDay] {
             pacingDelta = Int(pacing.delta)
             pacingZone = pacing.zone
             pacingResult = pacing
+        } else {
+            pacingDelta = 0
+            pacingZone = .onTrack
+            pacingResult = nil
         }
+        fiveHourPacing = allPacing[.fiveHour]
+        sonnetPacing = allPacing[.sonnet]
     }
 }

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -46,6 +46,8 @@
 "settings.menubar.title" = "Menu bar";
 "settings.tab.connection" = "Connection";
 "settings.tab.display" = "Display";
+"settings.session.reset" = "Show reset countdown";
+"pacing.session.label" = "Session pacing";
 "settings.metrics.pinned" = "Pinned metrics";
 "settings.metrics.pinned.footer" = "Choose which metrics appear in the menu bar.";
 "settings.pacing.display" = "Pacing display";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -46,6 +46,8 @@
 "settings.menubar.title" = "Barre de menu";
 "settings.tab.connection" = "Connexion";
 "settings.tab.display" = "Affichage";
+"settings.session.reset" = "Afficher le compte à rebours";
+"pacing.session.label" = "Rythme session";
 "settings.metrics.pinned" = "Métriques épinglées";
 "settings.metrics.pinned.footer" = "Choisissez les métriques affichées dans la barre de menu.";
 "settings.pacing.display" = "Affichage rythme";

--- a/TokenEaterApp/DashboardView.swift
+++ b/TokenEaterApp/DashboardView.swift
@@ -106,9 +106,15 @@ struct DashboardView: View {
                 profileCard
             }
 
-            // Pacing card
+            // Pacing cards
+            if let pacing = usageStore.fiveHourPacing {
+                pacingCard(pacing: pacing, label: PacingBucket.fiveHour.metricID.label)
+            }
             if let pacing = usageStore.pacingResult {
-                pacingCard(pacing: pacing)
+                pacingCard(pacing: pacing, label: PacingBucket.sevenDay.metricID.label)
+            }
+            if let pacing = usageStore.sonnetPacing {
+                pacingCard(pacing: pacing, label: PacingBucket.sonnet.metricID.label)
             }
 
             Spacer()
@@ -271,10 +277,10 @@ struct DashboardView: View {
 
     // MARK: - Pacing Card
 
-    private func pacingCard(pacing: PacingResult) -> some View {
+    private func pacingCard(pacing: PacingResult, label: String) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
-                Text(String(localized: "pacing.label"))
+                Text("\(String(localized: "pacing.label")) · \(label)")
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(.white.opacity(0.7))
                 Spacer()

--- a/TokenEaterApp/DisplaySectionView.swift
+++ b/TokenEaterApp/DisplaySectionView.swift
@@ -12,12 +12,14 @@ struct DisplaySectionView: View {
     @State private var showSevenDay: Bool
     @State private var showSonnet: Bool
     @State private var showPacing: Bool
+    @State private var showSessionPacing: Bool
 
     init(initialMetrics: Set<MetricID>) {
         _showFiveHour = State(initialValue: initialMetrics.contains(.fiveHour))
         _showSevenDay = State(initialValue: initialMetrics.contains(.sevenDay))
         _showSonnet = State(initialValue: initialMetrics.contains(.sonnet))
         _showPacing = State(initialValue: initialMetrics.contains(.pacing))
+        _showSessionPacing = State(initialValue: initialMetrics.contains(.sessionPacing))
     }
 
     var body: some View {
@@ -38,10 +40,14 @@ struct DisplaySectionView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     cardLabel(String(localized: "settings.metrics.pinned"))
                     darkToggle(String(localized: "metric.session"), isOn: $showFiveHour)
+                    if showFiveHour {
+                        darkToggle(String(localized: "settings.session.reset"), isOn: $settingsStore.showSessionReset)
+                    }
                     darkToggle(String(localized: "metric.weekly"), isOn: $showSevenDay)
                     darkToggle(String(localized: "metric.sonnet"), isOn: $showSonnet)
+                    darkToggle(String(localized: "pacing.session.label"), isOn: $showSessionPacing)
                     darkToggle(String(localized: "pacing.label"), isOn: $showPacing)
-                    if showPacing {
+                    if showPacing || showSessionPacing {
                         PacingDisplayPicker(selection: $settingsStore.pacingDisplayMode)
                             .padding(.leading, 8)
                     }
@@ -55,6 +61,11 @@ struct DisplaySectionView: View {
         .onChange(of: showFiveHour) { _, new in syncMetric(.fiveHour, on: new, revert: { showFiveHour = true }) }
         .onChange(of: showSevenDay) { _, new in syncMetric(.sevenDay, on: new, revert: { showSevenDay = true }) }
         .onChange(of: showSonnet) { _, new in syncMetric(.sonnet, on: new, revert: { showSonnet = true }) }
+        .onChange(of: showSessionPacing) { _, new in
+            withAnimation(.easeInOut(duration: 0.2)) {
+                syncMetric(.sessionPacing, on: new, revert: { showSessionPacing = true })
+            }
+        }
         .onChange(of: showPacing) { _, new in
             withAnimation(.easeInOut(duration: 0.2)) {
                 syncMetric(.pacing, on: new, revert: { showPacing = true })
@@ -65,6 +76,9 @@ struct DisplaySectionView: View {
             if showFiveHour != metrics.contains(.fiveHour) { showFiveHour = metrics.contains(.fiveHour) }
             if showSevenDay != metrics.contains(.sevenDay) { showSevenDay = metrics.contains(.sevenDay) }
             if showSonnet != metrics.contains(.sonnet) { showSonnet = metrics.contains(.sonnet) }
+            if showSessionPacing != metrics.contains(.sessionPacing) {
+                withAnimation(.easeInOut(duration: 0.2)) { showSessionPacing = metrics.contains(.sessionPacing) }
+            }
             if showPacing != metrics.contains(.pacing) {
                 withAnimation(.easeInOut(duration: 0.2)) { showPacing = metrics.contains(.pacing) }
             }

--- a/TokenEaterApp/MenuBarView.swift
+++ b/TokenEaterApp/MenuBarView.swift
@@ -52,46 +52,25 @@ struct MenuBarPopoverView: View {
                 .padding(.horizontal, 24)
                 .padding(.bottom, 14)
 
-            // Pacing section
-            if let pacing = usageStore.pacingResult {
+            // Session pacing
+            if let pacing = usageStore.fiveHourPacing {
                 VStack(alignment: .leading, spacing: 6) {
-                    Button {
-                        withAnimation(.easeInOut(duration: 0.15)) {
-                            settingsStore.toggleMetric(.pacing)
-                        }
-                    } label: {
-                        HStack(spacing: 6) {
-                            Image(systemName: settingsStore.pinnedMetrics.contains(.pacing) ? "pin.fill" : "pin")
-                                .font(.system(size: 7))
-                                .foregroundStyle(settingsStore.pinnedMetrics.contains(.pacing) ? colorForZone(pacing.zone) : .white.opacity(0.2))
-                                .rotationEffect(.degrees(settingsStore.pinnedMetrics.contains(.pacing) ? 0 : 45))
-                            Text(String(localized: "pacing.label"))
-                                .font(.system(size: 11, weight: .medium))
-                                .foregroundStyle(.white.opacity(0.5))
-                            Spacer()
-                            let sign = pacing.delta >= 0 ? "+" : ""
-                            GlowText(
-                                "\(sign)\(Int(pacing.delta))%",
-                                font: .system(size: 13, weight: .black, design: .rounded),
-                                color: colorForZone(pacing.zone),
-                                glowRadius: 3
-                            )
-                        }
+                    pacingPinHeader(metric: .sessionPacing, label: String(localized: "pacing.session.label"), zone: pacing.zone)
+                    pacingRow(pacing: pacing, label: PacingBucket.fiveHour.metricID.label)
+                }
+                .padding(.horizontal, 16)
+            }
+
+            // Weekly + Sonnet pacing
+            if usageStore.pacingResult != nil || usageStore.sonnetPacing != nil {
+                VStack(alignment: .leading, spacing: 6) {
+                    pacingPinHeader(metric: .pacing, label: String(localized: "pacing.label"), zone: usageStore.pacingResult?.zone ?? .onTrack)
+                    if let pacing = usageStore.pacingResult {
+                        pacingRow(pacing: pacing, label: PacingBucket.sevenDay.metricID.label)
                     }
-                    .buttonStyle(.plain)
-                    .help(settingsStore.pinnedMetrics.contains(.pacing) ? Text(String(localized: "menubar.hide")) : Text(String(localized: "menubar.show")))
-
-                    PacingBar(
-                        actual: pacing.actualUsage,
-                        expected: pacing.expectedUsage,
-                        zone: pacing.zone,
-                        gradient: gradientForZone(pacing.zone),
-                        compact: true
-                    )
-
-                    Text(pacing.message)
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundStyle(colorForZone(pacing.zone).opacity(0.8))
+                    if let pacing = usageStore.sonnetPacing {
+                        pacingRow(pacing: pacing, label: PacingBucket.sonnet.metricID.label)
+                    }
                 }
                 .padding(.horizontal, 16)
             }
@@ -357,6 +336,54 @@ struct MenuBarPopoverView: View {
         .padding(10)
         .background(Color.white.opacity(0.04))
         .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func pacingPinHeader(metric: MetricID, label: String, zone: PacingZone) -> some View {
+        let isPinned = settingsStore.pinnedMetrics.contains(metric)
+        return Button {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                settingsStore.toggleMetric(metric)
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: isPinned ? "pin.fill" : "pin")
+                    .font(.system(size: 7))
+                    .foregroundStyle(isPinned ? colorForZone(zone) : .white.opacity(0.2))
+                    .rotationEffect(.degrees(isPinned ? 0 : 45))
+                Text(label)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.5))
+                Spacer()
+            }
+        }
+        .buttonStyle(.plain)
+        .help(isPinned ? Text(String(localized: "menubar.hide")) : Text(String(localized: "menubar.show")))
+    }
+
+    private func pacingRow(pacing: PacingResult, label: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Text(label)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.4))
+                Spacer()
+                let sign = pacing.delta >= 0 ? "+" : ""
+                GlowText(
+                    "\(sign)\(Int(pacing.delta))%",
+                    font: .system(size: 13, weight: .black, design: .rounded),
+                    color: colorForZone(pacing.zone),
+                    glowRadius: 3
+                )
+            }
+
+            PacingBar(
+                actual: pacing.actualUsage,
+                expected: pacing.expectedUsage,
+                zone: pacing.zone,
+                gradient: gradientForZone(pacing.zone),
+                compact: true
+            )
+        }
     }
 
     private func colorForZone(_ zone: PacingZone) -> Color {

--- a/TokenEaterApp/StatusBarController.swift
+++ b/TokenEaterApp/StatusBarController.swift
@@ -89,6 +89,13 @@ final class StatusBarController: NSObject {
         }
         .store(in: &cancellables)
 
+        Timer.publish(every: 60, on: .main, in: .common).autoconnect()
+            .sink { [weak self] _ in
+                guard let self, self.settingsStore.showSessionReset else { return }
+                self.usageStore.refreshResetCountdown()
+            }
+            .store(in: &cancellables)
+
         settingsStore.$pacingMargin
             .removeDuplicates()
             .sink { [weak self] newMargin in
@@ -204,7 +211,12 @@ final class StatusBarController: NSObject {
             hasError: usageStore.hasError,
             themeColors: themeStore.current,
             thresholds: themeStore.thresholds,
-            menuBarMonochrome: themeStore.menuBarMonochrome
+            menuBarMonochrome: themeStore.menuBarMonochrome,
+            fiveHourReset: usageStore.fiveHourReset,
+            showSessionReset: settingsStore.showSessionReset,
+            sessionPacingDelta: Int(usageStore.fiveHourPacing?.delta ?? 0),
+            sessionPacingZone: usageStore.fiveHourPacing?.zone ?? .onTrack,
+            hasSessionPacing: usageStore.fiveHourPacing != nil
         ))
         statusItem.button?.image = image
     }

--- a/TokenEaterTests/PacingCalculatorTests.swift
+++ b/TokenEaterTests/PacingCalculatorTests.swift
@@ -11,9 +11,8 @@ struct PacingCalculatorTests {
         Date(timeIntervalSince1970: floor(Date().timeIntervalSince1970))
     }
 
-    private func makeResetsAt(elapsedFraction: Double, now: Date) -> String {
-        let totalDuration: TimeInterval = 7 * 24 * 3600
-        let resetsAt = now.addingTimeInterval((1 - elapsedFraction) * totalDuration)
+    private func makeResetsAt(elapsedFraction: Double, now: Date, duration: TimeInterval = 7 * 24 * 3600) -> String {
+        let resetsAt = now.addingTimeInterval((1 - elapsedFraction) * duration)
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
         return formatter.string(from: resetsAt)
@@ -299,5 +298,67 @@ struct PacingCalculatorTests {
         let explicit = PacingCalculator.calculate(from: usage, margin: 10, now: now)
         #expect(implicit?.zone == explicit?.zone)
         #expect(implicit?.zone == .onTrack)
+    }
+
+    // MARK: - Per-bucket pacing
+
+    @Test("fiveHour bucket uses 5h period duration")
+    func fiveHourBucketUses5hPeriod() {
+        let now = Self.stableNow()
+        // 50% elapsed in a 5h window, utilization = 80 → delta = +30 → hot
+        let usage = UsageResponse(
+            fiveHour: .fixture(utilization: 80, resetsAt: makeResetsAt(elapsedFraction: 0.5, now: now, duration: 5 * 3600))
+        )
+        let result = PacingCalculator.calculate(from: usage, bucket: .fiveHour, now: now)
+        #expect(result != nil)
+        #expect(result?.zone == .hot)
+        #expect(abs((result?.delta ?? 0) - 30) < 1)
+    }
+
+    @Test("sonnet bucket uses 7d period duration")
+    func sonnetBucketUses7dPeriod() {
+        let now = Self.stableNow()
+        let usage = UsageResponse(
+            sevenDaySonnet: .fixture(utilization: 20, resetsAt: makeResetsAt(elapsedFraction: 0.5, now: now))
+        )
+        let result = PacingCalculator.calculate(from: usage, bucket: .sonnet, now: now)
+        #expect(result != nil)
+        #expect(result?.zone == .chill)
+    }
+
+    @Test("calculateAll returns results for all available buckets")
+    func calculateAllReturnsAllBuckets() {
+        let now = Self.stableNow()
+        let usage = UsageResponse.fixture(
+            fiveHourUtil: 80,
+            sevenDayUtil: 50,
+            sonnetUtil: 20,
+            fiveHourResetsAt: makeResetsAt(elapsedFraction: 0.5, now: now, duration: 5 * 3600),
+            sevenDayResetsAt: makeResetsAt(elapsedFraction: 0.5, now: now),
+            sonnetResetsAt: makeResetsAt(elapsedFraction: 0.5, now: now)
+        )
+        let results = PacingCalculator.calculateAll(from: usage, now: now)
+        #expect(results.count == 3)
+        #expect(results[.fiveHour]?.zone == .hot)
+        #expect(results[.sevenDay]?.zone == .onTrack)
+        #expect(results[.sonnet]?.zone == .chill)
+    }
+
+    @Test("calculateAll skips buckets without reset dates")
+    func calculateAllSkipsMissingBuckets() {
+        let now = Self.stableNow()
+        let usage = UsageResponse.fixture(
+            sevenDayResetsAt: makeResetsAt(elapsedFraction: 0.5, now: now)
+        )
+        let results = PacingCalculator.calculateAll(from: usage, now: now)
+        #expect(results.count == 1)
+        #expect(results[.sevenDay] != nil)
+    }
+
+    @Test("per-bucket calculate returns nil when bucket is missing")
+    func perBucketReturnsNilWhenMissing() {
+        let usage = UsageResponse()
+        #expect(PacingCalculator.calculate(from: usage, bucket: .fiveHour) == nil)
+        #expect(PacingCalculator.calculate(from: usage, bucket: .sonnet) == nil)
     }
 }

--- a/TokenEaterTests/UsageStoreTests.swift
+++ b/TokenEaterTests/UsageStoreTests.swift
@@ -371,6 +371,80 @@ struct UsageStoreTests {
         #expect(store.pacingDelta > 0)
     }
 
+    // MARK: - refreshResetCountdown
+
+    @Test("refreshResetCountdown updates fiveHourReset from cached data")
+    func refreshResetCountdownUpdates() async {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let resetsAt = Date().addingTimeInterval(3700) // ~1h 1min from now
+        let usage = UsageResponse.fixture(
+            fiveHourResetsAt: formatter.string(from: resetsAt)
+        )
+        let (store, _, _, _, _) = makeSUT(usage: usage)
+
+        await store.refresh()
+        let initialReset = store.fiveHourReset
+        #expect(!initialReset.isEmpty)
+
+        // Simulate time passing — refreshResetCountdown recalculates from the cached date
+        store.refreshResetCountdown()
+        #expect(!store.fiveHourReset.isEmpty)
+        #expect(store.fiveHourReset.contains("h") || store.fiveHourReset.contains("min"))
+    }
+
+    @Test("refreshResetCountdown clears when no cached usage")
+    func refreshResetCountdownClearsWhenNoCachedData() {
+        let (store, _, _, _, _) = makeSUT()
+        store.refreshResetCountdown()
+        #expect(store.fiveHourReset == "")
+    }
+
+    @Test("refreshResetCountdown shows relative.now when reset is past")
+    func refreshResetCountdownShowsNowWhenPast() async {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let resetsAt = Date().addingTimeInterval(-60) // 1min in the past
+        let usage = UsageResponse.fixture(
+            fiveHourResetsAt: formatter.string(from: resetsAt)
+        )
+        let (store, _, _, _, _) = makeSUT(usage: usage)
+
+        await store.refresh()
+        store.refreshResetCountdown()
+        // Should show the "now" localized string, not an empty string
+        #expect(!store.fiveHourReset.isEmpty)
+        #expect(!store.fiveHourReset.contains("min"))
+    }
+
+    // MARK: - per-bucket pacing in store
+
+    @Test("refresh populates fiveHourPacing and sonnetPacing")
+    func refreshPopulatesPerBucketPacing() async {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let fiveHourReset = Date().addingTimeInterval(2.5 * 3600) // mid-period
+        let sevenDayReset = Date().addingTimeInterval(3.5 * 24 * 3600)
+        let sonnetReset = Date().addingTimeInterval(3.5 * 24 * 3600)
+        let usage = UsageResponse.fixture(
+            fiveHourUtil: 80,
+            sevenDayUtil: 50,
+            sonnetUtil: 20,
+            fiveHourResetsAt: formatter.string(from: fiveHourReset),
+            sevenDayResetsAt: formatter.string(from: sevenDayReset),
+            sonnetResetsAt: formatter.string(from: sonnetReset)
+        )
+        let (store, _, _, _, _) = makeSUT(usage: usage)
+
+        await store.refresh()
+
+        #expect(store.fiveHourPacing != nil)
+        #expect(store.sonnetPacing != nil)
+        #expect(store.pacingResult != nil)
+        #expect(store.fiveHourPacing?.zone == .hot)
+        #expect(store.sonnetPacing?.zone == .chill)
+    }
+
     // MARK: - new buckets (opus, cowork)
 
     @Test("refresh extracts opus and cowork percentages")


### PR DESCRIPTION
## Summary

- Extend pacing calculation to all 3 reset points (5h session, 7d weekly, 7d sonnet) — previously only the weekly bucket had pacing
- Add a pinnable **Session pacing** metric for the menu bar status item with dot/delta display modes
- Add an optional **reset countdown** (`1h 39min`) next to the session percentage in the menu bar, with a 60s refresh timer
- 10 new tests covering per-bucket calculation, `calculateAll`, store pacing, and `refreshResetCountdown` edge cases

### Changes

| File | What |
|------|------|
| `PacingModels.swift` | `PacingBucket` enum with `periodDuration` (5h vs 7d) and `metricID` mapping |
| `MetricModels.swift` | `.sessionPacing` case for menu bar pin support |
| `PacingCalculator.swift` | `calculateForBucket` (private), `calculate(from:bucket:)`, `calculateAll`, deterministic message selection |
| `MenuBarRenderer.swift` | Session pacing rendering, reset countdown display, filter empty sessionPacing from ordered list |
| `UsageStore.swift` | `fiveHourPacing`/`sonnetPacing` properties, `applyPacing()` that clears stale state, `refreshResetCountdown()` |
| `SettingsStore.swift` | `showSessionReset` toggle, `showSessionPacing` computed property |
| `StatusBarController.swift` | New `RenderData` fields, 60s countdown timer (guarded by `showSessionReset`) |
| `DashboardView.swift` | 3 pacing cards (session, weekly, sonnet) |
| `MenuBarView.swift` | Separate pacing sections with individual pin headers, `pacingPinHeader`/`pacingRow` helpers |
| `DisplaySectionView.swift` | Toggles for session pacing and reset countdown (conditionally shown) |
| `Localizable.strings` | `pacing.session.label` + `settings.session.reset` in en/fr |
| Tests | 10 new tests across `PacingCalculatorTests` and `UsageStoreTests` |

## Test plan

- [x] All 229 tests pass (`xcodebuild test`)
- [x] Release build succeeds with Xcode 16.4 toolchain
- [ ] Enable "Session pacing" in Settings → Display → Pinned metrics → verify it appears in the menu bar
- [ ] Enable "Show reset countdown" → verify countdown appears before `5h XX%` and ticks every minute
- [ ] Disable "Show reset countdown" → verify countdown disappears and timer stops firing
- [ ] Unpin "Session" metric → verify "Show reset countdown" toggle hides
- [ ] Pin "Session pacing" with no active session → verify no empty gap in menu bar
- [ ] Open dashboard → verify 3 pacing cards appear (session, weekly, sonnet) when data available
- [ ] Open menu bar popover → verify separate session and weekly pacing sections with pin buttons
- [ ] Change pacing display mode (dot/dotDelta/delta) → verify both session and weekly pacing respect it
- [ ] Change pacing margin in settings → verify all 3 pacing values recalculate

🤖 Generated with [Claude Code](https://claude.com/claude-code)