### PR TITLE
feat: Glow / Flat toggle in Settings > Themes

### DIFF
--- a/Shared/Components/DSGlowModifier.swift
+++ b/Shared/Components/DSGlowModifier.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// Environment-driven glow intensity. Every `.dsGlow()` call reads this from
+/// the environment so a single setter on the App root applies to the entire
+/// view tree -> no need to plumb the value through every call site.
+private struct GlowIntensityKey: EnvironmentKey {
+    static let defaultValue: DS.GlowIntensity = .glow
+}
+
+extension EnvironmentValues {
+    var glowIntensity: DS.GlowIntensity {
+        get { self[GlowIntensityKey.self] }
+        set { self[GlowIntensityKey.self] = newValue }
+    }
+}
+
+/// Applies `.shadow()` with radius + opacity scaled by the current `glowIntensity`
+/// from the environment. When the intensity zeroes out radius or opacity, the
+/// shadow is omitted entirely so SwiftUI can elide the render pass.
+private struct DSGlowModifier: ViewModifier {
+    let color: Color
+    let radius: CGFloat
+    let opacity: Double
+    let yOffset: CGFloat
+
+    @Environment(\.glowIntensity) private var intensity
+
+    func body(content: Content) -> some View {
+        if intensity.radiusMultiplier > 0 && intensity.opacityMultiplier > 0 {
+            content.shadow(
+                color: color.opacity(opacity * intensity.opacityMultiplier),
+                radius: radius * intensity.radiusMultiplier,
+                y: yOffset
+            )
+        } else {
+            content
+        }
+    }
+}
+
+extension View {
+    /// Design-system glow that respects the user's `GlowIntensity` setting.
+    ///
+    /// Use this in place of `.shadow(color: color.opacity(o), radius: r)`:
+    /// pass the base color (without opacity baked in), the desired radius,
+    /// and the opacity multiplier. The current environment intensity scales
+    /// both before SwiftUI applies the shadow.
+    func dsGlow(
+        _ color: Color,
+        radius: CGFloat,
+        opacity: Double = 0.6,
+        y: CGFloat = 0
+    ) -> some View {
+        modifier(DSGlowModifier(color: color, radius: radius, opacity: opacity, yOffset: y))
+    }
+}

--- a/Shared/Components/GlowText.swift
+++ b/Shared/Components/GlowText.swift
@@ -17,6 +17,6 @@ struct GlowText: View {
         Text(text)
             .font(font)
             .foregroundStyle(color)
-            .shadow(color: color.opacity(0.5), radius: glowRadius)
+            .dsGlow(color, radius: glowRadius, opacity: 0.5)
     }
 }

