### PR TITLE
fix(monitoring): align 5h hero hover with weekly metric tiles

### DIFF
--- a/TokenEaterApp/MonitoringView.swift
+++ b/TokenEaterApp/MonitoringView.swift
@@ -207,7 +207,7 @@ struct MonitoringView: View {
                     RoundedRectangle(cornerRadius: DS.Radius.cardLg)
                         .fill(
                             LinearGradient(
-                                colors: [accent.opacity(0.10), .clear],
+                                colors: [accent.opacity(heroHover ? 0.10 : 0.05), .clear],
                                 startPoint: .topLeading,
                                 endPoint: .bottomTrailing
                             )
@@ -216,14 +216,7 @@ struct MonitoringView: View {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: DS.Radius.cardLg)
-                    .stroke(
-                        LinearGradient(
-                            colors: [accent.opacity(heroHover ? 0.35 : 0.15), accent.opacity(0.02)],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        ),
-                        lineWidth: 1
-                    )
+                    .stroke(accent.opacity(heroHover ? 0.40 : 0.18), lineWidth: 1)
             )
             .dsShadow(heroHover ? DS.Shadow.lift : DS.Shadow.subtle)
         }


### PR DESCRIPTION
## Summary
- The 5h hero card on the monitoring home didn't react on hover the same way as the 3 weekly metric tiles next to it - the inner accent wash was fixed at 0.10, so there was no visible "light up" on hover, only the border shifted.
- Aligned the hero with `MetricTile`: inner gradient now animates 0.05 -> 0.10 on hover, and the border switches to a solid stroke with the same 0.18 -> 0.40 amplitude.
- Net effect: the whole grid (hero + 3 weekly tiles) now shares a single hover language.

## Test plan
- [ ] Build Release with Xcode 16.4 + nuke + install
- [ ] Hover over the 5h hero card and confirm the inner accent gradient brightens at the same intensity as a weekly tile
- [ ] Hover over weekly / sonnet / opus tiles and confirm visual parity (border + wash + lift)
- [ ] Confirm the click-to-flip animation on the hero is unaffected