### PR TITLE
fix: reminder notification title uses the configured offset

### DIFF
--- a/Shared/Services/NotificationService.swift
+++ b/Shared/Services/NotificationService.swift
@@ -303,29 +303,44 @@ final class NotificationService: NotificationServiceProtocol {
         if toggles.resetReminderSession,
            let target = sessionResetsAt?.addingTimeInterval(-Double(toggles.resetReminderSessionOffsetMinutes) * 60),
            target.timeIntervalSinceNow > 0 {
+            let duration = formatReminderDuration(minutes: toggles.resetReminderSessionOffsetMinutes)
+            let titleTemplate = NSLocalizedString("notif.title.reminder.session", comment: "")
             schedule(
                 id: "reminder_session",
-                titleKey: "notif.title.reminder.session",
-                bodyKey: "notif.body.reminder.session",
+                title: String(format: titleTemplate, duration),
+                body: NSLocalizedString("notif.body.reminder.session", comment: ""),
                 fireDate: target
             )
         }
         if toggles.resetReminderWeekly,
            let target = weeklyResetsAt?.addingTimeInterval(-Double(toggles.resetReminderWeeklyOffsetMinutes) * 60),
            target.timeIntervalSinceNow > 0 {
+            let duration = formatReminderDuration(minutes: toggles.resetReminderWeeklyOffsetMinutes)
+            let titleTemplate = NSLocalizedString("notif.title.reminder.weekly", comment: "")
             schedule(
                 id: "reminder_weekly",
-                titleKey: "notif.title.reminder.weekly",
-                bodyKey: "notif.body.reminder.weekly",
+                title: String(format: titleTemplate, duration),
+                body: NSLocalizedString("notif.body.reminder.weekly", comment: ""),
                 fireDate: target
             )
         }
     }
 
-    private func schedule(id: String, titleKey: String, bodyKey: String, fireDate: Date) {
+    /// Renders a human-readable duration matching the picker labels in the
+    /// settings UI: "1 h", "2 h" for round-hour values, "5 min", "30 min" for
+    /// minute-resolution offsets.
+    private func formatReminderDuration(minutes: Int) -> String {
+        if minutes >= 60, minutes % 60 == 0 {
+            let hours = minutes / 60
+            return String(format: NSLocalizedString("notif.duration.hours", comment: ""), hours)
+        }
+        return String(format: NSLocalizedString("notif.duration.minutes", comment: ""), minutes)
+    }
+
+    private func schedule(id: String, title: String, body: String, fireDate: Date) {
         let content = UNMutableNotificationContent()
-        content.title = NSLocalizedString(titleKey, comment: "")
-        content.body = NSLocalizedString(bodyKey, comment: "")
+        content.title = title
+        content.body = body
         content.sound = .default
 
         let comps = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: fireDate)

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -218,10 +218,12 @@
 "notif.title.pacing.warning" = "Drifting fast";
 "notif.body.pacing.warning" = "A touch faster than ideal, keep an eye";
 
-"notif.title.reminder.session" = "Session resets in 15";
+"notif.title.reminder.session" = "Session resets in %@";
 "notif.body.reminder.session" = "Save your spot or send it";
-"notif.title.reminder.weekly" = "Weekly resets in 1h";
+"notif.title.reminder.weekly" = "Weekly resets in %@";
 "notif.body.reminder.weekly" = "Last lap on the cycle";
+"notif.duration.minutes" = "%d min";
+"notif.duration.hours" = "%d h";
 
 /* Notifications - 5h session */
 "notif.title.fivehour.orange.chill" = "Pace check";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -218,10 +218,12 @@
 "notif.title.pacing.warning" = "Ça dérive";
 "notif.body.pacing.warning" = "Un poil rapide, garde l'œil";
 
-"notif.title.reminder.session" = "Reset session dans 15";
+"notif.title.reminder.session" = "Reset session dans %@";
 "notif.body.reminder.session" = "Sauve ton truc ou envoie";
-"notif.title.reminder.weekly" = "Reset hebdo dans 1h";
+"notif.title.reminder.weekly" = "Reset hebdo dans %@";
 "notif.body.reminder.weekly" = "Dernier tour sur le cycle";
+"notif.duration.minutes" = "%d min";
+"notif.duration.hours" = "%dh";
 
 /* Notifications - 5h session */
 "notif.title.fivehour.orange.chill" = "Petit point rythme";


### PR DESCRIPTION
## Summary

The reset reminder titles had \"15\" / \"1h\" hardcoded in the localized strings, so users who switched the offset via the picker (added in v5.2.0) still got a notification claiming \"Session resets in 15\" even at 30 min.

Closes #170

## What changed

- `notif.title.reminder.session` and `notif.title.reminder.weekly` now use a `%@` placeholder
- New `notif.duration.minutes` / `notif.duration.hours` strings format the offset the same way the picker labels do (e.g. \"30 min\", \"1 h\")
- `NotificationService.scheduleResetReminders` formats the title with the actual offset before scheduling

## Test plan

- [x] Set the session reminder offset to 30 min, fire a scheduled notification -> title reads \"Session resets in 30 min\"
- [x] Set the weekly reminder offset to 2 h, fire a scheduled notification -> title reads \"Weekly resets in 2 h\"
- [x] All 332 unit tests pass