### PR TITLE
fix: visible DSMenu component for all dropdown selects

### DIFF
--- a/Shared/Components/DSMenu.swift
+++ b/Shared/Components/DSMenu.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+/// Design-system dropdown that replaces the native `Picker(.menu)` style.
+///
+/// The default macOS Picker renders without a visible background, which makes
+/// it disappear against TokenEater's dark glass cards. `DSMenu` wraps a `Menu`
+/// in a styled capsule chip with a hover state, so users can actually see and
+/// find the dropdown.
+///
+/// Generic over the selected value's type. Pass an array of options and a
+/// closure to format each one into its human-readable label.
+struct DSMenu<Value: Hashable>: View {
+    @Binding var selection: Value
+    let options: [Value]
+    let label: (Value) -> String
+    var enabled: Bool = true
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Menu {
+            ForEach(options, id: \.self) { value in
+                Button(label(value)) { selection = value }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Text(label(selection))
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.white.opacity(enabled ? 0.9 : 0.3))
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundStyle(
+                        enabled
+                            ? (isHovering ? DS.Palette.accentSettings : .white.opacity(0.5))
+                            : .white.opacity(0.25)
+                    )
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(
+                Capsule()
+                    .fill(enabled
+                          ? (isHovering ? DS.Palette.glassFillHi : DS.Palette.glassFill)
+                          : DS.Palette.glassFill.opacity(0.5))
+                    .overlay(
+                        Capsule().stroke(
+                            enabled
+                                ? (isHovering ? DS.Palette.accentSettings.opacity(0.45) : DS.Palette.glassBorderHi)
+                                : DS.Palette.glassBorderLo,
+                            lineWidth: 0.8
+                        )
+                    )
+            )
+            .contentShape(Capsule())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .disabled(!enabled)
+        .onHover { isHovering = $0 }
+        .animation(.easeOut(duration: 0.12), value: isHovering)
+    }
+}

--- a/Shared/Components/ResetFormatPicker.swift
+++ b/Shared/Components/ResetFormatPicker.swift
@@ -4,12 +4,10 @@ struct ResetFormatPicker: View {
     @Binding var selection: ResetDisplayFormat
 
     var body: some View {
-        Picker(String(localized: "settings.reset.format"), selection: $selection) {
-            ForEach(ResetDisplayFormat.allCases) { format in
-                Text(format.localizedLabel).tag(format)
-            }
-        }
-        .pickerStyle(.menu)
-        .font(.system(size: 11))
+        DSMenu(
+            selection: $selection,
+            options: ResetDisplayFormat.allCases,
+            label: { $0.localizedLabel }
+        )
     }
 }

--- a/TokenEaterApp/NotificationsSectionView.swift
+++ b/TokenEaterApp/NotificationsSectionView.swift
@@ -201,16 +201,12 @@ struct NotificationsSectionView: View {
                 .font(.system(size: 11))
                 .foregroundStyle(.white.opacity(enabled ? 0.6 : 0.25))
             Spacer()
-            Picker("", selection: selection) {
-                ForEach(options, id: \.self) { value in
-                    Text(formatOffsetMinutes(value)).tag(value)
-                }
-            }
-            .labelsHidden()
-            .pickerStyle(.menu)
-            .tint(DS.Palette.accentSettings)
-            .disabled(!enabled)
-            .frame(width: 110)
+            DSMenu(
+                selection: selection,
+                options: options,
+                label: formatOffsetMinutes,
+                enabled: enabled
+            )
         }
         .padding(.leading, 12)
     }
@@ -253,3 +249,4 @@ struct NotificationsSectionView: View {
         }
     }
 }
+


### PR DESCRIPTION
## Summary

The native macOS `Picker(.menu)` style renders without a visible background, which made the new reset reminder dropdown invisible against the dark glass card -> reported in #167 by @pieterjanscheir.

Extracts a generic `DSMenu<Value: Hashable>` to `Shared/Components/` and uses it everywhere a dropdown is needed.

## What changed

- New `Shared/Components/DSMenu.swift` -> generic dropdown with capsule chip, glass fill, chevron, hover state with orange accent border
- `Shared/Components/ResetFormatPicker.swift` -> swapped from `Picker(.menu)` to `DSMenu`
- `TokenEaterApp/NotificationsSectionView.swift` -> the inline `ReminderOffsetMenu` got promoted to `DSMenu` and removed

Segmented chip pickers (`PacingDisplayPicker`, `smartColorProfilePicker`, `VariantPickerView`, `FocusHeroPicker`, `rangePicker` in History) are intentionally left alone since they already have a distinct visible style and serve a different UX purpose (always-visible options vs collapsed dropdown).

## Test plan

- [x] All 332 unit tests pass
- [x] Release build verified locally with Xcode 16.4
- [x] Visual: reset reminder dropdowns visible + hover state in Settings -> Notifications
- [x] Visual: reset format dropdown (relative / absolute) visible in Settings -> Display

Closes #167