### PR TITLE
fix: verify Sparkle EdDSA signature before installing update

### DIFF
--- a/Shared/Models/UpdateModels.swift
+++ b/Shared/Models/UpdateModels.swift
@@ -9,14 +9,28 @@ enum BrewMigrationState: Equatable {
 struct AppcastItem: Equatable {
     let version: String
     let downloadURL: URL
+    let edSignature: String?
+    let expectedLength: Int64?
+
+    init(
+        version: String,
+        downloadURL: URL,
+        edSignature: String? = nil,
+        expectedLength: Int64? = nil
+    ) {
+        self.version = version
+        self.downloadURL = downloadURL
+        self.edSignature = edSignature
+        self.expectedLength = expectedLength
+    }
 }
 
 enum UpdateState: Equatable {
     case idle
     case checking
-    case available(version: String, downloadURL: URL)
+    case available(version: String, downloadURL: URL, signature: String?, expectedLength: Int64?)
     case downloading(progress: Double)
-    case downloaded(fileURL: URL)
+    case downloaded(fileURL: URL, signature: String?, expectedLength: Int64?)
     case installing
     case upToDate
     case error(String)
@@ -31,7 +45,7 @@ enum UpdateState: Equatable {
     }
 
     var availableVersion: String? {
-        if case .available(let version, _) = self { return version }
+        if case .available(let version, _, _, _) = self { return version }
         return nil
     }
 }

--- a/Shared/Services/Protocols/SignatureVerifierProtocol.swift
+++ b/Shared/Services/Protocols/SignatureVerifierProtocol.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol SignatureVerifierProtocol: Sendable {
+    func verify(data: Data, base64Signature: String, base64PublicKey: String) -> Bool
+}

--- a/Shared/Services/SignatureVerifier.swift
+++ b/Shared/Services/SignatureVerifier.swift
@@ -1,0 +1,13 @@
+import Foundation
+import CryptoKit
+
+final class SignatureVerifier: SignatureVerifierProtocol {
+    func verify(data: Data, base64Signature: String, base64PublicKey: String) -> Bool {
+        guard !base64Signature.isEmpty, !base64PublicKey.isEmpty else { return false }
+        guard let sigData = Data(base64Encoded: base64Signature),
+              let keyData = Data(base64Encoded: base64PublicKey),
+              let publicKey = try? Curve25519.Signing.PublicKey(rawRepresentation: keyData)
+        else { return false }
+        return publicKey.isValidSignature(sigData, for: data)
+    }
+}

--- a/Shared/Services/UpdateService.swift
+++ b/Shared/Services/UpdateService.swift
@@ -76,13 +76,15 @@ final class UpdateService: NSObject, UpdateServiceProtocol, URLSessionDownloadDe
 
 // MARK: - Appcast XML Parser
 
-private final class AppcastXMLParser: NSObject, XMLParserDelegate {
+final class AppcastXMLParser: NSObject, XMLParserDelegate {
     private(set) var items: [AppcastItem] = []
     private var inItem = false
     private var currentElement = ""
     private var currentText = ""
     private var currentVersion: String?
     private var currentURL: String?
+    private var currentSignature: String?
+    private var currentLength: Int64?
 
     var latestItem: AppcastItem? {
         items.max { VersionComparator.compare($0.version, $1.version) == .orderedAscending }
@@ -106,11 +108,15 @@ private final class AppcastXMLParser: NSObject, XMLParserDelegate {
             inItem = true
             currentVersion = nil
             currentURL = nil
+            currentSignature = nil
+            currentLength = nil
         } else if inItem {
             currentElement = name
             currentText = ""
             if name == "enclosure" {
                 currentURL = attributeDict["url"]
+                currentSignature = attributeDict["sparkle:edSignature"]
+                currentLength = attributeDict["length"].flatMap(Int64.init)
             }
         }
     }
@@ -130,7 +136,14 @@ private final class AppcastXMLParser: NSObject, XMLParserDelegate {
             if let version = currentVersion,
                let urlString = currentURL,
                let url = URL(string: urlString) {
-                items.append(AppcastItem(version: version, downloadURL: url))
+                items.append(
+                    AppcastItem(
+                        version: version,
+                        downloadURL: url,
+                        edSignature: currentSignature,
+                        expectedLength: currentLength
+                    )
+                )
             }
             inItem = false
         } else if inItem && name == "sparkle:version" {

--- a/Shared/Stores/UpdateStore.swift
+++ b/Shared/Stores/UpdateStore.swift
@@ -9,6 +9,8 @@ final class UpdateStore: ObservableObject {
 
     private let service: UpdateServiceProtocol
     private let brewMigration: BrewMigrationServiceProtocol
+    private let signatureVerifier: SignatureVerifierProtocol
+    private let publicKeyProvider: () -> String?
 
     private var migrationDismissed: Bool {
         get { UserDefaults.standard.bool(forKey: "brewMigrationDismissed") }
@@ -21,11 +23,23 @@ final class UpdateStore: ObservableObject {
 
     init(
         service: UpdateServiceProtocol = UpdateService(),
-        brewMigration: BrewMigrationServiceProtocol = BrewMigrationService()
+        brewMigration: BrewMigrationServiceProtocol = BrewMigrationService(),
+        signatureVerifier: SignatureVerifierProtocol = SignatureVerifier(),
+        publicKeyProvider: @escaping () -> String? = UpdateStore.bundledPublicKey
     ) {
         self.service = service
         self.brewMigration = brewMigration
+        self.signatureVerifier = signatureVerifier
+        self.publicKeyProvider = publicKeyProvider
         self.brewUninstallCommand = brewMigration.brewUninstallCommand()
+    }
+
+    static func bundledPublicKey() -> String? {
+        guard let url = Bundle.main.url(forResource: "SparklePublicKey", withExtension: "txt"),
+              let contents = try? String(contentsOf: url, encoding: .utf8) else {
+            return nil
+        }
+        return contents.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     // MARK: - Update Flow
@@ -36,7 +50,12 @@ final class UpdateStore: ObservableObject {
         Task {
             do {
                 if let item = try await service.checkForUpdate() {
-                    updateState = .available(version: item.version, downloadURL: item.downloadURL)
+                    updateState = .available(
+                        version: item.version,
+                        downloadURL: item.downloadURL,
+                        signature: item.edSignature,
+                        expectedLength: item.expectedLength
+                    )
                 } else {
                     updateState = .upToDate
                     try? await Task.sleep(for: .seconds(3))
@@ -51,7 +70,7 @@ final class UpdateStore: ObservableObject {
     }
 
     func downloadUpdate() {
-        guard case .available(_, let url) = updateState else { return }
+        guard case .available(_, let url, let signature, let expectedLength) = updateState else { return }
         updateState = .downloading(progress: 0)
         Task {
             do {
@@ -63,7 +82,11 @@ final class UpdateStore: ObservableObject {
                         }
                     }
                 }
-                updateState = .downloaded(fileURL: fileURL)
+                updateState = .downloaded(
+                    fileURL: fileURL,
+                    signature: signature,
+                    expectedLength: expectedLength
+                )
             } catch {
                 updateState = .error(error.localizedDescription)
             }
@@ -71,7 +94,18 @@ final class UpdateStore: ObservableObject {
     }
 
     func installUpdate() {
-        guard case .downloaded(let dmgURL) = updateState else { return }
+        guard case .downloaded(let dmgURL, let signature, let expectedLength) = updateState else { return }
+
+        // Fail-closed: verify length + signature BEFORE giving the DMG to the privileged installer.
+        if let verificationError = verifyDownloadedUpdate(
+            at: dmgURL,
+            signature: signature,
+            expectedLength: expectedLength
+        ) {
+            updateState = .error(verificationError)
+            return
+        }
+
         updateState = .installing
 
         let realHome: String = {
@@ -146,7 +180,7 @@ final class UpdateStore: ObservableObject {
             return
         }
 
-        // 3. Quit — installer waits for us, then shows admin dialog and installs
+        // 3. Quit - installer waits for us, then shows admin dialog and installs
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             NSApp.terminate(nil)
         }
@@ -154,6 +188,47 @@ final class UpdateStore: ObservableObject {
 
     func dismissUpdateModal() {
         updateState = .idle
+    }
+
+    // MARK: - Verification
+
+    /// Returns a localized error message if verification fails, or nil if the DMG is acceptable.
+    /// Size check is only enforced when the appcast advertises a positive expected length
+    /// (older appcast entries sometimes ship `length="0"`, which we treat as "unknown").
+    /// Signature verification is always required (fail-closed).
+    func verifyDownloadedUpdate(
+        at dmgURL: URL,
+        signature: String?,
+        expectedLength: Int64?
+    ) -> String? {
+        if let expected = expectedLength, expected > 0 {
+            let actual = (try? FileManager.default.attributesOfItem(atPath: dmgURL.path)[.size] as? Int64) ?? -1
+            if actual != expected {
+                return String(localized: "update.error.sizeMismatch")
+            }
+        }
+
+        guard let signature, !signature.isEmpty else {
+            return String(localized: "update.error.signatureMissing")
+        }
+
+        guard let publicKey = publicKeyProvider(), !publicKey.isEmpty else {
+            return String(localized: "update.error.verifyReadFailed")
+        }
+
+        guard let dmgData = try? Data(contentsOf: dmgURL) else {
+            return String(localized: "update.error.verifyReadFailed")
+        }
+
+        guard signatureVerifier.verify(
+            data: dmgData,
+            base64Signature: signature,
+            base64PublicKey: publicKey
+        ) else {
+            return String(localized: "update.error.signatureInvalid")
+        }
+
+        return nil
     }
 
     // MARK: - Brew Migration

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -269,6 +269,10 @@
 "update.installing.hint" = "Enter your password when macOS asks";
 "update.version.current" = "Current";
 "update.version.new" = "New";
+"update.error.signatureInvalid" = "Signature verification failed. Aborting install.";
+"update.error.signatureMissing" = "Update is missing a signature. Aborting install.";
+"update.error.sizeMismatch" = "Update file size does not match the appcast. Aborting install.";
+"update.error.verifyReadFailed" = "Could not read update files for verification. Aborting install.";
 
 /* Brew Migration */
 "update.brew.detected" = "Installed via Homebrew";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -269,6 +269,10 @@
 "update.installing.hint" = "Entrez votre mot de passe quand macOS le demande";
 "update.version.current" = "Actuel";
 "update.version.new" = "Nouveau";
+"update.error.signatureInvalid" = "Échec de la vérification de signature. Installation annulée.";
+"update.error.signatureMissing" = "Signature manquante pour la mise à jour. Installation annulée.";
+"update.error.sizeMismatch" = "Taille de la mise à jour incorrecte. Installation annulée.";
+"update.error.verifyReadFailed" = "Impossible de lire les fichiers de mise à jour pour la vérification. Installation annulée.";
 
 /* Brew Migration */
 "update.brew.detected" = "Installé via Homebrew";

--- a/TokenEaterApp/Resources/SparklePublicKey.txt
+++ b/TokenEaterApp/Resources/SparklePublicKey.txt
@@ -1,0 +1,1 @@
+7K/7v1Y96LUzTSghUUKPB6uqYdJ/bIU/bFLaw14ptnM=

--- a/TokenEaterApp/UpdateModalView.swift
+++ b/TokenEaterApp/UpdateModalView.swift
@@ -21,7 +21,7 @@ struct UpdateModalView: View {
             // Modal card
             VStack(spacing: 0) {
                 switch updateStore.updateState {
-                case .available(let version, _):
+                case .available(let version, _, _, _):
                     availableContent(newVersion: version)
                 case .downloading(let progress):
                     downloadingContent(progress: progress)

--- a/TokenEaterTests/AppcastXMLParserTests.swift
+++ b/TokenEaterTests/AppcastXMLParserTests.swift
@@ -1,0 +1,137 @@
+import Testing
+import Foundation
+
+@Suite("AppcastXMLParser")
+struct AppcastXMLParserTests {
+    private func parse(_ xml: String) -> AppcastXMLParser {
+        let parser = AppcastXMLParser()
+        parser.parse(data: Data(xml.utf8))
+        return parser
+    }
+
+    private let header = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+            <channel>
+                <title>TokenEater</title>
+        """
+
+    private let footer = """
+            </channel>
+        </rss>
+        """
+
+    @Test("parses version, URL, signature, and length from an enclosure")
+    func parsesSignedEnclosure() {
+        let xml = """
+        \(header)
+            <item>
+                <title>5.0.0</title>
+                <sparkle:version>5.0.0</sparkle:version>
+                <enclosure url="https://example.com/TokenEater.dmg" sparkle:edSignature="AAAA==" length="1234" type="application/octet-stream" />
+            </item>
+        \(footer)
+        """
+        let parser = parse(xml)
+
+        let latest = parser.latestItem
+        #expect(latest?.version == "5.0.0")
+        #expect(latest?.downloadURL.absoluteString == "https://example.com/TokenEater.dmg")
+        #expect(latest?.edSignature == "AAAA==")
+        #expect(latest?.expectedLength == 1234)
+    }
+
+    @Test("preserves empty signature string (does not coerce to nil)")
+    func parsesEmptySignature() {
+        let xml = """
+        \(header)
+            <item>
+                <sparkle:version>4.7.5</sparkle:version>
+                <enclosure url="https://example.com/TokenEater.dmg" sparkle:edSignature="" length="2048" type="application/octet-stream" />
+            </item>
+        \(footer)
+        """
+        let parser = parse(xml)
+        #expect(parser.latestItem?.edSignature == "")
+    }
+
+    @Test("returns nil signature when attribute is absent")
+    func parsesMissingSignatureAsNil() {
+        let xml = """
+        \(header)
+            <item>
+                <sparkle:version>4.6.0</sparkle:version>
+                <enclosure url="https://example.com/TokenEater.dmg" length="512" type="application/octet-stream" />
+            </item>
+        \(footer)
+        """
+        let parser = parse(xml)
+        #expect(parser.latestItem?.edSignature == nil)
+    }
+
+    @Test("returns nil length when attribute is absent")
+    func parsesMissingLengthAsNil() {
+        let xml = """
+        \(header)
+            <item>
+                <sparkle:version>4.6.0</sparkle:version>
+                <enclosure url="https://example.com/TokenEater.dmg" sparkle:edSignature="AAAA==" type="application/octet-stream" />
+            </item>
+        \(footer)
+        """
+        let parser = parse(xml)
+        #expect(parser.latestItem?.expectedLength == nil)
+    }
+
+    @Test("returns nil length when length is not a valid integer")
+    func parsesInvalidLengthAsNil() {
+        let xml = """
+        \(header)
+            <item>
+                <sparkle:version>4.6.0</sparkle:version>
+                <enclosure url="https://example.com/TokenEater.dmg" sparkle:edSignature="AAAA==" length="nope" type="application/octet-stream" />
+            </item>
+        \(footer)
+        """
+        let parser = parse(xml)
+        #expect(parser.latestItem?.expectedLength == nil)
+    }
+
+    @Test("resets state between items (signature does not leak forward)")
+    func doesNotLeakSignatureBetweenItems() {
+        let xml = """
+        \(header)
+            <item>
+                <sparkle:version>5.0.0</sparkle:version>
+                <enclosure url="https://example.com/a.dmg" sparkle:edSignature="SIGA==" length="100" type="application/octet-stream" />
+            </item>
+            <item>
+                <sparkle:version>5.1.0</sparkle:version>
+                <enclosure url="https://example.com/b.dmg" length="200" type="application/octet-stream" />
+            </item>
+        \(footer)
+        """
+        let parser = parse(xml)
+
+        #expect(parser.items.count == 2)
+        let itemA = parser.items.first(where: { $0.version == "5.0.0" })
+        let itemB = parser.items.first(where: { $0.version == "5.1.0" })
+        #expect(itemA?.edSignature == "SIGA==")
+        #expect(itemB?.edSignature == nil)
+        #expect(parser.latestItem?.version == "5.1.0")
+    }
+
+    @Test("selects the highest semver item as latest")
+    func selectsHighestVersion() {
+        let xml = """
+        \(header)
+            <item><sparkle:version>4.6.0</sparkle:version><enclosure url="https://example.com/old.dmg" /></item>
+            <item><sparkle:version>5.0.0</sparkle:version><enclosure url="https://example.com/new.dmg" sparkle:edSignature="NEW==" length="999" /></item>
+            <item><sparkle:version>4.9.3</sparkle:version><enclosure url="https://example.com/mid.dmg" /></item>
+        \(footer)
+        """
+        let parser = parse(xml)
+        #expect(parser.latestItem?.version == "5.0.0")
+        #expect(parser.latestItem?.edSignature == "NEW==")
+    }
+}

--- a/TokenEaterTests/Mocks/MockSignatureVerifier.swift
+++ b/TokenEaterTests/Mocks/MockSignatureVerifier.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+final class MockSignatureVerifier: SignatureVerifierProtocol, @unchecked Sendable {
+    var verifyResult: Bool = true
+    private(set) var verifyCallCount: Int = 0
+    private(set) var lastSignature: String?
+    private(set) var lastPublicKey: String?
+    private(set) var lastDataSize: Int?
+
+    func verify(data: Data, base64Signature: String, base64PublicKey: String) -> Bool {
+        verifyCallCount += 1
+        lastSignature = base64Signature
+        lastPublicKey = base64PublicKey
+        lastDataSize = data.count
+        return verifyResult
+    }
+}

--- a/TokenEaterTests/SignatureVerifierTests.swift
+++ b/TokenEaterTests/SignatureVerifierTests.swift
@@ -1,0 +1,147 @@
+import Testing
+import Foundation
+import CryptoKit
+
+@Suite("SignatureVerifier")
+struct SignatureVerifierTests {
+    private struct Keypair {
+        let privateKey: Curve25519.Signing.PrivateKey
+        let publicKeyBase64: String
+
+        init() {
+            self.privateKey = Curve25519.Signing.PrivateKey()
+            self.publicKeyBase64 = privateKey.publicKey.rawRepresentation.base64EncodedString()
+        }
+
+        func sign(_ data: Data) -> String {
+            let sig = try! privateKey.signature(for: data)
+            return sig.base64EncodedString()
+        }
+    }
+
+    @Test("accepts a valid signature")
+    func acceptsValidSignature() {
+        let keypair = Keypair()
+        let data = Data("hello world".utf8)
+        let signature = keypair.sign(data)
+
+        let verifier = SignatureVerifier()
+        #expect(verifier.verify(data: data, base64Signature: signature, base64PublicKey: keypair.publicKeyBase64))
+    }
+
+    @Test("rejects a signature made with a different key")
+    func rejectsSignatureFromDifferentKey() {
+        let attacker = Keypair()
+        let trusted = Keypair()
+        let data = Data("hello world".utf8)
+        let attackerSignature = attacker.sign(data)
+
+        let verifier = SignatureVerifier()
+        #expect(!verifier.verify(
+            data: data,
+            base64Signature: attackerSignature,
+            base64PublicKey: trusted.publicKeyBase64
+        ))
+    }
+
+    @Test("rejects a signature on different data")
+    func rejectsSignatureOnDifferentData() {
+        let keypair = Keypair()
+        let originalData = Data("hello".utf8)
+        let signature = keypair.sign(originalData)
+        let tamperedData = Data("hellp".utf8)
+
+        let verifier = SignatureVerifier()
+        #expect(!verifier.verify(
+            data: tamperedData,
+            base64Signature: signature,
+            base64PublicKey: keypair.publicKeyBase64
+        ))
+    }
+
+    @Test("rejects malformed base64 signature")
+    func rejectsMalformedBase64Signature() {
+        let keypair = Keypair()
+        let data = Data("hello".utf8)
+
+        let verifier = SignatureVerifier()
+        #expect(!verifier.verify(
+            data: data,
+            base64Signature: "not-valid-base64!!!",
+            base64PublicKey: keypair.publicKeyBase64
+        ))
+    }
+
+    @Test("rejects malformed base64 public key")
+    func rejectsMalformedBase64PublicKey() {
+        let keypair = Keypair()
+        let data = Data("hello".utf8)
+        let signature = keypair.sign(data)
+
+        let verifier = SignatureVerifier()
+        #expect(!verifier.verify(
+            data: data,
+            base64Signature: signature,
+            base64PublicKey: "not-valid-base64!!!"
+        ))
+    }
+
+    @Test("rejects empty signature")
+    func rejectsEmptySignature() {
+        let keypair = Keypair()
+        let data = Data("hello".utf8)
+
+        let verifier = SignatureVerifier()
+        #expect(!verifier.verify(
+            data: data,
+            base64Signature: "",
+            base64PublicKey: keypair.publicKeyBase64
+        ))
+    }
+
+    @Test("rejects empty public key")
+    func rejectsEmptyPublicKey() {
+        let keypair = Keypair()
+        let data = Data("hello".utf8)
+        let signature = keypair.sign(data)
+
+        let verifier = SignatureVerifier()
+        #expect(!verifier.verify(
+            data: data,
+            base64Signature: signature,
+            base64PublicKey: ""
+        ))
+    }
+
+    @Test("rejects public key with wrong length")
+    func rejectsShortPublicKey() {
+        let keypair = Keypair()
+        let data = Data("hello".utf8)
+        let signature = keypair.sign(data)
+        // Valid base64, but decodes to 3 bytes not 32.
+        let shortKey = Data([0x01, 0x02, 0x03]).base64EncodedString()
+
+        let verifier = SignatureVerifier()
+        #expect(!verifier.verify(
+            data: data,
+            base64Signature: signature,
+            base64PublicKey: shortKey
+        ))
+    }
+
+    @Test("verifies large payload (simulated DMG)")
+    func verifiesLargePayload() {
+        let keypair = Keypair()
+        // ~2 MB of random-ish bytes, matching a real TokenEater DMG size range.
+        var rng = SystemRandomNumberGenerator()
+        let data = Data((0..<(2 * 1024 * 1024)).map { _ in UInt8.random(in: 0...255, using: &rng) })
+        let signature = keypair.sign(data)
+
+        let verifier = SignatureVerifier()
+        #expect(verifier.verify(
+            data: data,
+            base64Signature: signature,
+            base64PublicKey: keypair.publicKeyBase64
+        ))
+    }
+}

--- a/TokenEaterTests/UpdateStoreTests.swift
+++ b/TokenEaterTests/UpdateStoreTests.swift
@@ -8,6 +8,28 @@ struct UpdateStoreTests {
         UserDefaults.standard.removeObject(forKey: "brewMigrationDismissed")
     }
 
+    private func makeStore(
+        service: UpdateServiceProtocol = MockUpdateService(),
+        brewMigration: BrewMigrationServiceProtocol = MockBrewMigrationService(),
+        signatureVerifier: SignatureVerifierProtocol = MockSignatureVerifier(),
+        publicKey: String? = "stub-public-key"
+    ) -> UpdateStore {
+        UpdateStore(
+            service: service,
+            brewMigration: brewMigration,
+            signatureVerifier: signatureVerifier,
+            publicKeyProvider: { publicKey }
+        )
+    }
+
+    private func writeTempDMG(bytes: Int = 32) -> URL {
+        let dir = FileManager.default.temporaryDirectory
+        let url = dir.appendingPathComponent("test-\(UUID().uuidString).dmg")
+        let payload = Data((0..<bytes).map { UInt8($0 & 0xFF) })
+        try? payload.write(to: url)
+        return url
+    }
+
     // MARK: - Brew Migration
 
     @Test("shows brew migration when brew install detected")
@@ -17,10 +39,7 @@ struct UpdateStoreTests {
 
         let mockBrew = MockBrewMigrationService()
         mockBrew.isBrewInstallResult = true
-        let store = UpdateStore(
-            service: MockUpdateService(),
-            brewMigration: mockBrew
-        )
+        let store = makeStore(brewMigration: mockBrew)
         store.checkBrewMigration()
         #expect(store.brewMigrationState == .detected)
     }
@@ -32,10 +51,7 @@ struct UpdateStoreTests {
 
         let mockBrew = MockBrewMigrationService()
         mockBrew.isBrewInstallResult = false
-        let store = UpdateStore(
-            service: MockUpdateService(),
-            brewMigration: mockBrew
-        )
+        let store = makeStore(brewMigration: mockBrew)
         store.checkBrewMigration()
         #expect(store.brewMigrationState == .notNeeded)
     }
@@ -47,18 +63,12 @@ struct UpdateStoreTests {
 
         let mockBrew = MockBrewMigrationService()
         mockBrew.isBrewInstallResult = true
-        let store = UpdateStore(
-            service: MockUpdateService(),
-            brewMigration: mockBrew
-        )
+        let store = makeStore(brewMigration: mockBrew)
         store.checkBrewMigration()
         store.dismissBrewMigration()
         #expect(store.brewMigrationState == .dismissed)
 
-        let store2 = UpdateStore(
-            service: MockUpdateService(),
-            brewMigration: mockBrew
-        )
+        let store2 = makeStore(brewMigration: mockBrew)
         store2.checkBrewMigration()
         #expect(store2.brewMigrationState == .dismissed)
     }
@@ -70,20 +80,20 @@ struct UpdateStoreTests {
         let mockService = MockUpdateService()
         mockService.checkResult = AppcastItem(
             version: "9.9.9",
-            downloadURL: URL(string: "https://example.com/test.dmg")!
+            downloadURL: URL(string: "https://example.com/test.dmg")!,
+            edSignature: "sig==",
+            expectedLength: 1024
         )
-        let store = UpdateStore(
-            service: mockService,
-            brewMigration: MockBrewMigrationService()
-        )
+        let store = makeStore(service: mockService)
         store.checkForUpdates()
 
-        // Wait for async task to complete
         try await Task.sleep(for: .milliseconds(100))
 
         #expect(mockService.checkForUpdateCalled)
-        if case .available(let version, _) = store.updateState {
+        if case .available(let version, _, let signature, let length) = store.updateState {
             #expect(version == "9.9.9")
+            #expect(signature == "sig==")
+            #expect(length == 1024)
         } else {
             Issue.record("Expected .available state, got \(store.updateState)")
         }
@@ -93,10 +103,7 @@ struct UpdateStoreTests {
     func checkForUpdatesUpToDate() async throws {
         let mockService = MockUpdateService()
         mockService.checkResult = nil
-        let store = UpdateStore(
-            service: mockService,
-            brewMigration: MockBrewMigrationService()
-        )
+        let store = makeStore(service: mockService)
         store.checkForUpdates()
         try await Task.sleep(for: .milliseconds(100))
 
@@ -108,10 +115,7 @@ struct UpdateStoreTests {
     func checkForUpdatesError() async throws {
         let mockService = MockUpdateService()
         mockService.checkError = URLError(.notConnectedToInternet)
-        let store = UpdateStore(
-            service: mockService,
-            brewMigration: MockBrewMigrationService()
-        )
+        let store = makeStore(service: mockService)
         store.checkForUpdates()
         try await Task.sleep(for: .milliseconds(100))
 
@@ -149,12 +153,196 @@ struct UpdateStoreTests {
 
     @Test("dismiss update modal resets state")
     func dismissModal() {
-        let store = UpdateStore(
-            service: MockUpdateService(),
-            brewMigration: MockBrewMigrationService()
+        let store = makeStore()
+        store.updateState = .available(
+            version: "9.9.9",
+            downloadURL: URL(string: "https://example.com")!,
+            signature: nil,
+            expectedLength: nil
         )
-        store.updateState = .available(version: "9.9.9", downloadURL: URL(string: "https://example.com")!)
         store.dismissUpdateModal()
         #expect(store.updateState == .idle)
+    }
+
+    // MARK: - Signature Verification
+
+    @Test("verifyDownloadedUpdate accepts a valid signature")
+    func verifyAcceptsValidSignature() {
+        let dmgURL = writeTempDMG(bytes: 32)
+        defer { try? FileManager.default.removeItem(at: dmgURL) }
+
+        let verifier = MockSignatureVerifier()
+        verifier.verifyResult = true
+        let store = makeStore(signatureVerifier: verifier)
+
+        let error = store.verifyDownloadedUpdate(
+            at: dmgURL,
+            signature: "dummy-signature",
+            expectedLength: 32
+        )
+        #expect(error == nil)
+        #expect(verifier.verifyCallCount == 1)
+        #expect(verifier.lastSignature == "dummy-signature")
+        #expect(verifier.lastPublicKey == "stub-public-key")
+    }
+
+    @Test("verifyDownloadedUpdate rejects when signature is nil")
+    func verifyRejectsNilSignature() {
+        let dmgURL = writeTempDMG()
+        defer { try? FileManager.default.removeItem(at: dmgURL) }
+
+        let verifier = MockSignatureVerifier()
+        let store = makeStore(signatureVerifier: verifier)
+
+        let error = store.verifyDownloadedUpdate(
+            at: dmgURL,
+            signature: nil,
+            expectedLength: nil
+        )
+        #expect(error != nil)
+        #expect(verifier.verifyCallCount == 0)
+    }
+
+    @Test("verifyDownloadedUpdate rejects when signature is empty string")
+    func verifyRejectsEmptySignature() {
+        let dmgURL = writeTempDMG()
+        defer { try? FileManager.default.removeItem(at: dmgURL) }
+
+        let verifier = MockSignatureVerifier()
+        let store = makeStore(signatureVerifier: verifier)
+
+        let error = store.verifyDownloadedUpdate(
+            at: dmgURL,
+            signature: "",
+            expectedLength: nil
+        )
+        #expect(error != nil)
+        #expect(verifier.verifyCallCount == 0)
+    }
+
+    @Test("verifyDownloadedUpdate rejects when verifier returns false")
+    func verifyRejectsInvalidSignature() {
+        let dmgURL = writeTempDMG()
+        defer { try? FileManager.default.removeItem(at: dmgURL) }
+
+        let verifier = MockSignatureVerifier()
+        verifier.verifyResult = false
+        let store = makeStore(signatureVerifier: verifier)
+
+        let error = store.verifyDownloadedUpdate(
+            at: dmgURL,
+            signature: "tampered-signature",
+            expectedLength: nil
+        )
+        #expect(error != nil)
+        #expect(verifier.verifyCallCount == 1)
+    }
+
+    @Test("verifyDownloadedUpdate rejects when public key is unavailable")
+    func verifyRejectsMissingPublicKey() {
+        let dmgURL = writeTempDMG()
+        defer { try? FileManager.default.removeItem(at: dmgURL) }
+
+        let verifier = MockSignatureVerifier()
+        let store = makeStore(signatureVerifier: verifier, publicKey: nil)
+
+        let error = store.verifyDownloadedUpdate(
+            at: dmgURL,
+            signature: "dummy-signature",
+            expectedLength: nil
+        )
+        #expect(error != nil)
+        #expect(verifier.verifyCallCount == 0)
+    }
+
+    @Test("verifyDownloadedUpdate rejects when file size does not match expected length")
+    func verifyRejectsSizeMismatch() {
+        let dmgURL = writeTempDMG(bytes: 32)
+        defer { try? FileManager.default.removeItem(at: dmgURL) }
+
+        let verifier = MockSignatureVerifier()
+        verifier.verifyResult = true
+        let store = makeStore(signatureVerifier: verifier)
+
+        let error = store.verifyDownloadedUpdate(
+            at: dmgURL,
+            signature: "dummy-signature",
+            expectedLength: 999_999
+        )
+        #expect(error != nil)
+        #expect(verifier.verifyCallCount == 0)
+    }
+
+    @Test("verifyDownloadedUpdate treats expectedLength=0 as unknown (skips size check)")
+    func verifySkipsSizeCheckWhenZero() {
+        let dmgURL = writeTempDMG(bytes: 32)
+        defer { try? FileManager.default.removeItem(at: dmgURL) }
+
+        let verifier = MockSignatureVerifier()
+        verifier.verifyResult = true
+        let store = makeStore(signatureVerifier: verifier)
+
+        let error = store.verifyDownloadedUpdate(
+            at: dmgURL,
+            signature: "dummy-signature",
+            expectedLength: 0
+        )
+        #expect(error == nil)
+        #expect(verifier.verifyCallCount == 1)
+    }
+
+    @Test("verifyDownloadedUpdate treats expectedLength=nil as unknown (skips size check)")
+    func verifySkipsSizeCheckWhenNil() {
+        let dmgURL = writeTempDMG(bytes: 32)
+        defer { try? FileManager.default.removeItem(at: dmgURL) }
+
+        let verifier = MockSignatureVerifier()
+        verifier.verifyResult = true
+        let store = makeStore(signatureVerifier: verifier)
+
+        let error = store.verifyDownloadedUpdate(
+            at: dmgURL,
+            signature: "dummy-signature",
+            expectedLength: nil
+        )
+        #expect(error == nil)
+        #expect(verifier.verifyCallCount == 1)
+    }
+
+    @Test("installUpdate transitions to error state when signature is missing")
+    func installUpdateRejectsMissingSignature() {
+        let dmgURL = writeTempDMG()
+        defer { try? FileManager.default.removeItem(at: dmgURL) }
+
+        let verifier = MockSignatureVerifier()
+        let store = makeStore(signatureVerifier: verifier)
+        store.updateState = .downloaded(fileURL: dmgURL, signature: nil, expectedLength: nil)
+        store.installUpdate()
+
+        if case .error = store.updateState {
+            // OK, fail-closed
+        } else {
+            Issue.record("Expected .error state, got \(store.updateState)")
+        }
+        #expect(verifier.verifyCallCount == 0)
+    }
+
+    @Test("installUpdate transitions to error state when verifier rejects")
+    func installUpdateRejectsInvalidSignature() {
+        let dmgURL = writeTempDMG()
+        defer { try? FileManager.default.removeItem(at: dmgURL) }
+
+        let verifier = MockSignatureVerifier()
+        verifier.verifyResult = false
+        let store = makeStore(signatureVerifier: verifier)
+        store.updateState = .downloaded(fileURL: dmgURL, signature: "tampered", expectedLength: nil)
+        store.installUpdate()
+
+        if case .error = store.updateState {
+            // OK, fail-closed
+        } else {
+            Issue.record("Expected .error state, got \(store.updateState)")
+        }
+        #expect(verifier.verifyCallCount == 1)
     }
 }


### PR DESCRIPTION
## Summary

Closes #127. The Sparkle EdDSA signature has been generated for every release since v4.6.3-beta.1 but it was never verified on the client side. Any DMG served from the release URL (tampered binary, compromised maintainer account, leaked release token, etc.) would be installed as root with Gatekeeper quarantine stripped.

This PR adds the missing verification step.

## Changes

- `AppcastXMLParser` now reads `sparkle:edSignature` and `length` attributes from the `<enclosure>` element. Per-item state is reset cleanly so a signature does not leak from one item to the next.
- New `SignatureVerifier` service based on `CryptoKit.Curve25519.Signing.PublicKey.isValidSignature(_:for:)`, with a matching `SignatureVerifierProtocol` for dependency injection.
- `UpdateState.available` and `UpdateState.downloaded` now carry the signature and expected length so the store can verify exactly what it downloaded.
- `UpdateStore.installUpdate()` verifies length + signature before giving the DMG to the privileged installer and transitions to `.error` on any mismatch. Verification is fail-closed (nil or empty signature rejects; unknown public key rejects; bad base64 rejects).
- `length="0"` in older appcast entries (a legacy quirk of the release workflow) is treated as "unknown" and skips the size check. Signature verification is always required.
- Public key shipped as `TokenEaterApp/Resources/SparklePublicKey.txt`, embedded automatically by xcodegen.
- Localized error strings (en + fr) for each failure mode.
- Added `SignatureVerifierTests`, `AppcastXMLParserTests`, and new `UpdateStoreTests` covering the full verification matrix. `MockSignatureVerifier` added for DI in tests.

## Test plan

- [x] `xcodebuild test` - full test suite passes (all 240 tests, including 8 new signature tests and 9 new parser tests)
- [x] Release build succeeds with Xcode 16.4 / Swift 6.1.2
- [x] End-to-end sanity: signed a random payload with `sign_update` (Sparkle 2.9.0) using the private key currently in the Keychain/GitHub secret, verified that `Curve25519.Signing.PublicKey(rawRepresentation: ...)` on the bundled public key returns `true` for that signature
- [ ] Manual: tamper `docs/appcast.xml` locally with a garbage `sparkle:edSignature`, launch, trigger update check, confirm install is aborted with a localized error message
- [ ] Manual: legitimate release passes verification and installs normally

Credit to @jescoti for the security report and proposed fix.