### PR TITLE
feat: individual pacing pins and optional Sonnet metric

### DIFF
--- a/Shared/Helpers/MenuBarRenderer.swift
+++ b/Shared/Helpers/MenuBarRenderer.swift
@@ -1,14 +1,21 @@
 import AppKit
 
 enum MenuBarRenderer {
-    // FIX 1: Equatable RenderData with pure data (no closures)
     struct RenderData: Equatable {
         let pinnedMetrics: Set<MetricID>
+        let displaySonnet: Bool
         let fiveHourPct: Int
         let sevenDayPct: Int
         let sonnetPct: Int
-        let pacingDelta: Int
-        let pacingZone: PacingZone
+        let weeklyPacingDelta: Int
+        let weeklyPacingZone: PacingZone
+        let hasWeeklyPacing: Bool
+        let sonnetPacingDelta: Int
+        let sonnetPacingZone: PacingZone
+        let hasSonnetPacing: Bool
+        let sessionPacingDelta: Int
+        let sessionPacingZone: PacingZone
+        let hasSessionPacing: Bool
         let pacingDisplayMode: PacingDisplayMode
         let hasConfig: Bool
         let hasError: Bool
@@ -17,12 +24,8 @@ enum MenuBarRenderer {
         let menuBarMonochrome: Bool
         let fiveHourReset: String
         let showSessionReset: Bool
-        let sessionPacingDelta: Int
-        let sessionPacingZone: PacingZone
-        let hasSessionPacing: Bool
     }
 
-    // FIX 1: Static cache — returns same NSImage when data unchanged
     private static var cachedImage: NSImage?
     private static var cachedData: RenderData?
 
@@ -43,7 +46,7 @@ enum MenuBarRenderer {
         return image
     }
 
-    // MARK: - Color helpers (replaces closures)
+    // MARK: - Color helpers
 
     private static func colorForPct(_ pct: Int, data: RenderData) -> NSColor {
         if data.menuBarMonochrome { return .labelColor }
@@ -70,62 +73,51 @@ enum MenuBarRenderer {
             .foregroundColor: NSColor.tertiaryLabelColor,
         ]
 
-        let ordered: [MetricID] = [.fiveHour, .sessionPacing, .sevenDay, .sonnet, .pacing].filter {
+        let ordered: [MetricID] = [
+            .fiveHour, .sessionPacing, .sevenDay, .weeklyPacing, .sonnet, .sonnetPacing
+        ].filter {
             guard data.pinnedMetrics.contains($0) else { return false }
-            if $0 == .sessionPacing { return data.hasSessionPacing }
-            return true
+            if !data.displaySonnet && ($0 == .sonnet || $0 == .sonnetPacing) { return false }
+            switch $0 {
+            case .sessionPacing: return data.hasSessionPacing
+            case .weeklyPacing: return data.hasWeeklyPacing
+            case .sonnetPacing: return data.hasSonnetPacing
+            default: return true
+            }
         }
         for (i, metric) in ordered.enumerated() {
             if i > 0 {
                 str.append(NSAttributedString(string: "  ", attributes: sepAttrs))
             }
-            if metric == .sessionPacing {
-                let dotColor = colorForZone(data.sessionPacingZone, data: data)
-                    let dotAttrs: [NSAttributedString.Key: Any] = [
-                        .font: NSFont.systemFont(ofSize: 11, weight: .bold),
-                        .foregroundColor: dotColor,
-                    ]
-                    let deltaAttrs: [NSAttributedString.Key: Any] = [
-                        .font: NSFont.monospacedDigitSystemFont(ofSize: 10, weight: .bold),
-                        .foregroundColor: dotColor,
-                    ]
-                    let sign = data.sessionPacingDelta >= 0 ? "+" : ""
-                    switch data.pacingDisplayMode {
-                    case .dot:
-                        str.append(NSAttributedString(string: "\u{25CF}", attributes: dotAttrs))
-                    case .dotDelta:
-                        str.append(NSAttributedString(string: "\u{25CF}", attributes: dotAttrs))
-                        str.append(NSAttributedString(string: " \(sign)\(data.sessionPacingDelta)%", attributes: deltaAttrs))
-                    case .delta:
-                        str.append(NSAttributedString(string: "\(sign)\(data.sessionPacingDelta)%", attributes: deltaAttrs))
-                    }
-            } else if metric == .pacing {
-                let dotColor = colorForZone(data.pacingZone, data: data)
-                let dotAttrs: [NSAttributedString.Key: Any] = [
-                    .font: NSFont.systemFont(ofSize: 11, weight: .bold),
-                    .foregroundColor: dotColor,
-                ]
-                let deltaAttrs: [NSAttributedString.Key: Any] = [
-                    .font: NSFont.monospacedDigitSystemFont(ofSize: 10, weight: .bold),
-                    .foregroundColor: dotColor,
-                ]
-                let sign = data.pacingDelta >= 0 ? "+" : ""
-                switch data.pacingDisplayMode {
-                case .dot:
-                    str.append(NSAttributedString(string: "\u{25CF}", attributes: dotAttrs))
-                case .dotDelta:
-                    str.append(NSAttributedString(string: "\u{25CF}", attributes: dotAttrs))
-                    str.append(NSAttributedString(string: " \(sign)\(data.pacingDelta)%", attributes: deltaAttrs))
-                case .delta:
-                    str.append(NSAttributedString(string: "\(sign)\(data.pacingDelta)%", attributes: deltaAttrs))
-                }
-            } else {
+            switch metric {
+            case .sessionPacing:
+                appendPacing(
+                    to: str,
+                    delta: data.sessionPacingDelta,
+                    zone: data.sessionPacingZone,
+                    data: data
+                )
+            case .weeklyPacing:
+                appendPacing(
+                    to: str,
+                    delta: data.weeklyPacingDelta,
+                    zone: data.weeklyPacingZone,
+                    data: data
+                )
+            case .sonnetPacing:
+                appendPacing(
+                    to: str,
+                    delta: data.sonnetPacingDelta,
+                    zone: data.sonnetPacingZone,
+                    data: data
+                )
+            case .fiveHour, .sevenDay, .sonnet:
                 let value: Int
                 switch metric {
                 case .fiveHour: value = data.fiveHourPct
                 case .sevenDay: value = data.sevenDayPct
                 case .sonnet: value = data.sonnetPct
-                case .pacing, .sessionPacing: value = 0
+                default: value = 0
                 }
                 if metric == .fiveHour && data.showSessionReset && !data.fiveHourReset.isEmpty {
                     let resetLabelAttrs: [NSAttributedString.Key: Any] = [
@@ -149,7 +141,6 @@ enum MenuBarRenderer {
             }
         }
 
-        // FIX 4: Modern NSImage API (replaces deprecated lockFocus/unlockFocus)
         let size = str.size()
         let imgSize = NSSize(width: ceil(size.width) + 2, height: height)
         let img = NSImage(size: imgSize, flipped: false) { _ in
@@ -160,24 +151,34 @@ enum MenuBarRenderer {
         return img
     }
 
-    private static func renderText(_ text: String, color: NSColor) -> NSImage {
-        let height: CGFloat = 22
-        let attrs: [NSAttributedString.Key: Any] = [
-            .font: NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .medium),
-            .foregroundColor: color,
+    private static func appendPacing(
+        to str: NSMutableAttributedString,
+        delta: Int,
+        zone: PacingZone,
+        data: RenderData
+    ) {
+        let dotColor = colorForZone(zone, data: data)
+        let dotAttrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 11, weight: .bold),
+            .foregroundColor: dotColor,
         ]
-        let str = NSAttributedString(string: text, attributes: attrs)
-        let size = str.size()
-        let imgSize = NSSize(width: ceil(size.width) + 2, height: height)
-        let img = NSImage(size: imgSize, flipped: false) { _ in
-            str.draw(at: NSPoint(x: 1, y: (height - size.height) / 2))
-            return true
+        let deltaAttrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.monospacedDigitSystemFont(ofSize: 10, weight: .bold),
+            .foregroundColor: dotColor,
+        ]
+        let sign = delta >= 0 ? "+" : ""
+        switch data.pacingDisplayMode {
+        case .dot:
+            str.append(NSAttributedString(string: "\u{25CF}", attributes: dotAttrs))
+        case .dotDelta:
+            str.append(NSAttributedString(string: "\u{25CF}", attributes: dotAttrs))
+            str.append(NSAttributedString(string: " \(sign)\(delta)%", attributes: deltaAttrs))
+        case .delta:
+            str.append(NSAttributedString(string: "\(sign)\(delta)%", attributes: deltaAttrs))
         }
-        img.isTemplate = false
-        return img
     }
 
-    /// App logo silhouette for menu bar (template — macOS renders white/black automatically).
+    /// App logo silhouette for menu bar (template - macOS renders white/black automatically).
     private static func renderLogoTemplate() -> NSImage {
         let s: CGFloat = 16
         let height: CGFloat = 22
@@ -192,7 +193,6 @@ enum MenuBarRenderer {
 
             NSColor.black.setFill()
 
-            // L-shaped main body
             let lPath = CGMutablePath()
             let r: CGFloat = 32
             lPath.addRoundedRect(in: CGRect(x: 0, y: 0, width: 300, height: 122), cornerWidth: r, cornerHeight: r)
@@ -200,7 +200,6 @@ enum MenuBarRenderer {
             ctx.addPath(lPath)
             ctx.fillPath(using: .winding)
 
-            // Two horizontal bars
             let bar1 = CGRect(x: 142, y: 142, width: 158, height: 70)
             let bar2 = CGRect(x: 142, y: 230, width: 158, height: 70)
             let barR: CGFloat = 24

--- a/Shared/Models/MetricModels.swift
+++ b/Shared/Models/MetricModels.swift
@@ -4,16 +4,18 @@ enum MetricID: String, CaseIterable {
     case fiveHour = "fiveHour"
     case sevenDay = "sevenDay"
     case sonnet = "sonnet"
-    case pacing = "pacing"
     case sessionPacing = "sessionPacing"
+    case weeklyPacing = "weeklyPacing"
+    case sonnetPacing = "sonnetPacing"
 
     var label: String {
         switch self {
         case .fiveHour: return String(localized: "metric.session")
         case .sevenDay: return String(localized: "metric.weekly")
         case .sonnet: return String(localized: "metric.sonnet")
-        case .pacing: return String(localized: "pacing.label")
         case .sessionPacing: return String(localized: "pacing.session.label")
+        case .weeklyPacing: return String(localized: "pacing.weekly.label")
+        case .sonnetPacing: return String(localized: "pacing.sonnet.label")
         }
     }
 
@@ -22,8 +24,9 @@ enum MetricID: String, CaseIterable {
         case .fiveHour: return "5h"
         case .sevenDay: return "7d"
         case .sonnet: return "S"
-        case .pacing: return "P"
         case .sessionPacing: return "5hP"
+        case .weeklyPacing: return "7dP"
+        case .sonnetPacing: return "SP"
         }
     }
 }

--- a/Shared/Stores/SettingsStore.swift
+++ b/Shared/Stores/SettingsStore.swift
@@ -16,6 +16,16 @@ final class SettingsStore: ObservableObject {
     @Published var showSessionReset: Bool {
         didSet { UserDefaults.standard.set(showSessionReset, forKey: "showSessionReset") }
     }
+    @Published var displaySonnet: Bool {
+        didSet {
+            UserDefaults.standard.set(displaySonnet, forKey: "displaySonnet")
+            if !displaySonnet {
+                // Drop any sonnet-related pins so the menu bar does not keep
+                // a stale reference to a hidden metric.
+                pinnedMetrics.subtract([.sonnet, .sonnetPacing])
+            }
+        }
+    }
     @Published var hasCompletedOnboarding: Bool {
         didSet { UserDefaults.standard.set(hasCompletedOnboarding, forKey: "hasCompletedOnboarding") }
     }
@@ -116,11 +126,19 @@ final class SettingsStore: ObservableObject {
         }
     }
 
-    var showPacing: Bool {
-        get { pinnedMetrics.contains(.pacing) }
+    var showWeeklyPacing: Bool {
+        get { pinnedMetrics.contains(.weeklyPacing) }
         set {
-            if newValue { pinnedMetrics.insert(.pacing) }
-            else if pinnedMetrics.count > 1 { pinnedMetrics.remove(.pacing) }
+            if newValue { pinnedMetrics.insert(.weeklyPacing) }
+            else if pinnedMetrics.count > 1 { pinnedMetrics.remove(.weeklyPacing) }
+        }
+    }
+
+    var showSonnetPacing: Bool {
+        get { pinnedMetrics.contains(.sonnetPacing) }
+        set {
+            if newValue { pinnedMetrics.insert(.sonnetPacing) }
+            else if pinnedMetrics.count > 1 { pinnedMetrics.remove(.sonnetPacing) }
         }
     }
 
@@ -172,10 +190,23 @@ final class SettingsStore: ObservableObject {
             rawValue: UserDefaults.standard.string(forKey: "pacingDisplayMode") ?? "dotDelta"
         ) ?? .dotDelta
         self.showSessionReset = UserDefaults.standard.bool(forKey: "showSessionReset")
+        let legacyPinned: Set<MetricID>
         if let saved = UserDefaults.standard.stringArray(forKey: "pinnedMetrics") {
-            self.pinnedMetrics = Set(saved.compactMap { MetricID(rawValue: $0) })
+            // Migrate legacy "pacing" (covered weekly only) to the explicit weeklyPacing id.
+            let normalized = saved.map { $0 == "pacing" ? "weeklyPacing" : $0 }
+            legacyPinned = Set(normalized.compactMap { MetricID(rawValue: $0) })
         } else {
-            self.pinnedMetrics = [.fiveHour, .sevenDay]
+            legacyPinned = [.fiveHour, .sevenDay]
+        }
+        self.pinnedMetrics = legacyPinned
+
+        // displaySonnet defaults to false for new installs. Legacy users who
+        // had .sonnet pinned keep it on by default so their setup does not
+        // silently lose the ring after upgrade.
+        if UserDefaults.standard.object(forKey: "displaySonnet") != nil {
+            self.displaySonnet = UserDefaults.standard.bool(forKey: "displaySonnet")
+        } else {
+            self.displaySonnet = legacyPinned.contains(.sonnet)
         }
     }
 

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -48,6 +48,9 @@
 "settings.tab.display" = "Display";
 "settings.session.reset" = "Show reset countdown";
 "pacing.session.label" = "Session pacing";
+"pacing.weekly.label" = "Weekly pacing";
+"pacing.sonnet.label" = "Sonnet pacing";
+"settings.display.sonnet" = "Display Sonnet";
 "settings.metrics.pinned" = "Pinned metrics";
 "settings.metrics.pinned.footer" = "Choose which metrics appear in the menu bar.";
 "settings.pacing.display" = "Pacing display";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -48,6 +48,9 @@
 "settings.tab.display" = "Affichage";
 "settings.session.reset" = "Afficher le compte à rebours";
 "pacing.session.label" = "Rythme session";
+"pacing.weekly.label" = "Rythme hebdomadaire";
+"pacing.sonnet.label" = "Rythme Sonnet";
+"settings.display.sonnet" = "Afficher Sonnet";
 "settings.metrics.pinned" = "Métriques épinglées";
 "settings.metrics.pinned.footer" = "Choisissez les métriques affichées dans la barre de menu.";
 "settings.pacing.display" = "Affichage rythme";

--- a/TokenEaterApp/DashboardView.swift
+++ b/TokenEaterApp/DashboardView.swift
@@ -106,15 +106,28 @@ struct DashboardView: View {
                 profileCard
             }
 
-            // Pacing cards
+            // Pacing cards - the status catchphrase only renders on the weekly
+            // card to avoid three near-identical messages stacking up.
             if let pacing = usageStore.fiveHourPacing {
-                pacingCard(pacing: pacing, label: PacingBucket.fiveHour.metricID.label)
+                pacingCard(
+                    pacing: pacing,
+                    label: PacingBucket.fiveHour.metricID.label,
+                    showMessage: false
+                )
             }
             if let pacing = usageStore.pacingResult {
-                pacingCard(pacing: pacing, label: PacingBucket.sevenDay.metricID.label)
+                pacingCard(
+                    pacing: pacing,
+                    label: PacingBucket.sevenDay.metricID.label,
+                    showMessage: true
+                )
             }
-            if let pacing = usageStore.sonnetPacing {
-                pacingCard(pacing: pacing, label: PacingBucket.sonnet.metricID.label)
+            if settingsStore.displaySonnet, let pacing = usageStore.sonnetPacing {
+                pacingCard(
+                    pacing: pacing,
+                    label: PacingBucket.sonnet.metricID.label,
+                    showMessage: false
+                )
             }
 
             Spacer()
@@ -277,7 +290,7 @@ struct DashboardView: View {
 
     // MARK: - Pacing Card
 
-    private func pacingCard(pacing: PacingResult, label: String) -> some View {
+    private func pacingCard(pacing: PacingResult, label: String, showMessage: Bool) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
                 Text("\(String(localized: "pacing.label")) · \(label)")
@@ -300,9 +313,11 @@ struct DashboardView: View {
                 gradient: themeStore.current.pacingGradient(for: pacing.zone, startPoint: .leading, endPoint: .trailing)
             )
 
-            Text(pacing.message)
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(themeStore.current.pacingColor(for: pacing.zone).opacity(0.8))
+            if showMessage {
+                Text(pacing.message)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(themeStore.current.pacingColor(for: pacing.zone).opacity(0.8))
+            }
 
             if let resetDate = pacing.resetDate {
                 let diff = resetDate.timeIntervalSinceNow

--- a/TokenEaterApp/DisplaySectionView.swift
+++ b/TokenEaterApp/DisplaySectionView.swift
@@ -4,22 +4,24 @@ struct DisplaySectionView: View {
     @EnvironmentObject private var settingsStore: SettingsStore
     @EnvironmentObject private var themeStore: ThemeStore
 
-    // Local @State bindings — stable across body re-evaluations.
+    // Local @State bindings - stable across body re-evaluations.
     // Binding to computed properties via $store.computedProp creates
     // unstable LocationProjections that the AttributeGraph can never
     // memoize, causing an infinite re-evaluation loop in Release builds.
     @State private var showFiveHour: Bool
     @State private var showSevenDay: Bool
     @State private var showSonnet: Bool
-    @State private var showPacing: Bool
     @State private var showSessionPacing: Bool
+    @State private var showWeeklyPacing: Bool
+    @State private var showSonnetPacing: Bool
 
     init(initialMetrics: Set<MetricID>) {
         _showFiveHour = State(initialValue: initialMetrics.contains(.fiveHour))
         _showSevenDay = State(initialValue: initialMetrics.contains(.sevenDay))
         _showSonnet = State(initialValue: initialMetrics.contains(.sonnet))
-        _showPacing = State(initialValue: initialMetrics.contains(.pacing))
         _showSessionPacing = State(initialValue: initialMetrics.contains(.sessionPacing))
+        _showWeeklyPacing = State(initialValue: initialMetrics.contains(.weeklyPacing))
+        _showSonnetPacing = State(initialValue: initialMetrics.contains(.sonnetPacing))
     }
 
     var body: some View {
@@ -32,6 +34,7 @@ struct DisplaySectionView: View {
                     cardLabel(String(localized: "settings.menubar.title"))
                     darkToggle(String(localized: "settings.menubar.toggle"), isOn: $settingsStore.showMenuBar)
                     darkToggle(String(localized: "settings.theme.monochrome"), isOn: $themeStore.menuBarMonochrome)
+                    darkToggle(String(localized: "settings.display.sonnet"), isOn: $settingsStore.displaySonnet)
                 }
             }
 
@@ -44,10 +47,15 @@ struct DisplaySectionView: View {
                         darkToggle(String(localized: "settings.session.reset"), isOn: $settingsStore.showSessionReset)
                     }
                     darkToggle(String(localized: "metric.weekly"), isOn: $showSevenDay)
-                    darkToggle(String(localized: "metric.sonnet"), isOn: $showSonnet)
+                    if settingsStore.displaySonnet {
+                        darkToggle(String(localized: "metric.sonnet"), isOn: $showSonnet)
+                    }
                     darkToggle(String(localized: "pacing.session.label"), isOn: $showSessionPacing)
-                    darkToggle(String(localized: "pacing.label"), isOn: $showPacing)
-                    if showPacing || showSessionPacing {
+                    darkToggle(String(localized: "pacing.weekly.label"), isOn: $showWeeklyPacing)
+                    if settingsStore.displaySonnet {
+                        darkToggle(String(localized: "pacing.sonnet.label"), isOn: $showSonnetPacing)
+                    }
+                    if showSessionPacing || showWeeklyPacing || (settingsStore.displaySonnet && showSonnetPacing) {
                         PacingDisplayPicker(selection: $settingsStore.pacingDisplayMode)
                             .padding(.leading, 8)
                     }
@@ -66,9 +74,14 @@ struct DisplaySectionView: View {
                 syncMetric(.sessionPacing, on: new, revert: { showSessionPacing = true })
             }
         }
-        .onChange(of: showPacing) { _, new in
+        .onChange(of: showWeeklyPacing) { _, new in
             withAnimation(.easeInOut(duration: 0.2)) {
-                syncMetric(.pacing, on: new, revert: { showPacing = true })
+                syncMetric(.weeklyPacing, on: new, revert: { showWeeklyPacing = true })
+            }
+        }
+        .onChange(of: showSonnetPacing) { _, new in
+            withAnimation(.easeInOut(duration: 0.2)) {
+                syncMetric(.sonnetPacing, on: new, revert: { showSonnetPacing = true })
             }
         }
         // Sync: store -> local toggles (for external changes, e.g. from MenuBar popover)
@@ -79,8 +92,11 @@ struct DisplaySectionView: View {
             if showSessionPacing != metrics.contains(.sessionPacing) {
                 withAnimation(.easeInOut(duration: 0.2)) { showSessionPacing = metrics.contains(.sessionPacing) }
             }
-            if showPacing != metrics.contains(.pacing) {
-                withAnimation(.easeInOut(duration: 0.2)) { showPacing = metrics.contains(.pacing) }
+            if showWeeklyPacing != metrics.contains(.weeklyPacing) {
+                withAnimation(.easeInOut(duration: 0.2)) { showWeeklyPacing = metrics.contains(.weeklyPacing) }
+            }
+            if showSonnetPacing != metrics.contains(.sonnetPacing) {
+                withAnimation(.easeInOut(duration: 0.2)) { showSonnetPacing = metrics.contains(.sonnetPacing) }
             }
         }
     }

--- a/TokenEaterApp/MenuBarView.swift
+++ b/TokenEaterApp/MenuBarView.swift
@@ -42,34 +42,47 @@ struct MenuBarPopoverView: View {
                     .padding(.bottom, 8)
             }
 
-            // Mini hero ring — Session (fiveHour)
-            heroRing
-                .padding(.horizontal, 16)
-                .padding(.bottom, 20)
+            // Ring layout: hero + satellites when Sonnet is on, otherwise
+            // two equal rings side by side.
+            if settingsStore.displaySonnet {
+                heroRing
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 20)
 
-            // Satellite rings — Weekly + Sonnet
-            satelliteRings
-                .padding(.horizontal, 24)
-                .padding(.bottom, 14)
-
-            // Session pacing
-            if let pacing = usageStore.fiveHourPacing {
-                VStack(alignment: .leading, spacing: 6) {
-                    pacingPinHeader(metric: .sessionPacing, label: String(localized: "pacing.session.label"), zone: pacing.zone)
-                    pacingRow(pacing: pacing, label: PacingBucket.fiveHour.metricID.label)
-                }
-                .padding(.horizontal, 16)
+                satelliteRings
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 14)
+            } else {
+                twoEqualRings
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 14)
             }
 
-            // Weekly + Sonnet pacing
-            if usageStore.pacingResult != nil || usageStore.sonnetPacing != nil {
-                VStack(alignment: .leading, spacing: 6) {
-                    pacingPinHeader(metric: .pacing, label: String(localized: "pacing.label"), zone: usageStore.pacingResult?.zone ?? .onTrack)
-                    if let pacing = usageStore.pacingResult {
-                        pacingRow(pacing: pacing, label: PacingBucket.sevenDay.metricID.label)
+            // Pacing rows - compact stack, each row owns its own pin.
+            if usageStore.fiveHourPacing != nil
+                || usageStore.pacingResult != nil
+                || (settingsStore.displaySonnet && usageStore.sonnetPacing != nil) {
+                VStack(spacing: 12) {
+                    if let pacing = usageStore.fiveHourPacing {
+                        pacingRow(
+                            metric: .sessionPacing,
+                            label: String(localized: "pacing.session.label"),
+                            pacing: pacing
+                        )
                     }
-                    if let pacing = usageStore.sonnetPacing {
-                        pacingRow(pacing: pacing, label: PacingBucket.sonnet.metricID.label)
+                    if let pacing = usageStore.pacingResult {
+                        pacingRow(
+                            metric: .weeklyPacing,
+                            label: String(localized: "pacing.weekly.label"),
+                            pacing: pacing
+                        )
+                    }
+                    if settingsStore.displaySonnet, let pacing = usageStore.sonnetPacing {
+                        pacingRow(
+                            metric: .sonnetPacing,
+                            label: String(localized: "pacing.sonnet.label"),
+                            pacing: pacing
+                        )
                     }
                 }
                 .padding(.horizontal, 16)
@@ -206,6 +219,78 @@ struct MenuBarPopoverView: View {
         }
     }
 
+    // MARK: - Two Equal Rings (Session + Weekly, when Sonnet is hidden)
+
+    private var twoEqualRings: some View {
+        HStack(spacing: 40) {
+            equalRingItem(
+                id: .fiveHour,
+                label: String(localized: "metric.session"),
+                pct: usageStore.fiveHourPct,
+                showSessionReset: settingsStore.showSessionReset
+            )
+            equalRingItem(
+                id: .sevenDay,
+                label: String(localized: "metric.weekly"),
+                pct: usageStore.sevenDayPct,
+                showSessionReset: false
+            )
+        }
+    }
+
+    private func equalRingItem(
+        id: MetricID,
+        label: String,
+        pct: Int,
+        showSessionReset: Bool
+    ) -> some View {
+        let isPinned = settingsStore.pinnedMetrics.contains(id)
+        let showReset = showSessionReset && !usageStore.fiveHourReset.isEmpty
+        return Button {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                settingsStore.toggleMetric(id)
+            }
+        } label: {
+            VStack(spacing: 10) {
+                ZStack {
+                    RingGauge(
+                        percentage: pct,
+                        gradient: gradientForPct(pct),
+                        size: 88,
+                        glowColor: colorForPct(pct),
+                        glowRadius: 5
+                    )
+
+                    VStack(spacing: 2) {
+                        GlowText(
+                            "\(pct)%",
+                            font: .system(size: 20, weight: .black, design: .rounded),
+                            color: colorForPct(pct),
+                            glowRadius: 3
+                        )
+                        Text(label)
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.5))
+                    }
+                }
+
+                HStack(spacing: 3) {
+                    Image(systemName: isPinned ? "pin.fill" : "pin")
+                        .font(.system(size: 7))
+                        .foregroundStyle(isPinned ? colorForPct(pct) : .white.opacity(0.2))
+                        .rotationEffect(.degrees(isPinned ? 0 : 45))
+                    if showReset {
+                        Text(String(format: String(localized: "metric.reset"), usageStore.fiveHourReset))
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.25))
+                    }
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .help(isPinned ? Text(String(localized: "menubar.hide")) : Text(String(localized: "menubar.show")))
+    }
+
     private func satelliteRingItem(id: MetricID, label: String, pct: Int) -> some View {
         let isPinned = settingsStore.pinnedMetrics.contains(id)
         return Button {
@@ -338,51 +423,46 @@ struct MenuBarPopoverView: View {
         .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 
-    private func pacingPinHeader(metric: MetricID, label: String, zone: PacingZone) -> some View {
+    private func pacingRow(metric: MetricID, label: String, pacing: PacingResult) -> some View {
         let isPinned = settingsStore.pinnedMetrics.contains(metric)
-        return Button {
-            withAnimation(.easeInOut(duration: 0.15)) {
-                settingsStore.toggleMetric(metric)
-            }
-        } label: {
-            HStack(spacing: 6) {
-                Image(systemName: isPinned ? "pin.fill" : "pin")
-                    .font(.system(size: 7))
-                    .foregroundStyle(isPinned ? colorForZone(zone) : .white.opacity(0.2))
-                    .rotationEffect(.degrees(isPinned ? 0 : 45))
-                Text(label)
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.5))
-                Spacer()
-            }
-        }
-        .buttonStyle(.plain)
-        .help(isPinned ? Text(String(localized: "menubar.hide")) : Text(String(localized: "menubar.show")))
-    }
+        let sign = pacing.delta >= 0 ? "+" : ""
+        return VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.white.opacity(0.4))
 
-    private func pacingRow(pacing: PacingResult, label: String) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 6) {
-                Text(label)
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.4))
-                Spacer()
-                let sign = pacing.delta >= 0 ? "+" : ""
+            HStack(spacing: 10) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        settingsStore.toggleMetric(metric)
+                    }
+                } label: {
+                    Image(systemName: isPinned ? "pin.fill" : "pin")
+                        .font(.system(size: 9))
+                        .foregroundStyle(isPinned ? colorForZone(pacing.zone) : .white.opacity(0.25))
+                        .rotationEffect(.degrees(isPinned ? 0 : 45))
+                        .frame(width: 12, height: 12)
+                }
+                .buttonStyle(.plain)
+                .help(isPinned ? Text(String(localized: "menubar.hide")) : Text(String(localized: "menubar.show")))
+
+                PacingBar(
+                    actual: pacing.actualUsage,
+                    expected: pacing.expectedUsage,
+                    zone: pacing.zone,
+                    gradient: gradientForZone(pacing.zone),
+                    compact: true
+                )
+                .frame(maxWidth: .infinity)
+
                 GlowText(
                     "\(sign)\(Int(pacing.delta))%",
-                    font: .system(size: 13, weight: .black, design: .rounded),
+                    font: .system(size: 12, weight: .black, design: .rounded),
                     color: colorForZone(pacing.zone),
-                    glowRadius: 3
+                    glowRadius: 2
                 )
+                .frame(width: 48, alignment: .trailing)
             }
-
-            PacingBar(
-                actual: pacing.actualUsage,
-                expected: pacing.expectedUsage,
-                zone: pacing.zone,
-                gradient: gradientForZone(pacing.zone),
-                compact: true
-            )
         }
     }
 

--- a/TokenEaterApp/StatusBarController.swift
+++ b/TokenEaterApp/StatusBarController.swift
@@ -201,11 +201,19 @@ final class StatusBarController: NSObject {
     private func updateMenuBarIcon() {
         let image = MenuBarRenderer.render(MenuBarRenderer.RenderData(
             pinnedMetrics: settingsStore.pinnedMetrics,
+            displaySonnet: settingsStore.displaySonnet,
             fiveHourPct: usageStore.fiveHourPct,
             sevenDayPct: usageStore.sevenDayPct,
             sonnetPct: usageStore.sonnetPct,
-            pacingDelta: usageStore.pacingDelta,
-            pacingZone: usageStore.pacingZone,
+            weeklyPacingDelta: Int(usageStore.pacingResult?.delta ?? 0),
+            weeklyPacingZone: usageStore.pacingResult?.zone ?? .onTrack,
+            hasWeeklyPacing: usageStore.pacingResult != nil,
+            sonnetPacingDelta: Int(usageStore.sonnetPacing?.delta ?? 0),
+            sonnetPacingZone: usageStore.sonnetPacing?.zone ?? .onTrack,
+            hasSonnetPacing: usageStore.sonnetPacing != nil,
+            sessionPacingDelta: Int(usageStore.fiveHourPacing?.delta ?? 0),
+            sessionPacingZone: usageStore.fiveHourPacing?.zone ?? .onTrack,
+            hasSessionPacing: usageStore.fiveHourPacing != nil,
             pacingDisplayMode: settingsStore.pacingDisplayMode,
             hasConfig: usageStore.hasConfig,
             hasError: usageStore.hasError,
@@ -213,10 +221,7 @@ final class StatusBarController: NSObject {
             thresholds: themeStore.thresholds,
             menuBarMonochrome: themeStore.menuBarMonochrome,
             fiveHourReset: usageStore.fiveHourReset,
-            showSessionReset: settingsStore.showSessionReset,
-            sessionPacingDelta: Int(usageStore.fiveHourPacing?.delta ?? 0),
-            sessionPacingZone: usageStore.fiveHourPacing?.zone ?? .onTrack,
-            hasSessionPacing: usageStore.fiveHourPacing != nil
+            showSessionReset: settingsStore.showSessionReset
         ))
         statusItem.button?.image = image
     }

--- a/TokenEaterTests/SettingsStoreTests.swift
+++ b/TokenEaterTests/SettingsStoreTests.swift
@@ -86,17 +86,33 @@ struct SettingsStoreTests {
         #expect(store.pinnedMetrics.count == 1)
     }
 
-    @Test("toggleMetric works with .pacing")
-    func toggleMetricPacing() {
+    @Test("toggleMetric works with .weeklyPacing")
+    func toggleMetricWeeklyPacing() {
         let (store, _, _) = makeStore()
-        #expect(!store.pinnedMetrics.contains(.pacing))
+        #expect(!store.pinnedMetrics.contains(.weeklyPacing))
 
-        store.toggleMetric(.pacing)
-        #expect(store.pinnedMetrics.contains(.pacing))
+        store.toggleMetric(.weeklyPacing)
+        #expect(store.pinnedMetrics.contains(.weeklyPacing))
 
-        store.toggleMetric(.pacing)
-        // Still has other metrics, so pacing should be removed
-        #expect(!store.pinnedMetrics.contains(.pacing))
+        store.toggleMetric(.weeklyPacing)
+        // Still has other metrics, so weeklyPacing should be removed
+        #expect(!store.pinnedMetrics.contains(.weeklyPacing))
+    }
+
+    @Test("legacy 'pacing' pin migrates to weeklyPacing on load")
+    func legacyPacingMigrates() {
+        cleanDefaults()
+        defer { cleanDefaults() }
+        // Seed the legacy value after the cleanup so it survives SettingsStore init.
+        UserDefaults.standard.set(["fiveHour", "pacing"], forKey: "pinnedMetrics")
+
+        let store = SettingsStore(
+            notificationService: MockNotificationService(),
+            tokenProvider: MockTokenProvider()
+        )
+        #expect(store.pinnedMetrics.contains(.weeklyPacing))
+        #expect(store.pinnedMetrics.contains(.fiveHour))
+        #expect(!store.pinnedMetrics.contains(where: { $0.rawValue == "pacing" }))
     }
 
     // MARK: - Credentials delegation
@@ -161,11 +177,11 @@ struct SettingsStoreTests {
     func pinnedMetricsPersists() {
         let (store, _, _) = makeStore()
 
-        store.pinnedMetrics = [.sonnet, .pacing]
+        store.pinnedMetrics = [.sonnet, .weeklyPacing]
 
         let saved = UserDefaults.standard.stringArray(forKey: "pinnedMetrics") ?? []
         #expect(saved.contains("sonnet"))
-        #expect(saved.contains("pacing"))
+        #expect(saved.contains("weeklyPacing"))
     }
 
     // MARK: - Overlay


### PR DESCRIPTION
## Summary

Follow-up to #133. Two UX fixes for the per-bucket pacing landed in that PR:

1. **Pacing pins were not per-bucket.** The single \"Pacing\" pin covered only the weekly bucket but appeared to gate all pacing metrics, and Sonnet pacing rendered in the popover without a corresponding pin or menu bar entry. Each bucket now owns its own pin (\`.sessionPacing\`, \`.weeklyPacing\`, \`.sonnetPacing\`).
2. **Sonnet cluttered the popover for non-Sonnet users.** A new master \"Display Sonnet\" toggle (Settings -> Menu bar) gates every Sonnet-related surface (ring, pin, pacing row, pacing card, menu bar rendering). Defaults to off on fresh installs; legacy users who already had \`.sonnet\` pinned keep it on by default.

## Changes

### Menu bar popover
- 2-ring layout (Session + Weekly, same size, side by side) when Display Sonnet is off.
- Hero + 2-satellites layout when Display Sonnet is on (unchanged from current main).
- Pacing rows collapsed into a single compact stack. Each row has a leading pin icon, a small label on top, and an inline bar + delta. The two previous section headers (\`Session pacing\` / \`Pacing\`) are gone.

### Dashboard
- Pacing status message (\"you're on track\", etc.) renders only on the weekly card. Stacking 2-3 near-identical messages felt redundant.
- Sonnet pacing card only appears when Display Sonnet is on.

### Menu bar rendering
- \`MenuBarRenderer\` filters \`.sonnet\` and \`.sonnetPacing\` when Display Sonnet is off, even if the user has them pinned. Pin preferences are preserved across toggles.

### Settings (Display tab)
- New \`Display Sonnet\` master toggle next to \`Use monochrome menu bar\`.
- 3 separate pacing toggles (Session/Weekly/Sonnet pacing) instead of the previous 2 that coupled Weekly and Sonnet.
- Sonnet toggles are hidden when Display Sonnet is off.

### Migration
- Legacy saved \`\"pacing\"\` pin value is normalised to \`\"weeklyPacing\"\` on load.
- Display Sonnet seeds from \`pinnedMetrics.contains(.sonnet)\` on first launch after upgrade.

### Widget
- Untouched. Widget continues to read Sonnet data directly from the API payload, independent of the app's toggle.

## Test plan

- [x] Full test suite passes (242 tests, including updated \`SettingsStoreTests\` with new toggle + legacy \"pacing\" migration tests)
- [x] Release build succeeds with Xcode 16.4 / Swift 6.1.2
- [x] Manual: Display Sonnet off -> 2 equal rings side by side, pacing rows show Session + Weekly, no Sonnet anywhere
- [x] Manual: Display Sonnet on -> hero + 2 satellites, 3 pacing rows, 3 pacing cards on dashboard, Sonnet toggles appear in settings
- [x] Manual: pacing status message appears only on weekly card on dashboard
- [x] Manual: fresh install defaults to Display Sonnet off
- [x] Manual: user with legacy \`.sonnet\` pin sees Display Sonnet on after upgrade