### PR TITLE
fix: add Keychain helper for Claude Code credentials on new CLI versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
             -configuration Release \
             -derivedDataPath build \
             -destination 'platform=macOS' \
-            CODE_SIGN_IDENTITY="" \
+            CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
             build
 

--- a/Shared/Services/HelperManagerService.swift
+++ b/Shared/Services/HelperManagerService.swift
@@ -1,0 +1,183 @@
+import Foundation
+import AppKit
+import os.log
+
+private let logger = Logger(subsystem: "com.tokeneater.app", category: "HelperManager")
+
+final class HelperManagerService: HelperManagerProtocol, @unchecked Sendable {
+    static let defaultSyncInterval: TimeInterval = 300
+
+    private let home: String
+    private let plistPath: String
+    private let binaryPath: String
+    private let statusFilePath: String
+    private let logsDir: String
+    private let sharedDir: String
+    private let cmdScriptPath: String
+    private let label = "com.tokeneater.helper"
+
+    init() {
+        let resolvedHome: String = {
+            if let pw = getpwuid(getuid()) {
+                return String(cString: pw.pointee.pw_dir)
+            }
+            return NSHomeDirectory()
+        }()
+        self.home = resolvedHome
+        self.plistPath = "\(resolvedHome)/Library/LaunchAgents/com.tokeneater.helper.plist"
+        self.sharedDir = "\(resolvedHome)/Library/Application Support/com.tokeneater.shared"
+        self.statusFilePath = "\(sharedDir)/keychain-token.json"
+        self.cmdScriptPath = "\(sharedDir)/te-helper-cmd.sh"
+        self.logsDir = "\(resolvedHome)/Library/Logs/TokenEater"
+        self.binaryPath = Bundle.main.bundleURL
+            .appendingPathComponent("Contents/Library/LoginItems/TokenEaterHelper")
+            .path
+    }
+
+    // MARK: - Status
+
+    /// Reflects both "plist present on disk" AND "service actually loaded in launchd".
+    /// Plist without running service should not be reported as .installed.
+    func currentStatus() -> HelperStatus {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: binaryPath) else { return .binaryMissing }
+        guard fm.fileExists(atPath: plistPath) else { return .notInstalled }
+
+        guard let data = fm.contents(atPath: statusFilePath),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return .installed(lastSyncAt: nil, lastError: nil)
+        }
+        let lastSync = (obj["lastSyncAt"] as? String)
+            .flatMap { ISO8601DateFormatter().date(from: $0) }
+        let error = obj["error"] as? String
+        return .installed(lastSyncAt: lastSync, lastError: error)
+    }
+
+    // MARK: - Install
+
+    func install(syncInterval: TimeInterval) throws {
+        guard FileManager.default.fileExists(atPath: binaryPath) else {
+            throw HelperError.binaryMissing
+        }
+
+        guard let templateURL = Bundle.main.url(
+            forResource: "com.tokeneater.helper.plist",
+            withExtension: "template"
+        ), let template = try? String(contentsOf: templateURL, encoding: .utf8) else {
+            throw HelperError.templateMissing
+        }
+
+        let plist = template
+            .replacingOccurrences(of: "{{BINARY_PATH}}", with: binaryPath)
+            .replacingOccurrences(of: "{{SYNC_INTERVAL}}", with: String(Int(syncInterval)))
+            .replacingOccurrences(of: "{{HOME}}", with: home)
+
+        try ensureDirectoriesExist()
+
+        do {
+            try plist.write(toFile: plistPath, atomically: true, encoding: .utf8)
+        } catch {
+            throw HelperError.writeFailed(error.localizedDescription)
+        }
+
+        // The sandboxed app cannot exec /bin/launchctl directly (macOS sandbox
+        // rejects it with status 113). We punt to an AppleScript applet which
+        // is a separate .app bundle - launching it via /usr/bin/open runs it
+        // outside our sandbox, so its `do shell script` can reach launchctl.
+        let guiDomain = "gui/\(getuid())"
+        let command = """
+        #!/bin/bash
+        set -u
+        mkdir -p "\(logsDir)"
+        /bin/launchctl bootout \(guiDomain)/\(label) 2>/dev/null || true
+        /bin/launchctl bootstrap \(guiDomain) "\(plistPath)"
+        exit $?
+        """
+        try runViaInstallerApplet(command: command)
+        logger.info("Helper installed via helper-installer applet")
+    }
+
+    // MARK: - Uninstall
+
+    func uninstall() throws {
+        let guiDomain = "gui/\(getuid())"
+        let command = """
+        #!/bin/bash
+        /bin/launchctl bootout \(guiDomain)/\(label) 2>/dev/null || true
+        rm -f "\(plistPath)"
+        rm -f "\(statusFilePath)"
+        exit 0
+        """
+        try runViaInstallerApplet(command: command)
+        logger.info("Helper uninstalled via helper-installer applet")
+    }
+
+    // MARK: - Force sync
+
+    func forceSync() throws {
+        let guiDomain = "gui/\(getuid())"
+        let command = """
+        #!/bin/bash
+        /bin/launchctl kickstart -k \(guiDomain)/\(label)
+        exit $?
+        """
+        try runViaInstallerApplet(command: command)
+    }
+
+    // MARK: - Private
+
+    private func ensureDirectoriesExist() throws {
+        let fm = FileManager.default
+        try fm.createDirectory(
+            at: URL(fileURLWithPath: "\(home)/Library/LaunchAgents"),
+            withIntermediateDirectories: true
+        )
+        // Logs dir write may fail silently from the sandbox even with the
+        // home-relative entitlement; the helper-installer applet below
+        // re-creates it from outside the sandbox before launchctl runs.
+        try? fm.createDirectory(atPath: logsDir, withIntermediateDirectories: true)
+        try fm.createDirectory(atPath: sharedDir, withIntermediateDirectories: true)
+    }
+
+    /// Writes the command to the shared dir and launches the helper-installer
+    /// applet, which runs the script outside the sandbox. The applet exits
+    /// silently; this function returns once /usr/bin/open returns, which does
+    /// NOT mean the script has finished - we poll `currentStatus()` from the
+    /// caller side (settingsStore.refreshHelperStatus) to verify success.
+    private func runViaInstallerApplet(command: String) throws {
+        guard let installerURL = Bundle.main.url(
+            forResource: "TokenEaterHelperInstaller",
+            withExtension: "app"
+        ) else {
+            throw HelperError.templateMissing
+        }
+
+        do {
+            try command.write(toFile: cmdScriptPath, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o700],
+                ofItemAtPath: cmdScriptPath
+            )
+        } catch {
+            throw HelperError.writeFailed(error.localizedDescription)
+        }
+
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        // -g keeps the applet out of the foreground so TokenEater does not
+        // lose focus while the helper (un)installs. -W waits for the applet
+        // to exit so the caller can immediately re-check currentStatus().
+        task.arguments = ["-g", "-W", installerURL.path]
+        do {
+            try task.run()
+        } catch {
+            throw HelperError.appleScriptFailed(-1)
+        }
+        // -W waits for the applet to exit, which is fast because the applet
+        // only forks the shell script and returns.
+        task.waitUntilExit()
+        if task.terminationStatus != 0 {
+            throw HelperError.appleScriptFailed(Int(task.terminationStatus))
+        }
+    }
+}

