### PR TITLE
fix: exponential 429 backoff + clearer rate-limit messaging

### DIFF
--- a/Shared/Stores/UsageStore.swift
+++ b/Shared/Stores/UsageStore.swift
@@ -70,6 +70,12 @@ final class UsageStore: ObservableObject {
     /// Retry-After date from last 429 response
     private(set) var retryAfterDate: Date?
 
+    /// Number of consecutive 429s we've received. Drives the exponential
+    /// backoff because anthropic's /api/oauth/usage endpoint returns 429 with
+    /// no useful Retry-After header (known issue on their side, see
+    /// anthropics/claude-code#31637 and #31021). Reset on every success.
+    private var consecutiveRateLimits: Int = 0
+
     /// Effective interval based on current speed + user setting
     var effectiveInterval: TimeInterval {
         switch currentSpeed {
@@ -147,6 +153,7 @@ final class UsageStore: ObservableObject {
                 currentSpeed = .normal
             }
             retryAfterDate = nil
+            consecutiveRateLimits = 0
             WidgetReloader.scheduleReload()
             evaluateNotifications(usage: usage)
         } catch let error as APIError {
@@ -167,6 +174,7 @@ final class UsageStore: ObservableObject {
                             currentSpeed = .normal
                         }
                         retryAfterDate = nil
+                        consecutiveRateLimits = 0
                         WidgetReloader.scheduleReload()
                         evaluateNotifications(usage: usage)
                         return
@@ -180,11 +188,30 @@ final class UsageStore: ObservableObject {
                 }
             case .rateLimited(let retryAfter, _, _):
                 currentSpeed = .slow
-                // /api/oauth/usage returns retry-after: 0 when the token has hit its per-token
-                // request limit (not a transient throttle). A value of 0 or a missing header
-                // both signal the same "token exhausted" state - default to 6 hours so we stop
-                // hammering the endpoint every 20 minutes.
-                let backoff: TimeInterval = retryAfter.flatMap { $0 > 0 ? $0 : nil } ?? (6 * 3600)
+                // /api/oauth/usage returns 429 with Retry-After: 0 (or no header)
+                // when the throttle kicks in. Anthropic has known issues making
+                // this endpoint return persistent 429s for hours with no useful
+                // Retry-After (see anthropics/claude-code#31637 + #31021).
+                //
+                // Strategy: if the server gives us a real positive Retry-After
+                // we honor it. Otherwise use exponential backoff capped at 6h.
+                // Earlier passes (30 min, 1h, 2h, 4h) recover quickly when the
+                // throttle lifts on its own.
+                let backoff: TimeInterval
+                if let r = retryAfter, r > 0 {
+                    backoff = r
+                } else {
+                    consecutiveRateLimits += 1
+                    let exponential: [TimeInterval] = [
+                        30 * 60,   // 30 min
+                        60 * 60,   // 1 h
+                        2 * 3600,  // 2 h
+                        4 * 3600,  // 4 h
+                        6 * 3600   // 6 h cap
+                    ]
+                    let idx = min(consecutiveRateLimits - 1, exponential.count - 1)
+                    backoff = exponential[idx]
+                }
                 retryAfterDate = Date().addingTimeInterval(backoff)
                 errorState = .rateLimited
             default:

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -157,9 +157,10 @@
 "error.banner.reauth" = "Authorization needed";
 "error.banner.reauth.hint" = "Token expired and automatic recovery failed";
 "error.banner.reauth.button" = "Re-authorize";
-"error.banner.apiunavailable" = "Usage API unavailable";
-"error.banner.apiunavailable.hint" = "Your Claude Code OAuth token has hit its API request limit. Will retry in ~6h - or run \"claude /login\" in Claude Code for a fresh token.";
-"error.banner.apiunavailable.settings" = "Usage API rate limited - will retry in ~6h, or run \"claude /login\" in Claude Code for a fresh token";
+"error.banner.apiunavailable" = "Usage API throttled by Anthropic";
+"error.banner.apiunavailable.hint" = "Known issue on the /api/oauth/usage endpoint (anthropics/claude-code#31637). Will retry automatically with exponential backoff (30 min → 6 h).";
+"error.banner.apiunavailable.settings" = "Usage API throttled by Anthropic (anthropics/claude-code#31637). Retrying automatically.";
+"error.banner.apiunavailable.learnmore" = "Learn more";
 "error.banner.retry.button" = "Retry now";
 "error.banner.diagnostic.button" = "Copy diagnostic";
 "error.banner.diagnostic.copied" = "Copied";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -157,9 +157,10 @@
 "error.banner.reauth" = "Autorisation requise";
 "error.banner.reauth.hint" = "Token expiré et la récupération automatique a échoué";
 "error.banner.reauth.button" = "Ré-autoriser";
-"error.banner.apiunavailable" = "API usage indisponible";
-"error.banner.apiunavailable.hint" = "Votre token OAuth Claude Code a atteint sa limite de requêtes API. Nouvel essai dans ~6h - ou lancez \"claude /login\" dans Claude Code pour un nouveau token.";
-"error.banner.apiunavailable.settings" = "API usage rate limitee - nouvel essai dans ~6h, ou lancez \"claude /login\" dans Claude Code pour un nouveau token";
+"error.banner.apiunavailable" = "API throttle par Anthropic";
+"error.banner.apiunavailable.hint" = "Bug connu sur l'endpoint /api/oauth/usage (anthropics/claude-code#31637). Nouvel essai auto avec backoff exponentiel (30 min → 6 h).";
+"error.banner.apiunavailable.settings" = "API throttle par Anthropic (anthropics/claude-code#31637). Nouvel essai auto.";
+"error.banner.apiunavailable.learnmore" = "En savoir plus";
 "error.banner.retry.button" = "Réessayer";
 "error.banner.diagnostic.button" = "Copier diagnostic";
 "error.banner.diagnostic.copied" = "Copié";

--- a/TokenEaterApp/Popover/PopoverShared.swift
+++ b/TokenEaterApp/Popover/PopoverShared.swift
@@ -208,6 +208,24 @@ struct PopoverErrorBanner: View {
                 Task { await usageStore.refresh(force: true) }
             }
             CopyDiagnosticButton()
+            Button {
+                if let url = URL(string: "https://github.com/anthropics/claude-code/issues/31637") {
+                    NSWorkspace.shared.open(url)
+                }
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "arrow.up.right.square")
+                        .font(.system(size: 9))
+                    Text(String(localized: "error.banner.apiunavailable.learnmore"))
+                        .font(.system(size: 10, weight: .semibold))
+                }
+                .foregroundStyle(.white.opacity(0.6))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .background(Color.white.opacity(0.06))
+                .clipShape(Capsule())
+            }
+            .buttonStyle(.plain)
         }
         .padding(.top, 2)
     }

