### PR TITLE
fix: narrow overlay hover zone + sticky expand for click-through

### DIFF
--- a/Shared/Models/OverlayTriggerZone.swift
+++ b/Shared/Models/OverlayTriggerZone.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// How wide the strip at the edge of the screen that captures mouse clicks
+/// for the watchers overlay. A narrower zone leaves more of the screen
+/// clickable through to underlying apps. Minimal is the click-through
+/// best case: you have to hover the visible indicator strip itself, but
+/// once the overlay has expanded it stays grabable over a larger zone so
+/// the mouse doesn't have to stay pixel-pinned. See issue #134.
+enum OverlayTriggerZone: String, CaseIterable, Identifiable {
+    case minimal
+    case narrow
+    case medium
+    case wide
+
+    var id: String { rawValue }
+
+    /// Width (points, before multiplying by `overlayScale`) of the zone that
+    /// captures mouse clicks while the overlay is NOT already active.
+    var enterWidth: CGFloat {
+        switch self {
+        case .minimal: return 18
+        case .narrow: return 40
+        case .medium: return 80
+        case .wide: return 130
+        }
+    }
+
+    /// Width (points) the overlay keeps grabbing clicks within once it has
+    /// already been triggered - lets the cursor drift away from the strip
+    /// without the overlay snapping shut mid-hover. Minimal gets the
+    /// largest expansion since its entry zone is the tightest.
+    var exitWidth: CGFloat {
+        switch self {
+        case .minimal: return 110
+        case .narrow: return 100
+        case .medium: return 120
+        case .wide: return 150
+        }
+    }
+
+    var localizedLabel: String {
+        switch self {
+        case .minimal: return String(localized: "settings.watchers.trigger.minimal")
+        case .narrow: return String(localized: "settings.watchers.trigger.narrow")
+        case .medium: return String(localized: "settings.watchers.trigger.medium")
+        case .wide: return String(localized: "settings.watchers.trigger.wide")
+        }
+    }
+}