--- a/Shared/Services/KeychainHelperReader.swift
+++ b/Shared/Services/KeychainHelperReader.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+final class KeychainHelperReader: KeychainHelperReaderProtocol, @unchecked Sendable {
+    private let filePath: String
+
+    convenience init() {
+        let home: String
+        if let pw = getpwuid(getuid()) {
+            home = String(cString: pw.pointee.pw_dir)
+        } else {
+            home = NSHomeDirectory()
+        }
+        self.init(
+            filePath: "\(home)/Library/Application Support/com.tokeneater.shared/keychain-token.json"
+        )
+    }
+
+    init(filePath: String) {
+        self.filePath = filePath
+    }
+
+    func readToken() -> String? {
+        guard let payload = readPayload(),
+              payload["status"] as? String == "ok",
+              let token = payload["token"] as? String,
+              !token.isEmpty else {
+            return nil
+        }
+        return token
+    }
+
+    func lastSyncAt() -> Date? {
+        guard let payload = readPayload(),
+              let raw = payload["lastSyncAt"] as? String else {
+            return nil
+        }
+        let formatter = ISO8601DateFormatter()
+        return formatter.date(from: raw)
+    }
+
+    func lastError() -> String? {
+        guard let payload = readPayload(),
+              let error = payload["error"] as? String,
+              !error.isEmpty else {
+            return nil
+        }
+        return error
+    }
+
+    private func readPayload() -> [String: Any]? {
+        guard let data = FileManager.default.contents(atPath: filePath),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return obj
+    }
+}

--- a/Shared/Services/Protocols/HelperManagerProtocol.swift
+++ b/Shared/Services/Protocols/HelperManagerProtocol.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+enum HelperStatus: Equatable {
+    case notInstalled
+    case installed(lastSyncAt: Date?, lastError: String?)
+    case binaryMissing
+    case error(String)
+}
+
+enum HelperError: LocalizedError {
+    case templateMissing
+    case binaryMissing
+    case launchctlFailed(Int32)
+    case appleScriptFailed(Int)
+    case writeFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .templateMissing: return "Helper plist template is missing from the app bundle."
+        case .binaryMissing: return "Helper binary is missing from the app bundle."
+        case .launchctlFailed(let code): return "launchctl exited with status \(code)."
+        case .appleScriptFailed(let code): return "AppleScript installer failed with code \(code)."
+        case .writeFailed(let detail): return "Could not write LaunchAgent plist: \(detail)."
+        }
+    }
+}
+
+protocol HelperManagerProtocol: Sendable {
+    func currentStatus() -> HelperStatus
+    func install(syncInterval: TimeInterval) throws
+    func uninstall() throws
+    func forceSync() throws
+}

--- a/Shared/Services/Protocols/KeychainHelperReaderProtocol.swift
+++ b/Shared/Services/Protocols/KeychainHelperReaderProtocol.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+protocol KeychainHelperReaderProtocol: Sendable {
+    /// Returns the most recent token synced by the helper, or nil if the helper
+    /// has never run / is reporting an error / wrote an empty token.
+    func readToken() -> String?
+
+    /// Returns the last sync timestamp reported by the helper, or nil.
+    func lastSyncAt() -> Date?
+
+    /// Returns the last error reported by the helper, or nil if status is ok.
+    func lastError() -> String?
+}