--- a/TokenEaterTests/UsageStoreTests.swift
+++ b/TokenEaterTests/UsageStoreTests.swift
@@ -182,27 +182,30 @@ struct UsageStoreTests {
         #expect(store.retryAfterDate != nil)
     }
 
-    @Test("retry-after: 0 defaults to 6-hour backoff")
-    func rateLimitedWithZeroRetryAfterDefaultsToSixHours() async {
+    @Test("retry-after: 0 starts at 30-min exponential backoff")
+    func rateLimitedWithZeroRetryAfterUsesExponentialBackoff() async {
         let (store, _, _, _, _) = makeSUT(shouldFail: true, failWith: .rateLimited(retryAfter: 0, retryAfterRaw: "0", endpoint: "/api/oauth/usage"))
 
         await store.refresh()
 
         if let retryAfterDate = store.retryAfterDate {
-            #expect(retryAfterDate.timeIntervalSinceNow > 6 * 3600 - 5) // ~6h, allow 5s tolerance
+            // First 429 should back off ~30 min (1800s)
+            #expect(retryAfterDate.timeIntervalSinceNow > 1800 - 5)
+            #expect(retryAfterDate.timeIntervalSinceNow < 1800 + 5)
         } else {
             Issue.record("retryAfterDate should not be nil after retry-after: 0")
         }
     }
 
-    @Test("absent retry-after header defaults to 6-hour backoff")
-    func rateLimitedWithNilRetryAfterDefaultsToSixHours() async {
+    @Test("absent retry-after header starts at 30-min exponential backoff")
+    func rateLimitedWithNilRetryAfterUsesExponentialBackoff() async {
         let (store, _, _, _, _) = makeSUT(shouldFail: true, failWith: .rateLimited(retryAfter: nil, retryAfterRaw: nil, endpoint: "/api/oauth/usage"))
 
         await store.refresh()
 
         if let retryAfterDate = store.retryAfterDate {
-            #expect(retryAfterDate.timeIntervalSinceNow > 6 * 3600 - 5) // ~6h, allow 5s tolerance
+            #expect(retryAfterDate.timeIntervalSinceNow > 1800 - 5)
+            #expect(retryAfterDate.timeIntervalSinceNow < 1800 + 5)
         } else {
             Issue.record("retryAfterDate should not be nil when Retry-After header is absent")
         }


### PR DESCRIPTION
## Summary

The `/api/oauth/usage` endpoint has known issues on Anthropic's side that make it return persistent 429s with no useful `Retry-After` header (anthropics/claude-code#31637 + #31021). TokenEater was waiting a flat 6h on every 429 which left the user staring at a stale gauge long after the throttle actually lifted.

Refs #161

## What changed

- Replace the flat 6h backoff with an exponential ramp: **30 min → 1 h → 2 h → 4 h → 6 h cap**, keyed on consecutive 429 responses
- Reset the consecutive-rate-limit counter on every successful refresh
- Reword the popover error banner to credit the throttle to Anthropic's known issue, with a \"Learn more\" button that opens the GitHub issue so users see this is not a TokenEater bug

## Test plan

- [x] Unit tests updated to match the new 30-min initial backoff
- [x] All 332 unit tests pass
- [x] Visual: banner reads \"Usage API throttled by Anthropic\" + Learn more button opens the issue