--- a/Shared/Stores/SettingsStore.swift
+++ b/Shared/Stores/SettingsStore.swift
@@ -73,6 +73,9 @@ final class SettingsStore: ObservableObject {
     @Published var overlayLeftSide: Bool {
         didSet { UserDefaults.standard.set(overlayLeftSide, forKey: "overlayLeftSide") }
     }
+    @Published var overlayTriggerZone: OverlayTriggerZone {
+        didSet { UserDefaults.standard.set(overlayTriggerZone.rawValue, forKey: "overlayTriggerZone") }
+    }
     @Published var watchersDetailedMode: Bool {
         didSet { UserDefaults.standard.set(watchersDetailedMode, forKey: "watchersDetailedMode") }
     }
@@ -189,6 +192,9 @@ final class SettingsStore: ObservableObject {
         self.overlayDockEffect = UserDefaults.standard.object(forKey: "overlayDockEffect") as? Bool ?? true
         self.overlayScale = UserDefaults.standard.object(forKey: "overlayScale") as? Double ?? 1.1
         self.overlayLeftSide = UserDefaults.standard.bool(forKey: "overlayLeftSide")
+        self.overlayTriggerZone = OverlayTriggerZone(
+            rawValue: UserDefaults.standard.string(forKey: "overlayTriggerZone") ?? "medium"
+        ) ?? .medium
         self.watchersDetailedMode = UserDefaults.standard.object(forKey: "watchersDetailedMode") as? Bool ?? true
         self.watcherStyle = WatcherStyle(
             rawValue: UserDefaults.standard.string(forKey: "watcherStyle") ?? "frost"

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -325,6 +325,12 @@
 
 /* Agent Watchers */
 "settings.watchers.description" = "A floating overlay showing your active Claude Code sessions. Hover to expand, click to jump to a session.";
+"settings.watchers.trigger" = "Hover zone";
+"settings.watchers.trigger.minimal" = "Minimal";
+"settings.watchers.trigger.narrow" = "Narrow";
+"settings.watchers.trigger.medium" = "Medium";
+"settings.watchers.trigger.wide" = "Wide";
+"settings.watchers.trigger.hint" = "How close to the screen edge the cursor must get to open the overlay. Minimal keeps the rest of the screen fully clickable; once the overlay pops open the grabable area grows so the cursor can drift without snapping shut.";
 "settings.watchers.legend" = "Status legend";
 "settings.watchers.idle" = "Idle — waiting for input";
 "settings.watchers.thinking" = "Thinking — generating a response";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -325,6 +325,12 @@
 
 /* Agent Watchers */
 "settings.watchers.description" = "Un overlay flottant qui montre vos sessions Claude Code actives. Survolez pour agrandir, cliquez pour basculer vers une session.";
+"settings.watchers.trigger" = "Zone de survol";
+"settings.watchers.trigger.minimal" = "Minimal";
+"settings.watchers.trigger.narrow" = "Étroite";
+"settings.watchers.trigger.medium" = "Moyenne";
+"settings.watchers.trigger.wide" = "Large";
+"settings.watchers.trigger.hint" = "Distance du bord où la souris doit arriver pour ouvrir l'overlay. Minimal garde le reste de l'écran pleinement cliquable ; une fois l'overlay ouvert la zone de survol s'élargit pour que la souris puisse respirer sans refermer l'overlay.";
 "settings.watchers.legend" = "Légende des statuts";
 "settings.watchers.idle" = "Idle — en attente d'une action";
 "settings.watchers.thinking" = "Thinking — génère une réponse";

--- a/TokenEaterApp/AgentWatchersSectionView.swift
+++ b/TokenEaterApp/AgentWatchersSectionView.swift
@@ -82,6 +82,27 @@ struct AgentWatchersSectionView: View {
 
                     VStack(alignment: .leading, spacing: 6) {
                         HStack {
+                            Text(String(localized: "settings.watchers.trigger"))
+                                .font(.system(size: 13))
+                                .foregroundStyle(.white.opacity(0.8))
+                            Spacer()
+                            Picker("", selection: $settingsStore.overlayTriggerZone) {
+                                ForEach(OverlayTriggerZone.allCases) { zone in
+                                    Text(zone.localizedLabel).tag(zone)
+                                }
+                            }
+                            .pickerStyle(.segmented)
+                            .labelsHidden()
+                            .frame(maxWidth: 220)
+                        }
+                        Text(String(localized: "settings.watchers.trigger.hint"))
+                            .font(.system(size: 11))
+                            .foregroundStyle(.white.opacity(0.45))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack {
                             Text(String(localized: "settings.watchers.size"))
                                 .font(.system(size: 13))
                                 .foregroundStyle(.white.opacity(0.8))

--- a/TokenEaterApp/OverlayView.swift
+++ b/TokenEaterApp/OverlayView.swift
@@ -64,8 +64,12 @@ struct OverlayView: View {
         let vDistToGroup = abs(groupCenterY - cursor.y)
         guard vDistToGroup < totalHeight / 2 + 80 else { return 0 }
 
-        // Horizontal factor: steep curve — max reached within ~60px of travel
-        let hActivationZone: CGFloat = 180
+        // Horizontal factor: visual expansion is tied to the controller's
+        // active hover zone. While inactive the user needs to reach the
+        // (possibly tiny) enter strip to trigger expansion; once active the
+        // expansion persists across the larger exit zone so the user can
+        // pin a session without pixel-hunting.
+        let hActivationZone = max(overlayState.activationZone, 20)
         let hDistance = leftSide ? cursor.x : (wWidth - cursor.x)
         guard hDistance < hActivationZone else { return 0 }
         let rawH = 1 - (hDistance / hActivationZone)

--- a/TokenEaterApp/OverlayWindowController.swift
+++ b/TokenEaterApp/OverlayWindowController.swift
@@ -9,6 +9,11 @@ final class OverlayState: ObservableObject {
     @Published var windowWidth: CGFloat = 200
     @Published var leftSide: Bool = false
     @Published var contentOffset: CGFloat = 0
+    /// The effective horizontal activation zone (post-scale). Swapped between
+    /// the current trigger's enter and exit widths depending on whether the
+    /// overlay is already hover-active. SwiftUI uses this for visual
+    /// expansion so the visible expand tracks the click-capture zone.
+    @Published var activationZone: CGFloat = 180
 }
 
 @MainActor
@@ -28,7 +33,17 @@ final class OverlayWindowController {
         let expandedCard: CGFloat = 185 * CGFloat(settingsStore.overlayScale) + 20
         return max(base, expandedCard)
     }
-    private var interactiveZone: CGFloat { min(windowWidth, 120 * CGFloat(settingsStore.overlayScale)) }
+    /// True while the cursor has crossed the trigger's enter threshold and
+    /// has not yet strayed past the exit threshold. Used to give the user a
+    /// larger "hover grace area" once the overlay has actually expanded.
+    private var isPanelActive: Bool = false
+
+    private var enterZone: CGFloat {
+        min(windowWidth, settingsStore.overlayTriggerZone.enterWidth * CGFloat(settingsStore.overlayScale))
+    }
+    private var exitZone: CGFloat {
+        min(windowWidth, settingsStore.overlayTriggerZone.exitWidth * CGFloat(settingsStore.overlayScale))
+    }
 
     init(sessionStore: SessionStore, settingsStore: SettingsStore) {
         self.sessionStore = sessionStore
@@ -87,6 +102,22 @@ final class OverlayWindowController {
         .sink { [weak self] _ in
             self?.repositionIfNeeded()
         }
+        .store(in: &cancellables)
+
+        // Re-evaluate capture immediately when the trigger zone changes: drop
+        // the "already active" stickiness and clamp the panel back to
+        // pass-through until the cursor crosses the fresh enter threshold.
+        settingsStore.$overlayTriggerZone
+            .removeDuplicates()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.isPanelActive = false
+                self.panel?.ignoresMouseEvents = true
+                self.overlayState.activationZone = self.enterZone
+                self.lastCursorCheck = 0
+                self.updateCursorTracking()
+            }
         .store(in: &cancellables)
     }
 
@@ -227,11 +258,22 @@ final class OverlayWindowController {
             return
         }
 
-        // Interactive zone: edge-side area AND near session items vertically
+        // Horizontal zone: use the wider "exit" width once the panel is
+        // already active so the cursor can drift off the tight entry strip
+        // without the overlay snapping shut mid-hover.
         let distanceFromEdge = settingsStore.overlayLeftSide ? localX : (frame.width - localX)
-        guard distanceFromEdge <= interactiveZone else {
+        let threshold = isPanelActive ? exitZone : enterZone
+        guard distanceFromEdge <= threshold else {
+            isPanelActive = false
+            if overlayState.activationZone != enterZone {
+                overlayState.activationZone = enterZone
+            }
             panel.ignoresMouseEvents = true
             return
+        }
+        isPanelActive = true
+        if overlayState.activationZone != exitZone {
+            overlayState.activationZone = exitZone
         }
 
         let scale = CGFloat(settingsStore.overlayScale)


### PR DESCRIPTION
## Summary

Closes #134. The watchers overlay used to grab mouse clicks in a 120 * scale px strip (~132px with the default scale). That strip completely blocked clicks on any app behind that edge of the screen - the exact issue @ian-lmcb reported.

## Changes

New user setting **Agent watchers -> Behavior -> Hover zone** with 4 levels:

| Level | Enter zone | Exit zone (sticky while hovering) |
|---|---|---|
| Minimal | 18 px | 110 px |
| Narrow | 40 px | 100 px |
| Medium (default) | 80 px | 120 px |
| Wide | 130 px | 150 px |

- *Enter* is how close to the edge the cursor must get to trigger the overlay.
- *Exit* is how far the cursor can drift afterwards without the overlay snapping shut. This is what keeps Minimal usable: the entry strip is the size of the visible indicator, but once it has opened you can move around the whole hover area to pin a session without pixel-hunting.
- The visual expansion is now tied to the same active zone (previously hard-coded to 180 px in \`OverlayView.proximity\`), so the overlay no longer puffs out long before the cursor can actually grab it.
- Changing the setting takes effect immediately: the controller drops its sticky state, clamps the panel to pass-through, and re-runs tracking with the fresh threshold.
- Default is **Medium** for everyone (including users who were previously on the implicit Wide). This is a bug fix, so the new safer default ships to all.

## Test plan

- [x] Release build with Xcode 16.4 / Swift 6.1.2.
- [x] Manual: Minimal mode - clicks pass through to the app behind ~60 px from the edge, overlay only opens when the cursor reaches the visible strip, stays open until the cursor moves past 110 px.
- [x] Manual: Wide mode - opens further from the edge (legacy behaviour).
- [x] Manual: switching modes from the settings tab updates behaviour on the next hover without needing to restart.

Credit to @ian-lmcb for the report.