### PR TITLE
feat: reset-time display, per-bucket pacing style, and menu-bar colour customisation

### DIFF
--- a/Shared/Components/ResetFormatPicker.swift
+++ b/Shared/Components/ResetFormatPicker.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct ResetFormatPicker: View {
+    @Binding var selection: ResetDisplayFormat
+
+    var body: some View {
+        Picker(String(localized: "settings.reset.format"), selection: $selection) {
+            ForEach(ResetDisplayFormat.allCases) { format in
+                Text(format.localizedLabel).tag(format)
+            }
+        }
+        .pickerStyle(.menu)
+        .font(.system(size: 11))
+    }
+}

--- a/Shared/Helpers/MenuBarRenderer.swift
+++ b/Shared/Helpers/MenuBarRenderer.swift
@@ -10,20 +10,23 @@ enum MenuBarRenderer {
         let weeklyPacingDelta: Int
         let weeklyPacingZone: PacingZone
         let hasWeeklyPacing: Bool
-        let sonnetPacingDelta: Int
-        let sonnetPacingZone: PacingZone
-        let hasSonnetPacing: Bool
         let sessionPacingDelta: Int
         let sessionPacingZone: PacingZone
         let hasSessionPacing: Bool
-        let pacingDisplayMode: PacingDisplayMode
+        let sessionPacingDisplayMode: PacingDisplayMode
+        let weeklyPacingDisplayMode: PacingDisplayMode
         let hasConfig: Bool
         let hasError: Bool
         let themeColors: ThemeColors
         let thresholds: UsageThresholds
         let menuBarMonochrome: Bool
         let fiveHourReset: String
-        let showSessionReset: Bool
+        let fiveHourResetAbsolute: String
+        let fiveHourResetDate: Date?
+        let resetDisplayFormat: ResetDisplayFormat
+        let resetTextColorHex: String
+        let sessionPeriodColorHex: String
+        let smartResetColor: Bool
     }
 
     private static var cachedImage: NSImage?
@@ -34,16 +37,20 @@ enum MenuBarRenderer {
             return cached
         }
 
-        let image: NSImage
-        if !data.hasConfig || data.hasError {
-            image = renderLogoTemplate()
-        } else {
-            image = renderPinnedMetrics(data)
-        }
-
+        let image = renderUncached(data)
         cachedImage = image
         cachedData = data
         return image
+    }
+
+    /// Same rendering pipeline as `render(_:)` but never touches or updates
+    /// the static cache. Useful for live previews that may differ from the
+    /// status bar's current state and shouldn't poison it.
+    static func renderUncached(_ data: RenderData) -> NSImage {
+        if !data.hasConfig || data.hasError {
+            return renderLogoTemplate()
+        }
+        return renderPinnedMetrics(data)
     }
 
     // MARK: - Color helpers
@@ -58,30 +65,71 @@ enum MenuBarRenderer {
         return data.themeColors.pacingNSColor(for: zone)
     }
 