--- a/Shared/Components/RingGauge.swift
+++ b/Shared/Components/RingGauge.swift
@@ -35,7 +35,7 @@ struct RingGauge: View {
                 .trim(from: 0, to: animatedPct / 100)
                 .stroke(gradient, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
                 .rotationEffect(.degrees(-90))
-                .shadow(color: glowColor.opacity(0.6), radius: glowRadius)
+                .dsGlow(glowColor, radius: glowRadius, opacity: 0.6)
         }
         .frame(width: size, height: size)
         .onAppear {

--- a/Shared/Design/DesignTokens.swift
+++ b/Shared/Design/DesignTokens.swift
@@ -135,6 +135,32 @@ enum DS {
         static let strong = ShadowToken(radius: 24, y: 0, alpha: 0.40)
     }
 
+    /// Binary toggle for the popover and monitoring glow / halo effect.
+    /// `.glow` keeps the default neon look, `.flat` removes every shadow on
+    /// gauges, metric text, and pacing tiles. Driven via a single environment
+    /// value so toggling the setting applies everywhere immediately.
+    enum GlowIntensity: String, CaseIterable, Identifiable, Hashable {
+        case glow
+        case flat
+
+        public var id: String { rawValue }
+
+        var radiusMultiplier: CGFloat {
+            self == .glow ? 1.0 : 0.0
+        }
+
+        var opacityMultiplier: Double {
+            self == .glow ? 1.0 : 0.0
+        }
+
+        var localizedLabel: String {
+            switch self {
+            case .glow: return String(localized: "settings.glow.mode.glow")
+            case .flat: return String(localized: "settings.glow.mode.flat")
+            }
+        }
+    }
+
     // MARK: - Motion
 
     enum Duration {

--- a/Shared/Stores/SettingsStore.swift
+++ b/Shared/Stores/SettingsStore.swift
@@ -37,6 +37,11 @@ final class SettingsStore: ObservableObject {
             sharedFileService.updateSmartColorProfile(smartColorProfile)
         }
     }
+    /// Controls the global glow / halo intensity in the popover and monitoring
+    /// views. Drives a single environment value read by every `.dsGlow()` call.
+    @Published var glowIntensity: DS.GlowIntensity {
+        didSet { UserDefaults.standard.set(glowIntensity.rawValue, forKey: "glowIntensity") }
+    }
     /// Typography / separator style for the pinned metrics in the menu bar.
     @Published var menuBarStyle: MenuBarStyle {
         didSet { UserDefaults.standard.set(menuBarStyle.rawValue, forKey: "menuBarStyle") }
@@ -349,6 +354,9 @@ final class SettingsStore: ObservableObject {
         // Mirror the resolved profile to the shared file so the (sandboxed)
         // widget picks it up at first paint without waiting for a toggle.
         sharedFileService.updateSmartColorProfile(initialProfile)
+        self.glowIntensity = DS.GlowIntensity(
+            rawValue: UserDefaults.standard.string(forKey: "glowIntensity") ?? DS.GlowIntensity.glow.rawValue
+        ) ?? .glow
         self.menuBarStyle = MenuBarStyle(
             rawValue: UserDefaults.standard.string(forKey: "menuBarStyle") ?? "classic"
         ) ?? .classic

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -405,6 +405,10 @@
 /* Smart Color (global toggle in Themes) */
 "settings.smartcolor.title" = "Smart Color";
 "settings.smartcolor.hint" = "Color codes adapt to time-to-reset, not just absolute usage.";
+"settings.glow.title" = "Neon glow";
+"settings.glow.hint" = "Halo around gauges and metrics in the popover and monitoring view. Turn off for a cleaner, flatter look.";
+"settings.glow.mode.glow" = "Glow";
+"settings.glow.mode.flat" = "Flat";
 "settings.smartcolor.popover.title" = "How Smart Color works";
 "settings.smartcolor.popover.intro" = "Smart Color factors in the time you have left before the next reset. Same percentage gets a different color depending on how soon you'll be reset.";
 "settings.smartcolor.popover.example1.label" = "Low risk";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -405,6 +405,10 @@
 /* Smart Color (toggle global dans Themes) */
 "settings.smartcolor.title" = "Smart Color";
 "settings.smartcolor.hint" = "Les couleurs s'adaptent au temps restant avant reset, pas juste au pourcentage absolu.";
+"settings.glow.title" = "Effet néon";
+"settings.glow.hint" = "Halo autour des jauges et métriques dans le popover et le monitoring. Désactive pour un look plus plat et clean.";
+"settings.glow.mode.glow" = "Glow";
+"settings.glow.mode.flat" = "Flat";
 "settings.smartcolor.popover.title" = "Comment fonctionne Smart Color";
 "settings.smartcolor.popover.intro" = "Smart Color intègre le temps qu'il te reste avant le prochain reset. Même pourcentage, couleur différente selon la proximité du reset.";
 "settings.smartcolor.popover.example1.label" = "Risque faible";

--- a/TokenEaterApp/MainAppView.swift
+++ b/TokenEaterApp/MainAppView.swift
@@ -27,11 +27,14 @@ struct MainAppView: View {
     @StateObject private var insightsStore = MonitoringInsightsStore()
 
     var body: some View {
-        if settingsStore.hasCompletedOnboarding {
-            mainContent
-        } else {
-            onboardingContent
+        Group {
+            if settingsStore.hasCompletedOnboarding {
+                mainContent
+            } else {
+                onboardingContent
+            }
         }
+        .environment(\.glowIntensity, settingsStore.glowIntensity)
     }
 
     // MARK: - Main

--- a/TokenEaterApp/MenuBarView.swift
+++ b/TokenEaterApp/MenuBarView.swift
@@ -22,6 +22,7 @@ struct MenuBarPopoverView: View {
             }
         }
         .animation(.easeInOut(duration: 0.12), value: settingsStore.popoverConfig.activeVariant)
+        .environment(\.glowIntensity, settingsStore.glowIntensity)
     }
 
     private var transition: AnyTransition {

--- a/TokenEaterApp/MonitoringView.swift
+++ b/TokenEaterApp/MonitoringView.swift
@@ -28,6 +28,7 @@ struct MonitoringView: View {
     @State private var heroBlurProgress: CGFloat = 0
     @State private var heroFlipping: Bool = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.glowIntensity) private var glowIntensity
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
@@ -230,7 +231,7 @@ struct MonitoringView: View {
                     Circle()
                         .fill(gaugeColor)
                         .frame(width: 6, height: 6)
-                        .shadow(color: gaugeColor.opacity(0.6), radius: 4)
+                        .dsGlow(gaugeColor, radius: 4, opacity: 0.6)
                     Text(String(localized: "dashboard.hero.session.label").uppercased())
                         .font(DS.Typography.micro)
                         .tracking(1.5)
@@ -242,7 +243,7 @@ struct MonitoringView: View {
                         .font(.system(size: 64, weight: .bold, design: .rounded))
                         .monospacedDigit()
                         .foregroundStyle(gaugeColor)
-                        .shadow(color: gaugeColor.opacity(0.45), radius: 10)
+                        .dsGlow(gaugeColor, radius: 10, opacity: 0.45)
                         .contentTransition(.numericText(value: Double(pct)))
                         .animation(DS.Motion.springLiquid, value: pct)
                     Text("%")
@@ -276,15 +277,17 @@ struct MonitoringView: View {
 
             // Right -> ring + zone glyph
             ZStack {
-                RadialGradient(
-                    colors: [gaugeColor.opacity(0.20), gaugeColor.opacity(0.04), .clear],
-                    center: .center,
-                    startRadius: 10,
-                    endRadius: 90
-                )
-                .frame(width: 200, height: 200)
-                .blur(radius: 14)
-                .allowsHitTesting(false)
+                if glowIntensity == .glow {
+                    RadialGradient(
+                        colors: [gaugeColor.opacity(0.20), gaugeColor.opacity(0.04), .clear],
+                        center: .center,
+                        startRadius: 10,
+                        endRadius: 90
+                    )
+                    .frame(width: 200, height: 200)
+                    .blur(radius: 14)
+                    .allowsHitTesting(false)
+                }
 
                 RingGauge(
                     percentage: pct,
@@ -297,7 +300,7 @@ struct MonitoringView: View {
                 Image(systemName: zoneGlyph(for: zone))
                     .font(.system(size: 40, weight: .semibold))
                     .foregroundStyle(zone.map { themeStore.current.pacingColor(for: $0) } ?? gaugeColor)
-                    .shadow(color: (zone.map { themeStore.current.pacingColor(for: $0) } ?? gaugeColor).opacity(0.55), radius: 10)
+                    .dsGlow(zone.map { themeStore.current.pacingColor(for: $0) } ?? gaugeColor, radius: 10, opacity: 0.55)
                     .animation(DS.Motion.springLiquid, value: zone)
             }
             .frame(width: 160, height: 160)
@@ -320,7 +323,7 @@ struct MonitoringView: View {
                     Circle()
                         .fill(gaugeColor)
                         .frame(width: 6, height: 6)
-                        .shadow(color: gaugeColor.opacity(0.6), radius: 4)
+                        .dsGlow(gaugeColor, radius: 4, opacity: 0.6)
                     Text(String(localized: "dashboard.hero.session.label").uppercased() + " · PACING")
                         .font(DS.Typography.micro)
                         .tracking(1.5)
@@ -558,7 +561,7 @@ struct MonitoringView: View {
                         Circle()
                             .fill(tint)
                             .frame(width: 5, height: 5)
-                            .shadow(color: tint, radius: 3)
+                            .dsGlow(tint, radius: 3, opacity: 1.0)
                         Text(zoneLabel(pacing.zone))
                             .font(.system(size: 9, weight: .bold))
                             .tracking(1.2)
@@ -570,7 +573,7 @@ struct MonitoringView: View {
                     .font(.system(size: 28, weight: .bold, design: .rounded))
                     .monospacedDigit()
                     .foregroundStyle(tint)
-                    .shadow(color: tint.opacity(0.45), radius: 5)
+                    .dsGlow(tint, radius: 5, opacity: 0.45)
                     .contentTransition(.numericText(value: pacing.delta))
                     .animation(DS.Motion.springLiquid, value: pacing.delta)
             }
@@ -618,12 +621,12 @@ struct MonitoringView: View {
                 RoundedRectangle(cornerRadius: 3)
                     .fill(LinearGradient(colors: [tint.opacity(0.7), tint], startPoint: .leading, endPoint: .trailing))
                     .frame(width: geo.size.width * CGFloat(clampedActual) / 100, height: 6)
-                    .shadow(color: tint.opacity(0.4), radius: 4)
+                    .dsGlow(tint, radius: 4, opacity: 0.4)
                 Rectangle()
                     .fill(Color.white.opacity(0.85))
                     .frame(width: 2, height: 12)
                     .offset(x: geo.size.width * CGFloat(clampedExpected) / 100 - 1, y: -3)
-                    .shadow(color: .white.opacity(0.4), radius: 2)
+                    .dsGlow(.white, radius: 2, opacity: 0.4)
             }
         }
         .frame(height: 12)
@@ -652,7 +655,7 @@ struct MonitoringView: View {
                     .font(.system(size: 20, weight: .bold, design: .rounded))
                     .monospacedDigit()
                     .foregroundStyle(tint)
-                    .shadow(color: tint.opacity(0.45), radius: 4)
+                    .dsGlow(tint, radius: 4, opacity: 0.45)
             }
             if limit > 0 {
                 GeometryReader { geo in
@@ -922,7 +925,7 @@ private struct MetricTile: View {
                     RoundedRectangle(cornerRadius: 1.5)
                         .fill(LinearGradient(colors: [color.opacity(0.65), color], startPoint: .leading, endPoint: .trailing))
                         .frame(width: geo.size.width * clamped, height: 3)
-                        .shadow(color: color.opacity(0.5), radius: 3)
+                        .dsGlow(color, radius: 3, opacity: 0.5)
                 }
             }
             .frame(height: 3)
@@ -1252,7 +1255,7 @@ private struct HeroPacingGraph: View {
                 Circle()
                     .fill(trajectoryColor)
                     .frame(width: 8, height: 8)
-                    .shadow(color: trajectoryColor.opacity(0.6), radius: 5)
+                    .dsGlow(trajectoryColor, radius: 5, opacity: 0.6)
                     .position(actualPoint)
             }
         }

--- a/TokenEaterApp/Popover/CompactLayoutView.swift
+++ b/TokenEaterApp/Popover/CompactLayoutView.swift
@@ -251,7 +251,7 @@ private struct ChipView: View {
                     .stroke(color, style: StrokeStyle(lineWidth: 4, lineCap: .round))
                     .frame(width: 38, height: 38)
                     .rotationEffect(.degrees(-90))
-                    .shadow(color: color.opacity(0.4), radius: 3)
+                    .dsGlow(color, radius: 3, opacity: 0.4)
             }
             VStack(alignment: .leading, spacing: 1) {
                 Text(label.uppercased())
@@ -342,7 +342,7 @@ struct CompactExtraChip: View {
                     .stroke(color, style: StrokeStyle(lineWidth: 3, lineCap: .round))
                     .frame(width: 28, height: 28)
                     .rotationEffect(.degrees(-90))
-                    .shadow(color: color.opacity(0.4), radius: 2)
+                    .dsGlow(color, radius: 2, opacity: 0.4)
             }
             VStack(alignment: .leading, spacing: 0) {
                 Text(label.uppercased())

--- a/TokenEaterApp/Popover/FocusLayoutView.swift
+++ b/TokenEaterApp/Popover/FocusLayoutView.swift
@@ -157,7 +157,7 @@ private struct FocusHeroView: View {
                 Text(heroValue)
                     .font(.system(size: 38, weight: .black, design: .rounded))
                     .foregroundStyle(heroColor)
-                    .shadow(color: heroColor.opacity(0.35), radius: 10)
+                    .dsGlow(heroColor, radius: 10, opacity: 0.35)
                 Text(heroLabel.uppercased())
                     .font(.system(size: 9, weight: .semibold))
                     .foregroundStyle(.white.opacity(0.5))
@@ -253,7 +253,7 @@ private struct FocusHeroView: View {
                 path
                     .trim(from: 0, to: heroProgress)
                     .stroke(heroColor, style: StrokeStyle(lineWidth: strokeW, lineCap: .round))
-                    .shadow(color: heroColor.opacity(0.5), radius: 8)
+                    .dsGlow(heroColor, radius: 8, opacity: 0.5)
             }
         }
     }

--- a/TokenEaterApp/ThemesSectionView.swift
+++ b/TokenEaterApp/ThemesSectionView.swift
@@ -60,6 +60,27 @@ struct ThemesSectionView: View {
                 }
             }
 
+            // Glow intensity
+            glassCard {
+                HStack(alignment: .center) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        cardLabel(String(localized: "settings.glow.title"))
+                        Text(String(localized: "settings.glow.hint"))
+                            .font(.system(size: 11))
+                            .foregroundStyle(.white.opacity(0.5))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Spacer()
+                    Toggle("", isOn: Binding(
+                        get: { settingsStore.glowIntensity == .glow },
+                        set: { settingsStore.glowIntensity = $0 ? .glow : .flat }
+                    ))
+                    .toggleStyle(.switch)
+                    .tint(DS.Palette.accentSettings)
+                    .labelsHidden()
+                }
+            }
+
             // Presets
             glassCard {
                 VStack(alignment: .leading, spacing: 12) {


### PR DESCRIPTION
## Summary

Some users find the popover + monitoring view's neon halo too heavy. Adds a binary toggle under Settings > Themes that swaps every decorative shadow on the popover and monitoring view between the default glow look and a clean flat look. Driven via a single environment value, so toggling propagates everywhere instantly.

Addresses the request in Discussion [#168](https://github.com/AThevon/TokenEater/discussions/168) by @kjsmith1026.

## What changed

- New `DS.GlowIntensity` enum (`.glow` / `.flat`) and `.dsGlow()` view modifier that reads the current intensity from the SwiftUI environment
- Route every dominant glow shadow through `.dsGlow()` -> `RingGauge`, `GlowText`, MonitoringView hero ring + pacing + metric tiles, popover FocusLayout + CompactLayout rings
- Skip the radial gradient behind the 5h session hero ring when Flat is on (was the most visible \"residual\" glow)
- Persist via `SettingsStore.glowIntensity` (UserDefaults), defaults to `.glow`
- Plumb the intensity into the environment from `MainAppView` and `MenuBarPopoverView`
- Add the toggle UI in `ThemesSectionView` (Glow / Flat card, simple Toggle with `accentSettings` tint)

## Test plan

- [x] Toggle Glow / Flat in Settings > Themes
- [x] Popover updates immediately (all rings, pacing tiles)
- [x] Monitoring view updates immediately (hero ring + radial backdrop + pacing tiles)
- [x] Release build verified locally with Xcode 16.4