### PR TITLE
fix: improve slider and toggle contrast in Settings

### DIFF
--- a/TokenEaterApp/AgentWatchersSectionView.swift
+++ b/TokenEaterApp/AgentWatchersSectionView.swift
@@ -148,7 +148,7 @@ struct AgentWatchersSectionView: View {
                             .font(.system(size: 9))
                             .foregroundStyle(.white.opacity(0.3))
                         Slider(value: $settingsStore.overlayScale, in: 0.6...1.6, step: 0.05)
-                            .tint(.blue)
+                            .tint(DS.Palette.accentSettings)
                         Image(systemName: "plus")
                             .font(.system(size: 9))
                             .foregroundStyle(.white.opacity(0.3))

--- a/TokenEaterApp/DarkPremiumHelpers.swift
+++ b/TokenEaterApp/DarkPremiumHelpers.swift
@@ -43,7 +43,7 @@ func darkToggle(_ label: String, isOn: Binding<Bool>) -> some View {
     HStack {
         Toggle("", isOn: isOn)
             .toggleStyle(.switch)
-            .tint(.blue)
+            .tint(DS.Palette.accentSettings)
             .labelsHidden()
         Text(label)
             .font(.system(size: 13))

--- a/TokenEaterApp/SettingsSectionView.swift
+++ b/TokenEaterApp/SettingsSectionView.swift
@@ -206,6 +206,7 @@ struct SettingsSectionView: View {
                         in: 180...900,
                         step: 60
                     )
+                    .tint(DS.Palette.accentSettings)
                     if settingsStore.refreshInterval < 300 {
                         Label {
                             Text(String(localized: "settings.refresh.warning"))

--- a/TokenEaterApp/ThemesSectionView.swift
+++ b/TokenEaterApp/ThemesSectionView.swift
@@ -50,7 +50,7 @@ struct ThemesSectionView: View {
                         Spacer()
                         Toggle("", isOn: $settingsStore.smartColorEnabled)
                             .toggleStyle(.switch)
-                            .tint(.blue)
+                            .tint(DS.Palette.accentSettings)
                             .labelsHidden()
                     }
 
@@ -535,7 +535,7 @@ struct ThemesSectionView: View {
                 .foregroundStyle(.white.opacity(0.7))
                 .frame(width: 60, alignment: .leading)
             Slider(value: value, in: range, step: 5)
-                .tint(.blue)
+                .tint(DS.Palette.accentSettings)
             Text("\(Int(value.wrappedValue))%")
                 .font(.system(size: 12, design: .monospaced))
                 .foregroundStyle(.white.opacity(0.5))


### PR DESCRIPTION
## What this PR does

Applies `DS.Palette.accentSettings` to all sliders (refresh interval, pacing margin, threshold, overlay scale) and toggles (smart color, dark mode) in the Settings view.

## Why

The default system tint (blue) was near-invisible against the dark glass card background, making the refresh interval slider especially hard to see.

Closes #158 

## How to test

1. Open Settings
2. Verify all sliders have a visible accent color against the dark background
3. Verify toggles (smart color, dark mode) are clearly visible when active

## Screenshots / recordings

Before:
<img width="1434" height="382" alt="image" src="https://github.com/user-attachments/assets/9cf00503-c160-43c6-b4d4-17d30ddd9d46" />
<img width="1370" height="424" alt="image" src="https://github.com/user-attachments/assets/e4d4f91f-33fa-4f80-9790-5862e083eaeb" />

After:
[To be updated]