+    private static func periodColor(_ data: RenderData) -> NSColor {
+        data.menuBarMonochrome
+            ? NSColor.tertiaryLabelColor
+            : MenuBarTextColorResolver.resolve(
+                hex: data.sessionPeriodColorHex,
+                fallback: .tertiaryLabelColor
+            )
+    }
+
+    /// Reset countdown text color. Honors the Themes setting priority:
+    ///   1. monochrome: always system label;
+    ///   2. smart mode: risk-based (green/orange/red) using the same 3
+    ///      gauge colors so it visually agrees with the session ring;
+    ///   3. static: user-picked hex, falling back to the system label.
+    private static func resetValueColor(_ data: RenderData) -> NSColor {
+        if data.menuBarMonochrome { return NSColor.labelColor }
+        if data.smartResetColor, let reset = data.fiveHourResetDate {
+            return smartResetNSColor(
+                utilization: Double(data.fiveHourPct),
+                resetDate: reset,
+                themeColors: data.themeColors
+            )
+        }
+        return MenuBarTextColorResolver.resolve(
+            hex: data.resetTextColorHex,
+            fallback: .labelColor
+        )
+    }
+
+    /// Risk = utilization * remaining_minutes / 100. Thresholds mirror the
+    /// static gauge boundaries so the reset color lines up visually with the
+    /// 5-hour gauge elsewhere in the app.
+    private static func smartResetNSColor(
+        utilization: Double,
+        resetDate: Date,
+        themeColors: ThemeColors,
+        now: Date = Date()
+    ) -> NSColor {
+        let remainingMinutes = max(resetDate.timeIntervalSince(now), 0) / 60
+        let risk = utilization * remainingMinutes / 100
+        if risk > 100 { return themeColors.gaugeNSColor(for: 100, thresholds: .default) }
+        if risk > 70 { return themeColors.gaugeNSColor(for: 75, thresholds: .default) }
+        return themeColors.gaugeNSColor(for: 10, thresholds: .default)
+    }
+
     // MARK: - Rendering
 
     private static func renderPinnedMetrics(_ data: RenderData) -> NSImage {
         let height: CGFloat = 22
         let str = NSMutableAttributedString()
 
-        let labelAttrs: [NSAttributedString.Key: Any] = [
-            .font: NSFont.systemFont(ofSize: 9, weight: .medium),
-            .foregroundColor: NSColor.tertiaryLabelColor,
-        ]
         let sepAttrs: [NSAttributedString.Key: Any] = [
             .font: NSFont.systemFont(ofSize: 10, weight: .regular),
             .foregroundColor: NSColor.tertiaryLabelColor,
         ]
 
         let ordered: [MetricID] = [
-            .fiveHour, .sessionPacing, .sevenDay, .weeklyPacing, .sonnet, .sonnetPacing
+            .sessionReset, .fiveHour, .sessionPacing, .sevenDay, .weeklyPacing, .sonnet
         ].filter {
             guard data.pinnedMetrics.contains($0) else { return false }
-            if !data.displaySonnet && ($0 == .sonnet || $0 == .sonnetPacing) { return false }
+            if !data.displaySonnet && $0 == .sonnet { return false }
             switch $0 {
+            case .sessionReset: return !data.fiveHourReset.isEmpty || !data.fiveHourResetAbsolute.isEmpty
             case .sessionPacing: return data.hasSessionPacing
             case .weeklyPacing: return data.hasWeeklyPacing
-            case .sonnetPacing: return data.hasSonnetPacing
             default: return true
             }
         }
@@ -90,11 +138,14 @@ enum MenuBarRenderer {
                 str.append(NSAttributedString(string: "  ", attributes: sepAttrs))
             }
             switch metric {
+            case .sessionReset:
+                appendSessionReset(to: str, data: data)
             case .sessionPacing:
                 appendPacing(
                     to: str,
                     delta: data.sessionPacingDelta,
                     zone: data.sessionPacingZone,
+                    mode: data.sessionPacingDisplayMode,
                     data: data
                 )
             case .weeklyPacing:
@@ -102,13 +153,7 @@ enum MenuBarRenderer {
                     to: str,
                     delta: data.weeklyPacingDelta,
                     zone: data.weeklyPacingZone,
-                    data: data
-                )
-            case .sonnetPacing:
-                appendPacing(
-                    to: str,
-                    delta: data.sonnetPacingDelta,
-                    zone: data.sonnetPacingZone,
+                    mode: data.weeklyPacingDisplayMode,
                     data: data
                 )
             case .fiveHour, .sevenDay, .sonnet:
@@ -119,20 +164,11 @@ enum MenuBarRenderer {
                 case .sonnet: value = data.sonnetPct
                 default: value = 0
                 }
-                if metric == .fiveHour && data.showSessionReset && !data.fiveHourReset.isEmpty {
-                    let resetLabelAttrs: [NSAttributedString.Key: Any] = [
-                        .font: NSFont.monospacedDigitSystemFont(ofSize: 9, weight: .medium),
-                        .foregroundColor: NSColor.tertiaryLabelColor,
-                    ]
-                    let resetValueAttrs: [NSAttributedString.Key: Any] = [
-                        .font: NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .bold),
-                        .foregroundColor: NSColor.labelColor,
-                    ]
-                    str.append(NSAttributedString(string: "5h ", attributes: resetLabelAttrs))
-                    str.append(NSAttributedString(string: data.fiveHourReset, attributes: resetValueAttrs))
-                    str.append(NSAttributedString(string: "  ", attributes: labelAttrs))
-                }
-                str.append(NSAttributedString(string: "\(metric.shortLabel) ", attributes: labelAttrs))
+                let periodLabelAttrs: [NSAttributedString.Key: Any] = [
+                    .font: NSFont.systemFont(ofSize: 9, weight: .medium),
+                    .foregroundColor: periodColor(data),
+                ]
+                str.append(NSAttributedString(string: "\(metric.shortLabel) ", attributes: periodLabelAttrs))
                 let pctAttrs: [NSAttributedString.Key: Any] = [
                     .font: NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .bold),
                     .foregroundColor: colorForPct(value, data: data),
@@ -151,10 +187,36 @@ enum MenuBarRenderer {
         return img
     }
 
+    private static func appendSessionReset(to str: NSMutableAttributedString, data: RenderData) {
+        let text = resetDisplayText(data: data)
+        guard !text.isEmpty else { return }
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .bold),
+            .foregroundColor: resetValueColor(data),
+        ]
+        str.append(NSAttributedString(string: text, attributes: attrs))
+    }
+
+    private static func resetDisplayText(data: RenderData) -> String {
+        let relative = data.fiveHourReset
+        let absolute = data.fiveHourResetAbsolute
+        switch data.resetDisplayFormat {
+        case .relative:
+            return relative
+        case .absolute:
+            return absolute
+        case .both:
+            if relative.isEmpty { return absolute }
+            if absolute.isEmpty { return relative }
+            return "\(relative) - \(absolute)"
+        }
+    }
+
     private static func appendPacing(
         to str: NSMutableAttributedString,
         delta: Int,
         zone: PacingZone,
+        mode: PacingDisplayMode,
         data: RenderData
     ) {
         let dotColor = colorForZone(zone, data: data)
@@ -167,7 +229,7 @@ enum MenuBarRenderer {
             .foregroundColor: dotColor,
         ]
         let sign = delta >= 0 ? "+" : ""
-        switch data.pacingDisplayMode {
+        switch mode {
         case .dot:
             str.append(NSAttributedString(string: "\u{25CF}", attributes: dotAttrs))
         case .dotDelta:

--- a/Shared/Models/MenuBarTextColor.swift
+++ b/Shared/Models/MenuBarTextColor.swift
@@ -1,0 +1,53 @@
+import AppKit
+import Foundation
+
+/// Utilities for resolving user-picked hex strings to NSColors for the
+/// menu bar. We store colours as hex strings in SettingsStore (a single
+/// source of truth with the rest of the theming code). An empty string
+/// means "use the system default" - rendered as the caller's fallback.
+enum MenuBarTextColorResolver {
+    /// Resolves `hex` to an NSColor, falling back to `defaultColor` when
+    /// the hex is empty / malformed.
+    static func resolve(hex: String, fallback defaultColor: NSColor) -> NSColor {
+        let trimmed = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let color = NSColor.fromHex(trimmed) else {
+            return defaultColor
+        }
+        return color
+    }
+}
+
+extension NSColor {
+    /// Parses "#RRGGBB" / "RRGGBB" / "#RGB" / "RGB" into an NSColor.
+    /// Returns nil for anything that isn't exactly 3 or 6 hex digits.
+    static func fromHex(_ hex: String) -> NSColor? {
+        var cleaned = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if cleaned.hasPrefix("#") { cleaned.removeFirst() }
+
+        switch cleaned.count {
+        case 3:
+            cleaned = cleaned.map { "\($0)\($0)" }.joined()
+        case 6:
+            break
+        default:
+            return nil
+        }
+
+        var value: UInt64 = 0
+        guard Scanner(string: cleaned).scanHexInt64(&value) else { return nil }
+
+        let r = CGFloat((value >> 16) & 0xFF) / 255
+        let g = CGFloat((value >> 8) & 0xFF) / 255
+        let b = CGFloat(value & 0xFF) / 255
+        return NSColor(srgbRed: r, green: g, blue: b, alpha: 1)
+    }
+
+    /// Converts this color to a "#RRGGBB" string using sRGB components.
+    func hexString() -> String {
+        let c = usingColorSpace(.sRGB) ?? self
+        let r = Int((c.redComponent * 255).rounded())
+        let g = Int((c.greenComponent * 255).rounded())
+        let b = Int((c.blueComponent * 255).rounded())
+        return String(format: "#%02X%02X%02X", r, g, b)
+    }
+}

--- a/Shared/Models/MetricModels.swift
+++ b/Shared/Models/MetricModels.swift
@@ -2,31 +2,31 @@ import Foundation
 
 enum MetricID: String, CaseIterable {
     case fiveHour = "fiveHour"
+    case sessionReset = "sessionReset"
     case sevenDay = "sevenDay"
     case sonnet = "sonnet"
     case sessionPacing = "sessionPacing"
     case weeklyPacing = "weeklyPacing"
-    case sonnetPacing = "sonnetPacing"
 
     var label: String {
         switch self {
         case .fiveHour: return String(localized: "metric.session")
+        case .sessionReset: return String(localized: "metric.sessionReset")
         case .sevenDay: return String(localized: "metric.weekly")
         case .sonnet: return String(localized: "metric.sonnet")
         case .sessionPacing: return String(localized: "pacing.session.label")
         case .weeklyPacing: return String(localized: "pacing.weekly.label")
-        case .sonnetPacing: return String(localized: "pacing.sonnet.label")
         }
     }
 
     var shortLabel: String {
         switch self {
         case .fiveHour: return "5h"
+        case .sessionReset: return ""
         case .sevenDay: return "7d"
         case .sonnet: return "S"
         case .sessionPacing: return "5hP"
         case .weeklyPacing: return "7dP"
-        case .sonnetPacing: return "SP"
         }
     }
 }

--- a/Shared/Models/ResetDisplayFormat.swift
+++ b/Shared/Models/ResetDisplayFormat.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum ResetDisplayFormat: String, CaseIterable, Identifiable {
+    case relative   // "1h 39min"
+    case absolute   // "20:30" today, "Fri 08:00" other days
+    case both       // "1h 39min - 20:30"
+
+    var id: String { rawValue }
+
+    var localizedLabel: String {
+        switch self {
+        case .relative: return String(localized: "settings.reset.format.relative")
+        case .absolute: return String(localized: "settings.reset.format.absolute")
+        case .both: return String(localized: "settings.reset.format.both")
+        }
+    }
+}

--- a/Shared/Stores/SettingsStore.swift
+++ b/Shared/Stores/SettingsStore.swift
@@ -10,11 +10,30 @@ final class SettingsStore: ObservableObject {
     @Published var pinnedMetrics: Set<MetricID> {
         didSet { savePinnedMetrics() }
     }
-    @Published var pacingDisplayMode: PacingDisplayMode {
-        didSet { UserDefaults.standard.set(pacingDisplayMode.rawValue, forKey: "pacingDisplayMode") }
+    @Published var resetDisplayFormat: ResetDisplayFormat {
+        didSet { UserDefaults.standard.set(resetDisplayFormat.rawValue, forKey: "resetDisplayFormat") }
     }
-    @Published var showSessionReset: Bool {
-        didSet { UserDefaults.standard.set(showSessionReset, forKey: "showSessionReset") }
+    /// When true, the reset countdown text is coloured based on a risk score
+    /// (utilization x remaining minutes) rather than the static user-picked
+    /// hex. Useful to signal urgency without constantly watching the number.
+    @Published var smartResetColor: Bool {
+        didSet { UserDefaults.standard.set(smartResetColor, forKey: "smartResetColor") }
+    }
+    @Published var sessionPacingDisplayMode: PacingDisplayMode {
+        didSet { UserDefaults.standard.set(sessionPacingDisplayMode.rawValue, forKey: "sessionPacingDisplayMode") }
+    }
+    @Published var weeklyPacingDisplayMode: PacingDisplayMode {
+        didSet { UserDefaults.standard.set(weeklyPacingDisplayMode.rawValue, forKey: "weeklyPacingDisplayMode") }
+    }
+    /// Hex string ("#RRGGBB") for the menu-bar reset countdown text.
+    /// Empty = use the system's primary label color.
+    @Published var resetTextColorHex: String {
+        didSet { UserDefaults.standard.set(resetTextColorHex, forKey: "resetTextColorHex") }
+    }
+    /// Hex string ("#RRGGBB") for the "5h" / "7d" / "S" period label.
+    /// Empty = use the system's tertiary label color.
+    @Published var sessionPeriodColorHex: String {
+        didSet { UserDefaults.standard.set(sessionPeriodColorHex, forKey: "sessionPeriodColorHex") }
     }
     @Published var displaySonnet: Bool {
         didSet {
@@ -22,7 +41,7 @@ final class SettingsStore: ObservableObject {
             if !displaySonnet {
                 // Drop any sonnet-related pins so the menu bar does not keep
                 // a stale reference to a hidden metric.
-                pinnedMetrics.subtract([.sonnet, .sonnetPacing])
+                pinnedMetrics.remove(.sonnet)
             }
         }
     }
@@ -134,14 +153,6 @@ final class SettingsStore: ObservableObject {
         }
     }
 
-    var showSonnetPacing: Bool {
-        get { pinnedMetrics.contains(.sonnetPacing) }
-        set {
-            if newValue { pinnedMetrics.insert(.sonnetPacing) }
-            else if pinnedMetrics.count > 1 { pinnedMetrics.remove(.sonnetPacing) }
-        }
-    }
-
     // Notifications
     @Published var notificationStatus: UNAuthorizationStatus = .notDetermined
 
@@ -197,22 +208,45 @@ final class SettingsStore: ObservableObject {
             let val = UserDefaults.standard.integer(forKey: "refreshInterval")
             return val >= 180 ? val : 300
         }()
-        self.pacingDisplayMode = PacingDisplayMode(
+        self.resetDisplayFormat = ResetDisplayFormat(
+            rawValue: UserDefaults.standard.string(forKey: "resetDisplayFormat") ?? "relative"
+        ) ?? .relative
+        self.resetTextColorHex = UserDefaults.standard.string(forKey: "resetTextColorHex") ?? ""
+        self.sessionPeriodColorHex = UserDefaults.standard.string(forKey: "sessionPeriodColorHex") ?? ""
+        self.smartResetColor = UserDefaults.standard.bool(forKey: "smartResetColor")
+
+        // Migrate the legacy global `pacingDisplayMode` into the two per-bucket
+        // settings so existing users keep the mode they had. If either per-bucket
+        // value has been saved before, prefer it.
+        let legacyMode = PacingDisplayMode(
             rawValue: UserDefaults.standard.string(forKey: "pacingDisplayMode") ?? "dotDelta"
         ) ?? .dotDelta
-        self.showSessionReset = UserDefaults.standard.bool(forKey: "showSessionReset")
+        self.sessionPacingDisplayMode = PacingDisplayMode(
+            rawValue: UserDefaults.standard.string(forKey: "sessionPacingDisplayMode") ?? legacyMode.rawValue
+        ) ?? legacyMode
+        self.weeklyPacingDisplayMode = PacingDisplayMode(
+            rawValue: UserDefaults.standard.string(forKey: "weeklyPacingDisplayMode") ?? legacyMode.rawValue
+        ) ?? legacyMode
         self.helperSyncInterval = {
             let raw = UserDefaults.standard.integer(forKey: "helperSyncInterval")
             return raw >= 30 ? raw : Int(HelperManagerService.defaultSyncInterval)
         }()
         self.helperStatus = helperManager.currentStatus()
-        let legacyPinned: Set<MetricID>
+        var legacyPinned: Set<MetricID>
         if let saved = UserDefaults.standard.stringArray(forKey: "pinnedMetrics") {
             // Migrate legacy "pacing" (covered weekly only) to the explicit weeklyPacing id.
             let normalized = saved.map { $0 == "pacing" ? "weeklyPacing" : $0 }
             legacyPinned = Set(normalized.compactMap { MetricID(rawValue: $0) })
         } else {
             legacyPinned = [.fiveHour, .sevenDay]
+        }
+
+        // Migrate the old `showSessionReset` boolean into the new `.sessionReset`
+        // pinnable metric so existing users keep seeing the countdown they opted
+        // in to. The boolean itself is removed below.
+        if UserDefaults.standard.object(forKey: "showSessionReset") != nil,
+           UserDefaults.standard.bool(forKey: "showSessionReset") {
+            legacyPinned.insert(.sessionReset)
         }
         self.pinnedMetrics = legacyPinned
 

--- a/Shared/Stores/UsageStore.swift
+++ b/Shared/Stores/UsageStore.swift
@@ -12,6 +12,7 @@ final class UsageStore: ObservableObject {
     @Published var sevenDayPct: Int = 0
     @Published var sonnetPct: Int = 0
     @Published var fiveHourReset: String = ""
+    @Published var fiveHourResetAbsolute: String = ""
     @Published var pacingDelta: Int = 0
     @Published var pacingZone: PacingZone = .onTrack
     @Published var pacingResult: PacingResult?
@@ -310,16 +311,35 @@ final class UsageStore: ObservableObject {
     func refreshResetCountdown() {
         guard let reset = lastUsage?.fiveHour?.resetsAtDate else {
             fiveHourReset = ""
+            fiveHourResetAbsolute = ""
             return
         }
         let diff = reset.timeIntervalSinceNow
         if diff > 0 {
             let h = Int(diff) / 3600
             let m = (Int(diff) % 3600) / 60
-            fiveHourReset = h > 0 ? "\(h)h \(m)min" : "\(m)min"
+            // Clock-style format: "1h25" when hours are present, "25min" otherwise.
+            // The 2-digit padding keeps the width stable as minutes drain.
+            fiveHourReset = h > 0 ? "\(h)h\(String(format: "%02d", m))" : "\(m)min"
+            fiveHourResetAbsolute = Self.formatAbsoluteReset(reset)
         } else {
             fiveHourReset = String(localized: "relative.now")
+            fiveHourResetAbsolute = ""
         }
+    }
+
+    /// "20:30" when the reset is today, "Fri 08:00" otherwise. 24h time
+    /// because the menu bar has no room for AM/PM and seconds never help.
+    static func formatAbsoluteReset(_ date: Date, now: Date = Date()) -> String {
+        let calendar = Calendar.current
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        if calendar.isDate(date, inSameDayAs: now) {
+            formatter.dateFormat = "HH:mm"
+        } else {
+            formatter.dateFormat = "EEE HH:mm"
+        }
+        return formatter.string(from: date)
     }
 
     func recalculatePacing() {

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -8,6 +8,11 @@
 
 /* Metrics */
 "metric.session" = "Session 5h";
+"metric.sessionReset" = "Session reset countdown";
+"settings.pacing.style" = "Pacing style";
+"settings.group.session" = "Session (5h)";
+"settings.group.weekly" = "Weekly";
+"settings.group.sonnet" = "Sonnet";
 "metric.weekly" = "Weekly";
 "metric.sonnet" = "Sonnet";
 "metric.reset" = "reset %@";
@@ -272,6 +277,19 @@
 
 /* Settings - Onboarding reset */
 "settings.onboarding.reset" = "Run setup again";
+
+/* Reset time display + menu-bar colors */
+"settings.reset.format" = "Reset display";
+"settings.reset.format.relative" = "Relative (1h39)";
+"settings.reset.format.absolute" = "Absolute (20:30)";
+"settings.reset.format.both" = "Both";
+"settings.reset.color" = "Reset countdown";
+"settings.session.periodcolor" = "Period label (5h / 7d)";
+"settings.theme.menubar" = "Menu bar text";
+"settings.theme.menubar.hint" = "Customize the color of the reset countdown and period labels in the menu bar. Leave on system defaults if you want TokenEater to match your menu bar styling.";
+"settings.theme.menubar.resetColor" = "Revert to system default";
+"settings.theme.smartreset" = "Smart color for reset countdown";
+"settings.theme.smartreset.hint" = "Colour the reset countdown based on urgency (gauge colors): green when you have headroom, orange / red when usage is high relative to time remaining. Overrides the manual color above while on.";
 
 /* Update */
 "update.check" = "Check for updates";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -8,6 +8,11 @@
 
 /* Metrics */
 "metric.session" = "Session 5h";
+"metric.sessionReset" = "Compte à rebours de session";
+"settings.pacing.style" = "Style du pacing";
+"settings.group.session" = "Session (5h)";
+"settings.group.weekly" = "Weekly";
+"settings.group.sonnet" = "Sonnet";
 "metric.weekly" = "Hebdo";
 "metric.sonnet" = "Sonnet";
 "metric.reset" = "reset %@";
@@ -272,6 +277,19 @@
 
 /* Settings - Onboarding reset */
 "settings.onboarding.reset" = "Relancer la configuration";
+
+/* Affichage du reset + couleurs menu bar */
+"settings.reset.format" = "Affichage du reset";
+"settings.reset.format.relative" = "Relatif (1h39)";
+"settings.reset.format.absolute" = "Absolu (20:30)";
+"settings.reset.format.both" = "Les deux";
+"settings.reset.color" = "Compte à rebours";
+"settings.session.periodcolor" = "Libellé de période (5h / 7d)";
+"settings.theme.menubar" = "Texte de la barre de menu";
+"settings.theme.menubar.hint" = "Personnalisez la couleur du compte à rebours et des libellés de période. Laissez vide pour que TokenEater utilise les couleurs par défaut du système.";
+"settings.theme.menubar.resetColor" = "Rétablir la valeur par défaut";
+"settings.theme.smartreset" = "Couleur intelligente du reset";
+"settings.theme.smartreset.hint" = "Colorise le compte à rebours selon l'urgence (couleurs du gauge) : vert quand tu as de la marge, orange / rouge quand l'usage est élevé vs le temps restant. Override la couleur manuelle ci-dessus quand activé.";
 
 /* Update */
 "update.check" = "Vérifier les mises à jour";

--- a/TokenEaterApp/DashboardView.swift
+++ b/TokenEaterApp/DashboardView.swift
@@ -122,13 +122,6 @@ struct DashboardView: View {
                     showMessage: true
                 )
             }
-            if settingsStore.displaySonnet, let pacing = usageStore.sonnetPacing {
-                pacingCard(
-                    pacing: pacing,
-                    label: PacingBucket.sonnet.metricID.label,
-                    showMessage: false
-                )
-            }
 
             Spacer()
         }

--- a/TokenEaterApp/DisplaySectionView.swift
+++ b/TokenEaterApp/DisplaySectionView.swift
@@ -9,55 +9,92 @@ struct DisplaySectionView: View {
     // unstable LocationProjections that the AttributeGraph can never
     // memoize, causing an infinite re-evaluation loop in Release builds.
     @State private var showFiveHour: Bool
-    @State private var showSevenDay: Bool
-    @State private var showSonnet: Bool
+    @State private var showSessionReset: Bool
     @State private var showSessionPacing: Bool
+    @State private var showSevenDay: Bool
     @State private var showWeeklyPacing: Bool
-    @State private var showSonnetPacing: Bool
+    @State private var showSonnet: Bool
 
     init(initialMetrics: Set<MetricID>) {
         _showFiveHour = State(initialValue: initialMetrics.contains(.fiveHour))
-        _showSevenDay = State(initialValue: initialMetrics.contains(.sevenDay))
-        _showSonnet = State(initialValue: initialMetrics.contains(.sonnet))
+        _showSessionReset = State(initialValue: initialMetrics.contains(.sessionReset))
         _showSessionPacing = State(initialValue: initialMetrics.contains(.sessionPacing))
+        _showSevenDay = State(initialValue: initialMetrics.contains(.sevenDay))
         _showWeeklyPacing = State(initialValue: initialMetrics.contains(.weeklyPacing))
-        _showSonnetPacing = State(initialValue: initialMetrics.contains(.sonnetPacing))
+        _showSonnet = State(initialValue: initialMetrics.contains(.sonnet))
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             sectionTitle(String(localized: "sidebar.display"))
 
-            // Menu Bar
+            // 1. Menu bar visibility
             glassCard {
-                VStack(alignment: .leading, spacing: 8) {
-                    cardLabel(String(localized: "settings.menubar.title"))
-                    darkToggle(String(localized: "settings.menubar.toggle"), isOn: $settingsStore.showMenuBar)
-                    darkToggle(String(localized: "settings.theme.monochrome"), isOn: $themeStore.menuBarMonochrome)
-                    darkToggle(String(localized: "settings.display.sonnet"), isOn: $settingsStore.displaySonnet)
+                darkToggle(String(localized: "settings.menubar.toggle"), isOn: $settingsStore.showMenuBar)
+            }
+
+            // 2. Pinned metrics live preview
+            glassCard {
+                VStack(alignment: .leading, spacing: 10) {
+                    cardLabel(String(localized: "settings.metrics.pinned"))
+                    menuBarPreview
                 }
             }
 
-            // Pinned Metrics
+            // 3. Session (5h)
             glassCard {
-                VStack(alignment: .leading, spacing: 8) {
-                    cardLabel(String(localized: "settings.metrics.pinned"))
+                VStack(alignment: .leading, spacing: 10) {
+                    cardLabel(String(localized: "settings.group.session"))
                     darkToggle(String(localized: "metric.session"), isOn: $showFiveHour)
-                    if showFiveHour {
-                        darkToggle(String(localized: "settings.session.reset"), isOn: $settingsStore.showSessionReset)
+                    toggleWithTrailing(
+                        label: String(localized: "metric.sessionReset"),
+                        isOn: $showSessionReset
+                    ) {
+                        if showSessionReset {
+                            ResetFormatPicker(selection: $settingsStore.resetDisplayFormat)
+                                .labelsHidden()
+                                .frame(maxWidth: 160)
+                        }
                     }
+                    toggleWithTrailing(
+                        label: String(localized: "pacing.session.label"),
+                        isOn: $showSessionPacing
+                    ) {
+                        if showSessionPacing {
+                            PacingDisplayPicker(selection: $settingsStore.sessionPacingDisplayMode)
+                                .labelsHidden()
+                                .frame(maxWidth: 160)
+                        }
+                    }
+                }
+            }
+
+            // 4. Weekly
+            glassCard {
+                VStack(alignment: .leading, spacing: 10) {
+                    cardLabel(String(localized: "settings.group.weekly"))
                     darkToggle(String(localized: "metric.weekly"), isOn: $showSevenDay)
+                    toggleWithTrailing(
+                        label: String(localized: "pacing.weekly.label"),
+                        isOn: $showWeeklyPacing
+                    ) {
+                        if showWeeklyPacing {
+                            PacingDisplayPicker(selection: $settingsStore.weeklyPacingDisplayMode)
+                                .labelsHidden()
+                                .frame(maxWidth: 160)
+                        }
+                    }
+                }
+            }
+
+            // 5. Sonnet
+            glassCard {
+                VStack(alignment: .leading, spacing: 10) {
+                    cardLabel(String(localized: "settings.group.sonnet"))
+                    darkToggle(String(localized: "settings.display.sonnet"), isOn: $settingsStore.displaySonnet)
                     if settingsStore.displaySonnet {
                         darkToggle(String(localized: "metric.sonnet"), isOn: $showSonnet)
-                    }
-                    darkToggle(String(localized: "pacing.session.label"), isOn: $showSessionPacing)
-                    darkToggle(String(localized: "pacing.weekly.label"), isOn: $showWeeklyPacing)
-                    if settingsStore.displaySonnet {
-                        darkToggle(String(localized: "pacing.sonnet.label"), isOn: $showSonnetPacing)
-                    }
-                    if showSessionPacing || showWeeklyPacing || (settingsStore.displaySonnet && showSonnetPacing) {
-                        PacingDisplayPicker(selection: $settingsStore.pacingDisplayMode)
-                            .padding(.leading, 8)
+                            .padding(.leading, 20)
                     }
                 }
             }
@@ -67,38 +104,106 @@ struct DisplaySectionView: View {
         .padding(24)
         // Sync: local toggle -> store (with at-least-one guard)
         .onChange(of: showFiveHour) { _, new in syncMetric(.fiveHour, on: new, revert: { showFiveHour = true }) }
-        .onChange(of: showSevenDay) { _, new in syncMetric(.sevenDay, on: new, revert: { showSevenDay = true }) }
-        .onChange(of: showSonnet) { _, new in syncMetric(.sonnet, on: new, revert: { showSonnet = true }) }
+        .onChange(of: showSessionReset) { _, new in
+            withAnimation(.easeInOut(duration: 0.2)) {
+                syncMetric(.sessionReset, on: new, revert: { showSessionReset = true })
+            }
+        }
         .onChange(of: showSessionPacing) { _, new in
             withAnimation(.easeInOut(duration: 0.2)) {
                 syncMetric(.sessionPacing, on: new, revert: { showSessionPacing = true })
             }
         }
+        .onChange(of: showSevenDay) { _, new in syncMetric(.sevenDay, on: new, revert: { showSevenDay = true }) }
         .onChange(of: showWeeklyPacing) { _, new in
             withAnimation(.easeInOut(duration: 0.2)) {
                 syncMetric(.weeklyPacing, on: new, revert: { showWeeklyPacing = true })
             }
         }
-        .onChange(of: showSonnetPacing) { _, new in
-            withAnimation(.easeInOut(duration: 0.2)) {
-                syncMetric(.sonnetPacing, on: new, revert: { showSonnetPacing = true })
-            }
-        }
-        // Sync: store -> local toggles (for external changes, e.g. from MenuBar popover)
+        .onChange(of: showSonnet) { _, new in syncMetric(.sonnet, on: new, revert: { showSonnet = true }) }
+        // Sync: store -> local toggles (external changes, e.g. pin/unpin from popover)
         .onChange(of: settingsStore.pinnedMetrics) { _, metrics in
             if showFiveHour != metrics.contains(.fiveHour) { showFiveHour = metrics.contains(.fiveHour) }
-            if showSevenDay != metrics.contains(.sevenDay) { showSevenDay = metrics.contains(.sevenDay) }
-            if showSonnet != metrics.contains(.sonnet) { showSonnet = metrics.contains(.sonnet) }
+            if showSessionReset != metrics.contains(.sessionReset) {
+                withAnimation(.easeInOut(duration: 0.2)) { showSessionReset = metrics.contains(.sessionReset) }
+            }
             if showSessionPacing != metrics.contains(.sessionPacing) {
                 withAnimation(.easeInOut(duration: 0.2)) { showSessionPacing = metrics.contains(.sessionPacing) }
             }
+            if showSevenDay != metrics.contains(.sevenDay) { showSevenDay = metrics.contains(.sevenDay) }
             if showWeeklyPacing != metrics.contains(.weeklyPacing) {
                 withAnimation(.easeInOut(duration: 0.2)) { showWeeklyPacing = metrics.contains(.weeklyPacing) }
             }
-            if showSonnetPacing != metrics.contains(.sonnetPacing) {
-                withAnimation(.easeInOut(duration: 0.2)) { showSonnetPacing = metrics.contains(.sonnetPacing) }
-            }
+            if showSonnet != metrics.contains(.sonnet) { showSonnet = metrics.contains(.sonnet) }
         }
+    }
+
+    // MARK: - Components
+
+    private func toggleWithTrailing<Trailing: View>(
+        label: String,
+        isOn: Binding<Bool>,
+        @ViewBuilder trailing: () -> Trailing
+    ) -> some View {
+        HStack {
+            Toggle("", isOn: isOn)
+                .toggleStyle(.switch)
+                .tint(.blue)
+                .labelsHidden()
+            Text(label)
+                .font(.system(size: 13))
+                .foregroundStyle(.white.opacity(0.8))
+            Spacer()
+            trailing()
+        }
+    }
+
+    private var menuBarPreview: some View {
+        let image = MenuBarRenderer.renderUncached(previewData)
+        return Image(nsImage: image)
+            .interpolation(.high)
+            .frame(height: 22)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, 10)
+            .padding(.horizontal, 12)
+            .background(
+                ZStack {
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(Color.black.opacity(0.45))
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(.white.opacity(0.08), lineWidth: 1)
+                }
+            )
+    }
+
+    private var previewData: MenuBarRenderer.RenderData {
+        MenuBarRenderer.RenderData(
+            pinnedMetrics: settingsStore.pinnedMetrics,
+            displaySonnet: settingsStore.displaySonnet,
+            fiveHourPct: 45,
+            sevenDayPct: 72,
+            sonnetPct: 30,
+            weeklyPacingDelta: 2,
+            weeklyPacingZone: .onTrack,
+            hasWeeklyPacing: true,
+            sessionPacingDelta: -15,
+            sessionPacingZone: .chill,
+            hasSessionPacing: true,
+            sessionPacingDisplayMode: settingsStore.sessionPacingDisplayMode,
+            weeklyPacingDisplayMode: settingsStore.weeklyPacingDisplayMode,
+            hasConfig: true,
+            hasError: false,
+            themeColors: themeStore.current,
+            thresholds: themeStore.thresholds,
+            menuBarMonochrome: themeStore.menuBarMonochrome,
+            fiveHourReset: "1h58",
+            fiveHourResetAbsolute: "20:30",
+            fiveHourResetDate: Date().addingTimeInterval(1 * 3600 + 58 * 60),
+            resetDisplayFormat: settingsStore.resetDisplayFormat,
+            resetTextColorHex: settingsStore.resetTextColorHex,
+            sessionPeriodColorHex: settingsStore.sessionPeriodColorHex,
+            smartResetColor: settingsStore.smartResetColor
+        )
     }
 
     private func syncMetric(_ metric: MetricID, on: Bool, revert: @escaping () -> Void) {

--- a/TokenEaterApp/MenuBarView.swift
+++ b/TokenEaterApp/MenuBarView.swift
@@ -59,9 +59,7 @@ struct MenuBarPopoverView: View {
             }
 
             // Pacing rows - compact stack, each row owns its own pin.
-            if usageStore.fiveHourPacing != nil
-                || usageStore.pacingResult != nil
-                || (settingsStore.displaySonnet && usageStore.sonnetPacing != nil) {
+            if usageStore.fiveHourPacing != nil || usageStore.pacingResult != nil {
                 VStack(spacing: 12) {
                     if let pacing = usageStore.fiveHourPacing {
                         pacingRow(
@@ -74,13 +72,6 @@ struct MenuBarPopoverView: View {
                         pacingRow(
                             metric: .weeklyPacing,
                             label: String(localized: "pacing.weekly.label"),
-                            pacing: pacing
-                        )
-                    }
-                    if settingsStore.displaySonnet, let pacing = usageStore.sonnetPacing {
-                        pacingRow(
-                            metric: .sonnetPacing,
-                            label: String(localized: "pacing.sonnet.label"),
                             pacing: pacing
                         )
                     }
@@ -227,7 +218,7 @@ struct MenuBarPopoverView: View {
                 id: .fiveHour,
                 label: String(localized: "metric.session"),
                 pct: usageStore.fiveHourPct,
-                showSessionReset: settingsStore.showSessionReset
+                showSessionReset: settingsStore.pinnedMetrics.contains(.sessionReset)
             )
             equalRingItem(
                 id: .sevenDay,

--- a/TokenEaterApp/StatusBarController.swift
+++ b/TokenEaterApp/StatusBarController.swift
@@ -91,7 +91,8 @@ final class StatusBarController: NSObject {
 
         Timer.publish(every: 60, on: .main, in: .common).autoconnect()
             .sink { [weak self] _ in
-                guard let self, self.settingsStore.showSessionReset else { return }
+                guard let self,
+                      self.settingsStore.pinnedMetrics.contains(.sessionReset) else { return }
                 self.usageStore.refreshResetCountdown()
             }
             .store(in: &cancellables)
@@ -208,20 +209,23 @@ final class StatusBarController: NSObject {
             weeklyPacingDelta: Int(usageStore.pacingResult?.delta ?? 0),
             weeklyPacingZone: usageStore.pacingResult?.zone ?? .onTrack,
             hasWeeklyPacing: usageStore.pacingResult != nil,
-            sonnetPacingDelta: Int(usageStore.sonnetPacing?.delta ?? 0),
-            sonnetPacingZone: usageStore.sonnetPacing?.zone ?? .onTrack,
-            hasSonnetPacing: usageStore.sonnetPacing != nil,
             sessionPacingDelta: Int(usageStore.fiveHourPacing?.delta ?? 0),
             sessionPacingZone: usageStore.fiveHourPacing?.zone ?? .onTrack,
             hasSessionPacing: usageStore.fiveHourPacing != nil,
-            pacingDisplayMode: settingsStore.pacingDisplayMode,
+            sessionPacingDisplayMode: settingsStore.sessionPacingDisplayMode,
+            weeklyPacingDisplayMode: settingsStore.weeklyPacingDisplayMode,
             hasConfig: usageStore.hasConfig,
             hasError: usageStore.hasError,
             themeColors: themeStore.current,
             thresholds: themeStore.thresholds,
             menuBarMonochrome: themeStore.menuBarMonochrome,
             fiveHourReset: usageStore.fiveHourReset,
-            showSessionReset: settingsStore.showSessionReset
+            fiveHourResetAbsolute: usageStore.fiveHourResetAbsolute,
+            fiveHourResetDate: usageStore.lastUsage?.fiveHour?.resetsAtDate,
+            resetDisplayFormat: settingsStore.resetDisplayFormat,
+            resetTextColorHex: settingsStore.resetTextColorHex,
+            sessionPeriodColorHex: settingsStore.sessionPeriodColorHex,
+            smartResetColor: settingsStore.smartResetColor
         ))
         statusItem.button?.image = image
     }

--- a/TokenEaterApp/ThemesSectionView.swift
+++ b/TokenEaterApp/ThemesSectionView.swift
@@ -20,6 +20,40 @@ struct ThemesSectionView: View {
         VStack(alignment: .leading, spacing: 16) {
             sectionTitle(String(localized: "sidebar.themes"))
 
+            // Menu bar text appearance (monochrome + custom colors + smart reset)
+            glassCard {
+                VStack(alignment: .leading, spacing: 10) {
+                    cardLabel(String(localized: "settings.theme.menubar"))
+                    darkToggle(String(localized: "settings.theme.monochrome"), isOn: $themeStore.menuBarMonochrome)
+                    if !themeStore.menuBarMonochrome {
+                        Divider().opacity(0.15)
+                        menuBarColorRow(
+                            label: "settings.reset.color",
+                            hex: $settingsStore.resetTextColorHex,
+                            fallback: .white,
+                            disabled: settingsStore.smartResetColor
+                        )
+                        VStack(alignment: .leading, spacing: 4) {
+                            darkToggle(
+                                String(localized: "settings.theme.smartreset"),
+                                isOn: $settingsStore.smartResetColor
+                            )
+                            Text(String(localized: "settings.theme.smartreset.hint"))
+                                .font(.system(size: 11))
+                                .foregroundStyle(.white.opacity(0.4))
+                                .fixedSize(horizontal: false, vertical: true)
+                                .padding(.leading, 48)
+                        }
+                        menuBarColorRow(
+                            label: "settings.session.periodcolor",
+                            hex: $settingsStore.sessionPeriodColorHex,
+                            fallback: .white.opacity(0.4),
+                            disabled: false
+                        )
+                    }
+                }
+            }
+
             // Presets
             glassCard {
                 VStack(alignment: .leading, spacing: 12) {
@@ -93,6 +127,12 @@ struct ThemesSectionView: View {
                     Button(String(localized: "settings.theme.reset.cancel"), role: .cancel) { }
                     Button(String(localized: "settings.theme.reset.action"), role: .destructive) {
                         themeStore.resetToDefaults()
+                        // Reset is scoped to the Themes view, so it also clears the
+                        // menu-bar text colors displayed on this page.
+                        settingsStore.resetTextColorHex = ""
+                        settingsStore.sessionPeriodColorHex = ""
+                        settingsStore.smartResetColor = false
+                        themeStore.menuBarMonochrome = false
                     }
                 }
             }
@@ -184,6 +224,47 @@ struct ThemesSectionView: View {
     }
 
     // MARK: - Helpers
+
+    /// Like `themeColorRow` but lets an empty hex fall through to a system
+    /// default color. Shows a revert-to-default button when the user has
+    /// picked a custom color.
+    private func menuBarColorRow(
+        label: LocalizedStringKey,
+        hex: Binding<String>,
+        fallback: Color,
+        disabled: Bool = false
+    ) -> some View {
+        let colorBinding = Binding<Color>(
+            get: {
+                hex.wrappedValue.isEmpty ? fallback : Color(hex: hex.wrappedValue)
+            },
+            set: { newColor in
+                let nsColor = NSColor(newColor).usingColorSpace(.sRGB) ?? NSColor(newColor)
+                hex.wrappedValue = nsColor.hexString()
+            }
+        )
+        return HStack {
+            Text(label)
+                .font(.system(size: 12))
+                .foregroundStyle(.white.opacity(disabled ? 0.35 : 0.7))
+            Spacer()
+            if !hex.wrappedValue.isEmpty && !disabled {
+                Button {
+                    hex.wrappedValue = ""
+                } label: {
+                    Image(systemName: "arrow.uturn.backward.circle.fill")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.white.opacity(0.35))
+                }
+                .buttonStyle(.plain)
+                .help(Text(String(localized: "settings.theme.menubar.resetColor")))
+            }
+            ColorPicker("", selection: colorBinding, supportsOpacity: false)
+                .labelsHidden()
+                .disabled(disabled)
+                .opacity(disabled ? 0.4 : 1)
+        }
+    }
 
     private func themeColorRow(_ labelKey: LocalizedStringKey, hex: Binding<String>) -> some View {
         let colorBinding = Binding<Color>(

--- a/TokenEaterTests/Mocks/MockKeychainHelperReader.swift
+++ b/TokenEaterTests/Mocks/MockKeychainHelperReader.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+final class MockKeychainHelperReader: KeychainHelperReaderProtocol, @unchecked Sendable {
+    var token: String?
+    var syncDate: Date?
+    var errorMessage: String?
+
+    func readToken() -> String? { token }
+    func lastSyncAt() -> Date? { syncDate }
+    func lastError() -> String? { errorMessage }
+}

--- a/TokenEaterTests/TokenProviderTests.swift
+++ b/TokenEaterTests/TokenProviderTests.swift
@@ -11,6 +11,7 @@ struct TokenProviderTests {
 
     private func makeSUT(
         credentialsToken: String? = nil,
+        helperToken: String? = nil,
         keychainToken: String? = nil,
         encryptedToken: String? = nil,
         hasEncryptionKey: Bool = false,
@@ -18,6 +19,9 @@ struct TokenProviderTests {
     ) -> (TokenProvider, MockCredentialsFileReader, MockClaudeConfigReader, MockElectronDecryptionService) {
         let credentials = MockCredentialsFileReader()
         credentials.storedToken = credentialsToken
+
+        let helperReader = MockKeychainHelperReader()
+        helperReader.token = helperToken
 
         let configReader = MockClaudeConfigReader()
         configReader.encryptedToken = encryptedToken
@@ -30,6 +34,7 @@ struct TokenProviderTests {
 
         let provider = TokenProvider(
             credentialsFileReader: credentials,
+            keychainHelperReader: helperReader,
             configReader: configReader,
             decryptionService: decryption,
             keychainReader: keychainReader
@@ -157,6 +162,7 @@ struct TokenProviderTests {
 
         let provider = TokenProvider(
             credentialsFileReader: credentials,
+            keychainHelperReader: MockKeychainHelperReader(),
             configReader: configReader,
             decryptionService: decryption,
             keychainReader: keychainReader
@@ -186,6 +192,7 @@ struct TokenProviderTests {
 
         let provider = TokenProvider(
             credentialsFileReader: credentials,
+            keychainHelperReader: MockKeychainHelperReader(),
             configReader: configReader,
             decryptionService: decryption,
             keychainReader: { _ in nil }
@@ -209,6 +216,7 @@ struct TokenProviderTests {
 
         let provider = TokenProvider(
             credentialsFileReader: credentials,
+            keychainHelperReader: MockKeychainHelperReader(),
             configReader: configReader,
             decryptionService: decryption,
             keychainReader: { _ in "keychain-fallback" }

--- a/TokenEaterTests/UsageStoreResetFormatTests.swift
+++ b/TokenEaterTests/UsageStoreResetFormatTests.swift
@@ -1,0 +1,30 @@
+import Testing
+import Foundation
+
+@Suite("UsageStore.formatAbsoluteReset")
+@MainActor
+struct UsageStoreResetFormatTests {
+
+    @Test("formats same-day reset as HH:mm")
+    func sameDay() {
+        let calendar = Calendar.current
+        let now = calendar.date(from: DateComponents(year: 2026, month: 4, day: 16, hour: 14))!
+        let reset = calendar.date(from: DateComponents(year: 2026, month: 4, day: 16, hour: 20, minute: 30))!
+
+        let formatted = UsageStore.formatAbsoluteReset(reset, now: now)
+        #expect(formatted == "20:30")
+    }
+
+    @Test("formats other-day reset as EEE HH:mm")
+    func otherDay() {
+        let calendar = Calendar.current
+        let now = calendar.date(from: DateComponents(year: 2026, month: 4, day: 16, hour: 20))!
+        let reset = calendar.date(from: DateComponents(year: 2026, month: 4, day: 17, hour: 8, minute: 0))!
+
+        let formatted = UsageStore.formatAbsoluteReset(reset, now: now)
+        // The weekday label depends on the current locale; we only assert
+        // the HH:mm portion is present and there is a space-separated prefix.
+        #expect(formatted.hasSuffix(" 08:00"))
+        #expect(formatted.count > 6)
+    }
+}

--- a/TokenEaterTests/UsageStoreTests.swift
+++ b/TokenEaterTests/UsageStoreTests.swift
@@ -326,8 +326,10 @@ struct UsageStoreTests {
 
         await store.refresh()
 
+        // With hours the format is clock-style "2h29" (no "min" suffix, 2-digit minute padding).
         #expect(store.fiveHourReset.contains("h"))
-        #expect(store.fiveHourReset.contains("min"))
+        #expect(!store.fiveHourReset.contains("min"))
+        #expect(store.fiveHourReset.count == 4)
     }
 
     @Test("refresh formats fiveHourReset as minutes only when < 1h")


### PR DESCRIPTION
## Summary

Closes #130. Reorganises the Display tab into per-bucket sections (Session / Weekly / Sonnet), ships the reset-countdown + menu-bar colour customisation jeromeajot asked for, gives each pacing its own display-style picker, and cherry-picks an opt-in smart-colour mode for the reset countdown from #122.

## Highlights

### Session reset as a standalone metric
- New `.sessionReset` MetricID. The reset countdown is now pinnable on its own, alongside the percentage, or neither. The duplicated "5h" that used to appear when both were on is gone.
- Relative countdown shortened to clock-style: \`1h25\` instead of \`1h 25min\`, with 2-digit minute padding so the width stays stable as minutes drain.
- New \`ResetDisplayFormat\`: \`Relative (1h25)\`, \`Absolute (20:30)\` / \`Fri 08:00\` on other days, or \`Both\` separated by a dash.

### Per-bucket pacing display mode
- \`sessionPacingDisplayMode\` and \`weeklyPacingDisplayMode\` replace the single global \`pacingDisplayMode\`. Each pacing metric has its own dot/dot+delta/delta picker right next to its toggle on the Display tab.
- Migration: the legacy global value is copied into both buckets on first launch, so existing users don't lose their choice.

### Menu-bar text colour customisation
- New "Menu bar text" card at the top of the Themes tab.
  - Monochrome toggle (moved here from Display).
  - Reset countdown colour picker (native \`ColorPicker\`, revert-to-system button).
  - **Smart color for reset countdown** opt-in toggle - colours the countdown text based on \`risk = utilization * remaining_minutes / 100\` mapped to the gauge colours (green < 70, orange 70-100, red > 100). Overrides the manual picker while on, which is visually disabled.
  - Period label colour picker (5h / 7d / S).
- Reset-to-defaults on the Themes card now also clears the four menu-bar text settings + the smart flag.

### Display tab reorg
- Card 1 **Show in menu bar** (single toggle).
- Card 2 **Pinned metrics**: live NSImage preview rendered via \`MenuBarRenderer.renderUncached\` so changes reflect instantly without poisoning the status-bar cache.
- Card 3 **Session**: Session toggle / Reset countdown + format picker inline / Session pacing + style picker inline.
- Card 4 **Weekly**: Weekly toggle / Weekly pacing + style picker inline.
- Card 5 **Sonnet**: Display Sonnet master toggle, Session Sonnet nested under it when on.
- Dropped \`.sonnetPacing\` from the UI entirely (it never rendered anything real).

### Menu bar renderer
- \`.sessionReset\` renders the countdown without the legacy \`5h\` prefix.
- Smart colour applied only to the reset countdown text when the setting is on and a reset date is known.
- Per-bucket pacing picker is wired end-to-end (RenderData, StatusBarController, DisplaySectionView preview).

## Cherry-picked from #122

The smart-colour formula (\`risk = utilization * remaining_minutes / 100\`) comes from @AThevon's #122. Only the minimum needed surface for the reset countdown is included here; the larger dashboard / widget / menu-bar-ring integration from #122 stays out of scope. #122 has been closed; a follow-up PR can reopen it on current main if desired.

## Test plan

- [x] Full test suite passes (254 tests; existing \`TokenProvider\`, \`UsageStore\`, \`SettingsStore\` tests still green after the migrations).
- [x] New \`UsageStoreResetFormatTests\` for the absolute reset formatter (\"20:30\" same-day, \"Mon 08:00\" other days).
- [x] Release build succeeds with Xcode 16.4 / Swift 6.1.2.
- [x] Manual: toggled every pinnable metric, verified the live preview matches the actual menu-bar render, verified per-pacing style pickers are independent, smart-color mode vs custom hex priority works, legacy \`showSessionReset=true\` users get \`.sessionReset\` auto-pinned after upgrade.

Credit to @jeromeajot for the feature request. Kept out of scope here and tracked separately in a follow-up: the overlay trigger-zone adjustment for #134.