--- a/Shared/Services/TokenProvider.swift
+++ b/Shared/Services/TokenProvider.swift
@@ -6,11 +6,12 @@ private let logger = Logger(subsystem: "com.tokeneater.app", category: "TokenPro
 
 final class TokenProvider: TokenProviderProtocol, @unchecked Sendable {
     private let credentialsFileReader: CredentialsFileReaderProtocol
+    private let keychainHelperReader: KeychainHelperReaderProtocol
     private let configReader: ClaudeConfigReaderProtocol
     private let decryptionService: ElectronDecryptionServiceProtocol
     private let keychainReader: KeychainTokenReader
 
-    /// In-memory token cache — avoids hitting the Keychain on every refresh.
+    /// In-memory token cache - avoids hitting the Keychain on every refresh.
     /// Only cleared on 401 (token expired) via `invalidateToken()`.
     private var cachedToken: String?
 
@@ -19,11 +20,13 @@ final class TokenProvider: TokenProviderProtocol, @unchecked Sendable {
 
     init(
         credentialsFileReader: CredentialsFileReaderProtocol = CredentialsFileReader(),
+        keychainHelperReader: KeychainHelperReaderProtocol = KeychainHelperReader(),
         configReader: ClaudeConfigReaderProtocol = ClaudeConfigReader(),
         decryptionService: ElectronDecryptionServiceProtocol = ElectronDecryptionService(),
         keychainReader: KeychainTokenReader? = nil
     ) {
         self.credentialsFileReader = credentialsFileReader
+        self.keychainHelperReader = keychainHelperReader
         self.configReader = configReader
         self.decryptionService = decryptionService
         self.keychainReader = keychainReader ?? Self.defaultKeychainReader
@@ -34,6 +37,7 @@ final class TokenProvider: TokenProviderProtocol, @unchecked Sendable {
     func hasTokenSource() -> Bool {
         if cachedToken != nil { return true }
         if credentialsFileReader.readToken() != nil { return true }
+        if keychainHelperReader.readToken() != nil { return true }
         if configReader.readEncryptedToken() != nil { return true }
         if keychainReader(true) != nil { return true }
         return false
@@ -42,22 +46,31 @@ final class TokenProvider: TokenProviderProtocol, @unchecked Sendable {
     /// Returns the current token, using the in-memory cache if available.
     /// The Keychain is only read when the cache is empty (app start, or after `invalidateToken()`).
     func currentToken() -> String? {
-        // Fast path: cached token from a previous successful read
         if let token = cachedToken { return token }
 
-        // Source 1: credentials file (no keychain, no popup)
+        // Source 1: credentials file (legacy Claude Code that still wrote it)
         if let token = credentialsFileReader.readToken() {
             cachedToken = token
             return token
         }
 
-        // Source 2: decrypt config.json (no keychain if key file exists)
+        // Source 2: helper-synced Keychain token (new Claude Code CLI). Reads a
+        // JSON file the helper LaunchAgent writes - no Keychain access from this
+        // process, so this path is sandbox-safe.
+        if let token = keychainHelperReader.readToken() {
+            cachedToken = token
+            logger.info("Token read from Keychain helper file")
+            return token
+        }
+
+        // Source 3: decrypt config.json (Claude Desktop)
         if let token = tokenFromConfigJSON() {
             cachedToken = token
             return token
         }
 
-        // Source 3: Keychain — silent read, last resort
+        // Source 4: Keychain direct - almost never works for sandboxed ad-hoc
+        // signed apps (ACL blocks us) but kept as a last resort.
         if let token = keychainReader(true) {
             cachedToken = token
             logger.info("Token read from Keychain (silent) and cached in memory")
@@ -71,13 +84,11 @@ final class TokenProvider: TokenProviderProtocol, @unchecked Sendable {
     private func tokenFromConfigJSON() -> String? {
         guard let encrypted = configReader.readEncryptedToken() else { return nil }
 
-        // Try with existing key
         if decryptionService.hasEncryptionKey,
            let token = decryptFromConfigJSON(encrypted) {
             return token
         }
 
-        // Key missing or stale — try silent re-bootstrap (no popup)
         if decryptionService.trySilentRebootstrap(),
            let token = decryptFromConfigJSON(encrypted) {
             logger.info("Token recovered via silent re-bootstrap of decryption key")
@@ -87,21 +98,19 @@ final class TokenProvider: TokenProviderProtocol, @unchecked Sendable {
         return nil
     }
 
-    /// Call this after a 401 — clears the in-memory cache so the next `currentToken()`
+    /// Call this after a 401 - clears the in-memory cache so the next `currentToken()`
     /// re-reads from Keychain/file to pick up a refreshed token.
     func invalidateToken() {
         cachedToken = nil
-        logger.info("Token cache invalidated — next read will check Keychain")
+        logger.info("Token cache invalidated - next read will check Keychain")
     }
 
     func bootstrap() throws {
-        // Interactive Keychain read — triggers macOS "Allow" dialog
         if let token = keychainReader(false) {
             cachedToken = token
             logger.info("Bootstrap succeeded via interactive Keychain read")
         }
 
-        // Also bootstrap decryption key for config.json fallback
         do {
             try decryptionService.bootstrapEncryptionKey()
         } catch {

--- a/Shared/Stores/SettingsStore.swift
+++ b/Shared/Stores/SettingsStore.swift
@@ -145,15 +145,26 @@ final class SettingsStore: ObservableObject {
     // Notifications
     @Published var notificationStatus: UNAuthorizationStatus = .notDetermined
 
+    // Keychain helper
+    @Published var helperStatus: HelperStatus = .notInstalled
+    @Published var helperBusy: Bool = false
+    @Published var helperLastError: String?
+    @Published var helperSyncInterval: Int {
+        didSet { UserDefaults.standard.set(helperSyncInterval, forKey: "helperSyncInterval") }
+    }
+
     private let notificationService: NotificationServiceProtocol
     private let tokenProvider: TokenProviderProtocol
+    private let helperManager: HelperManagerProtocol
 
     init(
         notificationService: NotificationServiceProtocol = NotificationService(),
-        tokenProvider: TokenProviderProtocol = TokenProvider()
+        tokenProvider: TokenProviderProtocol = TokenProvider(),
+        helperManager: HelperManagerProtocol = HelperManagerService()
     ) {
         self.notificationService = notificationService
         self.tokenProvider = tokenProvider
+        self.helperManager = helperManager
 
         self.showMenuBar = UserDefaults.standard.object(forKey: "showMenuBar") as? Bool ?? true
         self.hasCompletedOnboarding = UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
@@ -190,6 +201,11 @@ final class SettingsStore: ObservableObject {
             rawValue: UserDefaults.standard.string(forKey: "pacingDisplayMode") ?? "dotDelta"
         ) ?? .dotDelta
         self.showSessionReset = UserDefaults.standard.bool(forKey: "showSessionReset")
+        self.helperSyncInterval = {
+            let raw = UserDefaults.standard.integer(forKey: "helperSyncInterval")
+            return raw >= 30 ? raw : Int(HelperManagerService.defaultSyncInterval)
+        }()
+        self.helperStatus = helperManager.currentStatus()
         let legacyPinned: Set<MetricID>
         if let saved = UserDefaults.standard.stringArray(forKey: "pinnedMetrics") {
             // Migrate legacy "pacing" (covered weekly only) to the explicit weeklyPacing id.
@@ -247,5 +263,55 @@ final class SettingsStore: ObservableObject {
 
     func credentialsTokenExists() -> Bool {
         tokenProvider.currentToken() != nil
+    }
+
+    // MARK: - Keychain helper
+
+    func refreshHelperStatus() {
+        helperStatus = helperManager.currentStatus()
+    }
+
+    func installHelper() async {
+        helperBusy = true
+        helperLastError = nil
+        defer {
+            helperBusy = false
+            refreshHelperStatus()
+        }
+        do {
+            try helperManager.install(syncInterval: TimeInterval(helperSyncInterval))
+            tokenProvider.invalidateToken()
+        } catch {
+            helperLastError = error.localizedDescription
+        }
+    }
+
+    func uninstallHelper() async {
+        helperBusy = true
+        helperLastError = nil
+        defer {
+            helperBusy = false
+            refreshHelperStatus()
+        }
+        do {
+            try helperManager.uninstall()
+            tokenProvider.invalidateToken()
+        } catch {
+            helperLastError = error.localizedDescription
+        }
+    }
+
+    func forceHelperSync() async {
+        helperBusy = true
+        helperLastError = nil
+        defer {
+            helperBusy = false
+            refreshHelperStatus()
+        }
+        do {
+            try helperManager.forceSync()
+        } catch {
+            helperLastError = error.localizedDescription
+        }
     }
 }

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -126,6 +126,23 @@
 "pacing.label" = "Pacing";
 "pacing.reset" = "reset %@";
 
+/* Keychain helper */
+"credentials.helper.title" = "Keychain helper";
+"credentials.helper.description" = "Claude Code 2.1+ stores your token only in the macOS Keychain - sandboxed apps like TokenEater cannot read it directly. This helper is a tiny background service that reads the token every few minutes and hands it to TokenEater. One click to install, no admin password, keeps working across token refreshes.";
+"credentials.helper.trust" = "Everything stays on your Mac: the helper only calls Apple's own /usr/bin/security to read your Keychain, then writes the token to a local file TokenEater reads. Zero network calls. Full source is public on GitHub if you want to verify before installing.";
+"credentials.helper.source" = "View source on GitHub";
+"credentials.helper.status.notinstalled" = "Not installed";
+"credentials.helper.status.binaryMissing" = "Helper binary missing from the app bundle - reinstall the app.";
+"credentials.helper.status.active" = "Active - last sync %@";
+"credentials.helper.status.active.nosync" = "Active - awaiting first sync";
+"credentials.helper.status.error" = "Error: %@";
+"credentials.helper.install" = "Install helper";
+"credentials.helper.uninstall" = "Remove helper";
+"credentials.helper.forcesync" = "Force sync now";
+"helper.banner.title" = "Claude Code credentials not reachable";
+"helper.banner.description" = "Install the TokenEater helper to read the token from your Keychain.";
+"helper.banner.install" = "Install helper";
+
 /* Pacing Margin */
 "settings.pacing.margin" = "Pacing Sensitivity";
 "settings.pacing.margin.value" = "Margin";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -126,6 +126,23 @@
 "pacing.label" = "Rythme";
 "pacing.reset" = "reset %@";
 
+/* Assistant Keychain */
+"credentials.helper.title" = "Assistant Keychain";
+"credentials.helper.description" = "Claude Code 2.1+ stocke ton token uniquement dans le Keychain macOS - les apps sandboxées comme TokenEater ne peuvent pas le lire directement. Cet assistant est un petit service en arrière-plan qui lit le token toutes les quelques minutes et le transmet à TokenEater. Un clic pour installer, pas de mot de passe admin, continue de fonctionner à travers les refreshs de token.";
+"credentials.helper.trust" = "Tout reste sur ton Mac : l'assistant appelle uniquement /usr/bin/security (l'outil Apple lui-même) pour lire ton Keychain, puis écrit le token dans un fichier local que TokenEater lit. Aucun appel réseau. Le code source complet est public sur GitHub si tu veux vérifier avant d'installer.";
+"credentials.helper.source" = "Voir le code sur GitHub";
+"credentials.helper.status.notinstalled" = "Non installé";
+"credentials.helper.status.binaryMissing" = "Binaire assistant absent du bundle - réinstallez l'app.";
+"credentials.helper.status.active" = "Actif - dernière synchro %@";
+"credentials.helper.status.active.nosync" = "Actif - en attente de la première synchro";
+"credentials.helper.status.error" = "Erreur : %@";
+"credentials.helper.install" = "Installer l'assistant";
+"credentials.helper.uninstall" = "Désinstaller l'assistant";
+"credentials.helper.forcesync" = "Forcer une synchro";
+"helper.banner.title" = "Identifiants Claude Code inaccessibles";
+"helper.banner.description" = "Installez l'assistant TokenEater pour lire le token depuis votre Keychain.";
+"helper.banner.install" = "Installer l'assistant";
+
 /* Marge pacing */
 "settings.pacing.margin" = "Sensibilité du pacing";
 "settings.pacing.margin.value" = "Marge";

--- a/TokenEaterApp/MainAppView.swift
+++ b/TokenEaterApp/MainAppView.swift
@@ -25,28 +25,29 @@ struct MainAppView: View {
         HStack(spacing: 4) {
             AppSidebar(selection: $selectedSection)
 
-            ScrollView(.vertical, showsIndicators: true) {
-                Group {
-                    switch selectedSection {
-                    case .dashboard:
-                        DashboardView()
-                    case .display:
-                        DisplaySectionView(initialMetrics: settingsStore.pinnedMetrics)
-                    case .themes:
+            Group {
+                switch selectedSection {
+                case .dashboard:
+                    // Dashboard expects to fill the viewport (uses maxHeight: .infinity
+                    // internally). Wrapping it in a ScrollView collapses that layout.
+                    DashboardView()
+                case .display:
+                    scrollingSection { DisplaySectionView(initialMetrics: settingsStore.pinnedMetrics) }
+                case .themes:
+                    scrollingSection {
                         ThemesSectionView(
                             initialWarning: themeStore.warningThreshold,
                             initialCritical: themeStore.criticalThreshold,
                             initialMargin: settingsStore.pacingMargin
                         )
-                    case .agentWatchers:
-                        AgentWatchersSectionView()
-                    case .performance:
-                        PerformanceSectionView()
-                    case .settings:
-                        SettingsSectionView()
                     }
+                case .agentWatchers:
+                    scrollingSection { AgentWatchersSectionView() }
+                case .performance:
+                    scrollingSection { PerformanceSectionView() }
+                case .settings:
+                    scrollingSection { SettingsSectionView() }
                 }
-                .frame(maxWidth: .infinity, alignment: .top)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(RoundedRectangle(cornerRadius: 16).fill(panelBg))
@@ -65,6 +66,14 @@ struct MainAppView: View {
                let target = AppSection(rawValue: section) {
                 selectedSection = target
             }
+        }
+    }
+
+    @ViewBuilder
+    private func scrollingSection<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        ScrollView(.vertical, showsIndicators: true) {
+            content()
+                .frame(maxWidth: .infinity, alignment: .top)
         }
     }
 

--- a/TokenEaterApp/MainAppView.swift
+++ b/TokenEaterApp/MainAppView.swift
@@ -25,25 +25,28 @@ struct MainAppView: View {
         HStack(spacing: 4) {
             AppSidebar(selection: $selectedSection)
 
-            Group {
-                switch selectedSection {
-                case .dashboard:
-                    DashboardView()
-                case .display:
-                    DisplaySectionView(initialMetrics: settingsStore.pinnedMetrics)
-                case .themes:
-                    ThemesSectionView(
-                        initialWarning: themeStore.warningThreshold,
-                        initialCritical: themeStore.criticalThreshold,
-                        initialMargin: settingsStore.pacingMargin
-                    )
-                case .agentWatchers:
-                    AgentWatchersSectionView()
-                case .performance:
-                    PerformanceSectionView()
-                case .settings:
-                    SettingsSectionView()
+            ScrollView(.vertical, showsIndicators: true) {
+                Group {
+                    switch selectedSection {
+                    case .dashboard:
+                        DashboardView()
+                    case .display:
+                        DisplaySectionView(initialMetrics: settingsStore.pinnedMetrics)
+                    case .themes:
+                        ThemesSectionView(
+                            initialWarning: themeStore.warningThreshold,
+                            initialCritical: themeStore.criticalThreshold,
+                            initialMargin: settingsStore.pacingMargin
+                        )
+                    case .agentWatchers:
+                        AgentWatchersSectionView()
+                    case .performance:
+                        PerformanceSectionView()
+                    case .settings:
+                        SettingsSectionView()
+                    }
                 }
+                .frame(maxWidth: .infinity, alignment: .top)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(RoundedRectangle(cornerRadius: 16).fill(panelBg))

--- a/TokenEaterApp/MenuBarView.swift
+++ b/TokenEaterApp/MenuBarView.swift
@@ -368,25 +368,29 @@ struct MenuBarPopoverView: View {
         VStack(alignment: .leading, spacing: 4) {
             switch usageStore.errorState {
             case .tokenUnavailable:
-                Label(String(localized: "error.banner.expired"), systemImage: "exclamationmark.triangle.fill")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.red)
-                Text(String(localized: "error.banner.expired.hint"))
-                    .font(.system(size: 10))
-                    .foregroundStyle(.white.opacity(0.5))
-                Button {
-                    Task { await usageStore.reauthenticate() }
-                } label: {
-                    Text(String(localized: "error.banner.reauth.button"))
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundStyle(.white)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 4)
-                        .background(.orange.opacity(0.3))
-                        .clipShape(Capsule())
+                if case .notInstalled = settingsStore.helperStatus {
+                    helperInstallBannerContent
+                } else {
+                    Label(String(localized: "error.banner.expired"), systemImage: "exclamationmark.triangle.fill")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(.red)
+                    Text(String(localized: "error.banner.expired.hint"))
+                        .font(.system(size: 10))
+                        .foregroundStyle(.white.opacity(0.5))
+                    Button {
+                        Task { await usageStore.reauthenticate() }
+                    } label: {
+                        Text(String(localized: "error.banner.reauth.button"))
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 4)
+                            .background(.orange.opacity(0.3))
+                            .clipShape(Capsule())
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.top, 2)
                 }
-                .buttonStyle(.plain)
-                .padding(.top, 2)
             case .rateLimited:
                 Label(String(localized: "error.banner.apiunavailable"), systemImage: "icloud.slash")
                     .font(.system(size: 11, weight: .semibold))
@@ -421,6 +425,34 @@ struct MenuBarPopoverView: View {
         .padding(10)
         .background(Color.white.opacity(0.04))
         .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    @ViewBuilder
+    private var helperInstallBannerContent: some View {
+        Label(String(localized: "helper.banner.title"), systemImage: "key.slash")
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(.orange)
+        Text(String(localized: "helper.banner.description"))
+            .font(.system(size: 10))
+            .foregroundStyle(.white.opacity(0.5))
+            .fixedSize(horizontal: false, vertical: true)
+        Button {
+            Task {
+                await settingsStore.installHelper()
+                await usageStore.refresh(force: true)
+            }
+        } label: {
+            Text(String(localized: "helper.banner.install"))
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .background(.blue.opacity(0.3))
+                .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .disabled(settingsStore.helperBusy)
+        .padding(.top, 2)
     }
 
     private func pacingRow(metric: MetricID, label: String, pacing: PacingResult) -> some View {

--- a/TokenEaterApp/Resources/com.tokeneater.helper.plist.template
+++ b/TokenEaterApp/Resources/com.tokeneater.helper.plist.template
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.tokeneater.helper</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{BINARY_PATH}}</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>SYNC_INTERVAL</key>
+        <string>{{SYNC_INTERVAL}}</string>
+        <key>HOME</key>
+        <string>{{HOME}}</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/Library/Logs/TokenEater/helper.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/Library/Logs/TokenEater/helper.err</string>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>LowPriorityIO</key>
+    <true/>
+</dict>
+</plist>

--- a/TokenEaterApp/Resources/helper-installer.applescript
+++ b/TokenEaterApp/Resources/helper-installer.applescript
@@ -1,0 +1,6 @@
+-- Reads a command written by the sandboxed main app to the shared dir and
+-- runs it as a user-level (no admin) shell script. Because this applet is
+-- a separate .app bundle launched via /usr/bin/open, its shell script runs
+-- outside the main app's sandbox and can therefore invoke /bin/launchctl.
+set sharedDir to do shell script "echo ~/Library/Application\\ Support/com.tokeneater.shared"
+do shell script "bash '" & sharedDir & "/te-helper-cmd.sh'"

--- a/TokenEaterApp/SettingsSectionView.swift
+++ b/TokenEaterApp/SettingsSectionView.swift
@@ -65,6 +65,9 @@ struct SettingsSectionView: View {
                 }
             }
 
+            // Credentials (Keychain helper)
+            credentialsCard
+
             // Proxy
             glassCard {
                 VStack(alignment: .leading, spacing: 8) {
@@ -220,6 +223,152 @@ struct SettingsSectionView: View {
         .padding(24)
         .onAppear {
             Task { await settingsStore.refreshNotificationStatus() }
+            settingsStore.refreshHelperStatus()
+        }
+    }
+
+    // MARK: - Credentials card
+
+    private var credentialsCard: some View {
+        glassCard {
+            VStack(alignment: .leading, spacing: 10) {
+                cardLabel(String(localized: "credentials.helper.title"))
+                Text(String(localized: "credentials.helper.description"))
+                    .font(.system(size: 11))
+                    .foregroundStyle(.white.opacity(0.5))
+                    .fixedSize(horizontal: false, vertical: true)
+
+                helperTrustCallout
+
+                helperStatusRow
+                helperActions
+
+                if let err = settingsStore.helperLastError {
+                    Label(err, systemImage: "exclamationmark.triangle.fill")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.red.opacity(0.8))
+                }
+            }
+        }
+    }
+
+    private var helperTrustCallout: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "lock.shield")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.green.opacity(0.8))
+                    .padding(.top, 1)
+                Text(String(localized: "credentials.helper.trust"))
+                    .font(.system(size: 11))
+                    .foregroundStyle(.white.opacity(0.65))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Button {
+                NSWorkspace.shared.open(
+                    URL(string: "https://github.com/AThevon/TokenEater/tree/main/TokenEaterHelper")!
+                )
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "arrow.up.right.square")
+                        .font(.system(size: 10))
+                    Text(String(localized: "credentials.helper.source"))
+                        .font(.system(size: 11, weight: .medium))
+                }
+                .foregroundStyle(.blue)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.green.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.green.opacity(0.15), lineWidth: 0.5)
+        )
+    }
+
+    @ViewBuilder
+    private var helperStatusRow: some View {
+        HStack(spacing: 8) {
+            switch settingsStore.helperStatus {
+            case .notInstalled:
+                Circle().fill(Color.white.opacity(0.2)).frame(width: 8, height: 8)
+                Text(String(localized: "credentials.helper.status.notinstalled"))
+                    .font(.system(size: 12))
+                    .foregroundStyle(.white.opacity(0.7))
+            case .binaryMissing:
+                Circle().fill(Color.red).frame(width: 8, height: 8)
+                Text(String(localized: "credentials.helper.status.binaryMissing"))
+                    .font(.system(size: 12))
+                    .foregroundStyle(.red)
+            case .installed(let lastSync, let error):
+                if let error, !error.isEmpty {
+                    Circle().fill(Color.orange).frame(width: 8, height: 8)
+                    Text(String(format: String(localized: "credentials.helper.status.error"), error))
+                        .font(.system(size: 12))
+                        .foregroundStyle(.orange.opacity(0.9))
+                        .lineLimit(2)
+                } else {
+                    Circle().fill(Color.green).frame(width: 8, height: 8)
+                    if let lastSync {
+                        let relative = lastSync.formatted(.relative(presentation: .named))
+                        Text(String(format: String(localized: "credentials.helper.status.active"), relative))
+                            .font(.system(size: 12))
+                            .foregroundStyle(.green.opacity(0.9))
+                    } else {
+                        Text(String(localized: "credentials.helper.status.active.nosync"))
+                            .font(.system(size: 12))
+                            .foregroundStyle(.green.opacity(0.9))
+                    }
+                }
+            case .error(let msg):
+                Circle().fill(Color.red).frame(width: 8, height: 8)
+                Text(msg)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.red)
+                    .lineLimit(2)
+            }
+            Spacer()
+            if settingsStore.helperBusy {
+                ProgressView().scaleEffect(0.5)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var helperActions: some View {
+        HStack(spacing: 10) {
+            switch settingsStore.helperStatus {
+            case .notInstalled:
+                Button(String(localized: "credentials.helper.install")) {
+                    Task { await settingsStore.installHelper() }
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.blue)
+                .disabled(settingsStore.helperBusy)
+            case .binaryMissing:
+                EmptyView()
+            case .installed, .error:
+                Button(String(localized: "credentials.helper.forcesync")) {
+                    Task { await settingsStore.forceHelperSync() }
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.blue)
+                .disabled(settingsStore.helperBusy)
+
+                Button(String(localized: "credentials.helper.uninstall")) {
+                    Task { await settingsStore.uninstallHelper() }
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundStyle(.red.opacity(0.7))
+                .disabled(settingsStore.helperBusy)
+            }
+            Spacer()
         }
     }
 

--- a/TokenEaterApp/TokenEaterApp.entitlements
+++ b/TokenEaterApp/TokenEaterApp.entitlements
@@ -10,6 +10,8 @@
     <array>
         <string>/Library/Application Support/com.tokeneater.shared/</string>
         <string>/Library/Application Support/com.claudeusagewidget.shared/</string>
+        <string>/Library/LaunchAgents/</string>
+        <string>/Library/Logs/TokenEater/</string>
     </array>
     <key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
     <array>

--- a/TokenEaterHelper/TokenSync.swift
+++ b/TokenEaterHelper/TokenSync.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+final class TokenSync {
+    private let interval: TimeInterval
+    private let outputURL: URL
+    private let helperVersion: String
+
+    init(interval: TimeInterval) {
+        self.interval = interval
+        let home = ProcessInfo.processInfo.environment["HOME"] ?? NSHomeDirectory()
+        self.outputURL = URL(fileURLWithPath: home)
+            .appendingPathComponent("Library/Application Support/com.tokeneater.shared/keychain-token.json")
+        self.helperVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev"
+    }
+
+    func runForever() -> Never {
+        // Signal-based wake-up: SIGUSR1 from the main app (via `launchctl kickstart
+        // -k` or kill) interrupts the sleep and triggers an immediate resync.
+        signal(SIGUSR1, { _ in })
+
+        while true {
+            performSync()
+            Thread.sleep(forTimeInterval: interval)
+        }
+    }
+
+    func performSync() {
+        guard let token = readKeychain() else {
+            writeStatus(status: "no-token", token: nil, error: "security returned no password")
+            return
+        }
+        writeStatus(status: "ok", token: token, error: nil)
+    }
+
+    private func readKeychain() -> String? {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        task.arguments = ["find-generic-password", "-s", "Claude Code-credentials", "-w"]
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        task.standardOutput = stdout
+        task.standardError = stderr
+
+        do {
+            try task.run()
+        } catch {
+            return nil
+        }
+        task.waitUntilExit()
+        guard task.terminationStatus == 0 else { return nil }
+
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        guard let raw = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty else {
+            return nil
+        }
+
+        // Claude Code stores the whole JSON blob in the Keychain value. Extract
+        // claudeAiOauth.accessToken - same shape used by TokenProvider elsewhere.
+        guard let jsonData = raw.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+              let oauth = obj["claudeAiOauth"] as? [String: Any],
+              let token = oauth["accessToken"] as? String,
+              !token.isEmpty else {
+            return nil
+        }
+
+        return token
+    }
+
+    private func writeStatus(status: String, token: String?, error: String?) {
+        var payload: [String: Any] = [
+            "status": status,
+            "lastSyncAt": ISO8601DateFormatter().string(from: Date()),
+            "helperVersion": helperVersion,
+        ]
+        if let token { payload["token"] = token }
+        if let error { payload["error"] = error }
+
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: payload,
+            options: [.prettyPrinted, .sortedKeys]
+        ) else { return }
+
+        let parent = outputURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(
+            at: parent,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+
+        // Atomic write via a temp file + rename so partial reads are impossible.
+        let tmpURL = parent.appendingPathComponent(".keychain-token.json.tmp")
+        do {
+            try data.write(to: tmpURL, options: [.atomic, .completeFileProtection])
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: tmpURL.path
+            )
+            _ = try FileManager.default.replaceItemAt(outputURL, withItemAt: tmpURL)
+        } catch {
+            // Best effort - next tick will retry.
+            try? FileManager.default.removeItem(at: tmpURL)
+        }
+    }
+}

--- a/TokenEaterHelper/main.swift
+++ b/TokenEaterHelper/main.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+// MARK: - Helper entry point
+//
+// This binary is NOT sandboxed. It is loaded by the user's LaunchAgent so it
+// can shell out to /usr/bin/security - the only process explicitly whitelisted
+// in the ACL of the "Claude Code-credentials" Keychain item. The sandboxed
+// main TokenEater app cannot do this itself.
+//
+// The helper runs a simple loop: read the Keychain, write the decoded access
+// token to a shared JSON file, sleep, repeat. Configurable interval via the
+// SYNC_INTERVAL env var (floor of 30s).
+
+let defaultInterval: TimeInterval = 300 // 5 minutes
+
+let interval: TimeInterval = {
+    guard let raw = ProcessInfo.processInfo.environment["SYNC_INTERVAL"],
+          let value = TimeInterval(raw),
+          value >= 30 else {
+        return defaultInterval
+    }
+    return value
+}()
+
+let sync = TokenSync(interval: interval)
+sync.runForever()

--- a/project.yml
+++ b/project.yml
@@ -45,10 +45,39 @@ targets:
     preBuildScripts:
       - script: |
           osacompile -o "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.app/Contents/Resources/TokenEaterInstaller.app" "$SRCROOT/TokenEaterApp/Resources/installer.applescript"
-        name: Compile installer applet
+          osacompile -o "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.app/Contents/Resources/TokenEaterHelperInstaller.app" "$SRCROOT/TokenEaterApp/Resources/helper-installer.applescript"
+        name: Compile installer applets
+    postBuildScripts:
+      - script: |
+          # Embed TokenEaterHelper in Contents/Library/LoginItems (idiomatic spot for
+          # login-style tools; app-sandbox-compatible because we are not embedding
+          # an .app bundle here, just a command-line executable).
+          mkdir -p "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.app/Contents/Library/LoginItems"
+          if [ -f "$BUILT_PRODUCTS_DIR/TokenEaterHelper" ]; then
+            cp "$BUILT_PRODUCTS_DIR/TokenEaterHelper" \
+              "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.app/Contents/Library/LoginItems/TokenEaterHelper"
+            chmod +x "$BUILT_PRODUCTS_DIR/$PRODUCT_NAME.app/Contents/Library/LoginItems/TokenEaterHelper"
+          fi
+        name: Embed Keychain helper binary
     dependencies:
       - target: TokenEaterWidgetExtension
         embed: true
+      - target: TokenEaterHelper
+        embed: false
+        link: false
+
+  TokenEaterHelper:
+    type: tool
+    platform: macOS
+    sources:
+      - path: TokenEaterHelper
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.tokeneater.helper
+        PRODUCT_NAME: TokenEaterHelper
+        SKIP_INSTALL: "YES"
+        CODE_SIGN_IDENTITY: "-"
+        CODE_SIGNING_REQUIRED: "NO"
 
   TokenEaterTests:
     type: bundle.unit-test
@@ -94,6 +123,7 @@ schemes:
       targets:
         TokenEaterApp: all
         TokenEaterWidgetExtension: all
+        TokenEaterHelper: all
     run:
       config: Debug
     archive:


### PR DESCRIPTION
## Summary

Closes #128. Users on Claude Code 2.1+ CLI without Claude Desktop lost token discovery entirely because Anthropic moved the OAuth token to the macOS Keychain under an ACL that whitelists only \`/usr/bin/security\`. A sandboxed ad-hoc-signed app like TokenEater cannot reach that item. This PR adds a non-sandboxed helper binary that sits in the bundle, runs as a LaunchAgent once the user opts in, and bridges the token into a file TokenEater can read.

## Architecture

| Component | Role |
|---|---|
| \`TokenEaterHelper\` | New non-sandboxed CLI target. Shells out to \`/usr/bin/security find-generic-password -s \"Claude Code-credentials\" -w\` on a loop (default 5 min). Extracts \`claudeAiOauth.accessToken\` and writes the result to \`~/Library/Application Support/com.tokeneater.shared/keychain-token.json\` (0600 + atomic write). Zero network calls. |
| \`KeychainHelperReader\` | Reads that JSON file and exposes the token. Wired into \`TokenProvider\` as source #2 (between the legacy credentials file and the Claude Desktop config.json fallback). |
| \`HelperManagerService\` | Install/uninstall/force-sync. Writes the LaunchAgent plist (template in \`TokenEaterApp/Resources/\`) and delegates launchctl calls to a new \`TokenEaterHelperInstaller.app\` applet. |
| \`helper-installer.applescript\` | A tiny \`do shell script\` applet that executes a command file written to the shared dir. The applet is a separate ad-hoc-signed \`.app\` launched via \`/usr/bin/open -g -W\`, so it runs outside the main app's sandbox and can legally call \`/bin/launchctl\`. No admin privileges requested (user-level Launch Agents do not need them). |

## Why an applet and not a direct \`Process()\`?

Initial implementation tried \`Process(launchPath: \"/bin/launchctl\")\` from the sandboxed main app. It returns exit code 113 consistently (verified on Xcode 16.4 + macOS 15.5 Personal Team). Manual \`launchctl bootstrap\` from Terminal works fine with the exact same plist, confirming the plist and the helper are correct - the sandbox is what blocks subprocess execution of launchctl. Reusing the existing auto-update applet pattern unblocks the flow without admin prompts.

## Changes

- New target \`TokenEaterHelper\` embedded at \`Contents/Library/LoginItems/TokenEaterHelper\` via a postBuildScript
- New compiled applet \`TokenEaterHelperInstaller.app\` in \`Contents/Resources/\` (built from \`helper-installer.applescript\` by an additional osacompile step)
- \`TokenProvider\` source order: cached -> credentials file -> **keychain-helper file (new)** -> config.json -> direct Keychain
- \`SettingsStore\` grows a \`helperManager\` dependency and \`helperStatus\` / \`helperBusy\` / \`helperLastError\` / \`helperSyncInterval\` published properties plus \`installHelper()\` / \`uninstallHelper()\` / \`forceHelperSync()\` / \`refreshHelperStatus()\`
- \`SettingsSectionView\` adds a new card with description, a green trust callout explaining local-only behaviour, a link to the helper source on GitHub, status row (Not installed / Active - last sync X / Helper binary missing / Error), and action buttons
- \`MenuBarView\` popover shows an Install helper banner when \`errorState == .tokenUnavailable\` AND the helper is not installed (replaces the now-misleading \"Credentials expired\" banner for first-time CLI 2.1+ users)
- \`MainAppView\` wraps each section in a \`ScrollView\` so longer content in the Settings section remains reachable
- Entitlements grow \`~/Library/LaunchAgents/\` and \`~/Library/Logs/TokenEater/\` as home-relative read-write exceptions
- Localized strings (en + fr) for the card, trust copy, status variants, and banner

## Transparency

Because \"a tiny daemon that reads your credentials\" is legitimately sketchy to some users, the Settings card now includes:

- a green trust callout with \`lock.shield\` icon stating everything stays on device, zero network calls, only \`/usr/bin/security\` (Apple's own tool) is invoked;
- a direct link to \`github.com/AThevon/TokenEater/tree/main/TokenEaterHelper\` so users can read the 130 lines of Swift before installing.

## Test plan

- [x] Full test suite passes (252 tests; existing TokenProvider / SettingsStore / UsageStore tests confirmed no regressions)
- [x] Release build with Xcode 16.4 + \`DEVELOPER_DIR\` pinned
- [x] Manual: install helper from Settings -> applet runs in background (\`-g\` keeps TokenEater focused), launchctl bootstraps the LaunchAgent, helper writes a valid token within seconds, status transitions to Active
- [x] Manual: Force sync now -> status timestamp updates
- [x] Manual: Remove helper -> launchctl bootout, plist + status file removed, status returns to Not installed
- [x] Manual: delete \`~/.claude/.credentials.json\`, ensure helper is uninstalled -> popover shows Install helper banner instead of the generic \"Credentials expired\"

## Deferred (not blocking v4.10.0)

- \`HelperManagerServiceTests\` / \`KeychainHelperReaderTests\`: the \`Process()\` path and the launchctl call surface are hard to mock cleanly without a dedicated protocol. Real-hardware verification covers the same ground.
- Sync-interval picker in the UI (currently uses the default 5 min; underlying config is already there, just no picker surface).
- Automatic View Logs button.

Once the repo moves to an Apple Developer Program signing identity, the helper becomes unnecessary; the main app can be desandboxed and read the Keychain directly. Tracked in \`docs/APPLE_DEV_MIGRATION.md\` phase 3A.

Credit to @shuhulx for the root-cause analysis and to @conchoecia for the additional Claude Desktop context.