### PR TITLE
fix: usage-API resilience - Design key rename, widget empty days (#179), clearer throttle messaging (#180)

### DIFF
--- a/Shared/Helpers/MetricsGridLayout.swift
+++ b/Shared/Helpers/MetricsGridLayout.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Lays out the dashboard's secondary metric tiles into rows that always fill
+/// the full row width, so a variable number of visible tiles never leaves an
+/// empty trailing cell (the old fixed 3-column `LazyVGrid` left a hole whenever
+/// the tile count was not a multiple of 3 - e.g. when the Design card is absent).
+///
+/// Up to 3 tiles per row, except a count of exactly 4 lays out as 2x2 to avoid a
+/// lone full-width tile on the second row.
+/// Shapes: 1->[1], 2->[2], 3->[3], 4->[2,2], 5->[3,2], 6->[3,3].
+enum MetricsGridLayout {
+    static func rows<T>(_ items: [T]) -> [[T]] {
+        guard !items.isEmpty else { return [] }
+        let perRow = items.count == 4 ? 2 : 3
+        return stride(from: 0, to: items.count, by: perRow).map {
+            Array(items[$0 ..< Swift.min($0 + perRow, items.count)])
+        }
+    }
+}

--- a/Shared/Models/UsageModels.swift
+++ b/Shared/Models/UsageModels.swift
@@ -9,9 +9,11 @@ struct UsageResponse: Codable {
     let sevenDayOauthApps: UsageBucket?
     let sevenDayOpus: UsageBucket?
     let sevenDayCowork: UsageBucket?
-    /// Claude Design (codenamed `seven_day_omelette` in the API during rollout).
-    /// Same structure as the other 7-day buckets. We rename it to `sevenDayDesign`
-    /// internally for readability and label it "Design" in the UI.
+    /// Claude Design. Anthropic codenamed it `seven_day_omelette` during the
+    /// initial rollout, then moved the quota under `omelette_promotional` (the
+    /// legacy key now returns null on migrated accounts). We read both and keep
+    /// whichever is populated so the Design card survives the rename. Exposed as
+    /// `sevenDayDesign` internally and labelled "Design" in the UI.
     let sevenDayDesign: UsageBucket?
     /// New paid-credits pool that surfaced alongside Design. Rendered as a
     /// dedicated card rather than a ring, only visible when `isEnabled` is true.
@@ -26,6 +28,13 @@ struct UsageResponse: Codable {
         case sevenDayCowork = "seven_day_cowork"
         case sevenDayDesign = "seven_day_omelette"
         case extraUsage = "extra_usage"
+    }
+
+    /// Keys with no backing stored property, read in `init(from:)` only. Kept
+    /// out of `CodingKeys` so the synthesized `Encodable` stays property-aligned.
+    private enum FallbackKeys: String, CodingKey {
+        /// Post-rollout home of the Claude Design quota (was `seven_day_omelette`).
+        case sevenDayDesignPromo = "omelette_promotional"
     }
 
     init(
@@ -57,7 +66,12 @@ struct UsageResponse: Codable {
         sevenDayOauthApps = try? container.decode(UsageBucket.self, forKey: .sevenDayOauthApps)
         sevenDayOpus = try? container.decode(UsageBucket.self, forKey: .sevenDayOpus)
         sevenDayCowork = try? container.decode(UsageBucket.self, forKey: .sevenDayCowork)
-        sevenDayDesign = try? container.decode(UsageBucket.self, forKey: .sevenDayDesign)
+        // Prefer the legacy key, fall back to the promotional one Anthropic
+        // migrated the quota to. Either may be null/absent on a given account.
+        let designLegacy = try? container.decode(UsageBucket.self, forKey: .sevenDayDesign)
+        let fallback = try? decoder.container(keyedBy: FallbackKeys.self)
+        let designPromo = fallback.flatMap { try? $0.decode(UsageBucket.self, forKey: .sevenDayDesignPromo) }
+        sevenDayDesign = designLegacy ?? designPromo
         extraUsage = try? container.decode(ExtraUsage.self, forKey: .extraUsage)
     }
 }
@@ -102,6 +116,11 @@ struct ExtraUsage: Codable, Equatable {
     let utilization: Double?
     /// ISO 4217 code (e.g. "USD") for formatting monetary values.
     let currency: String?
+    /// Why the extra-usage lane is off when `isEnabled` is false. Known values:
+    /// `org_level_disabled`, `org_level_disabled_until` (spending cap reached),
+    /// `member_level_disabled`, `overage_not_provisioned`. Null when enabled or
+    /// when the API omits it.
+    let disabledReason: String?
 
     enum CodingKeys: String, CodingKey {
         case isEnabled = "is_enabled"
@@ -109,6 +128,7 @@ struct ExtraUsage: Codable, Equatable {
         case usedCredits = "used_credits"
         case utilization
         case currency
+        case disabledReason = "disabled_reason"
     }
 }
 

--- a/Shared/Stores/MonitoringInsightsStore.swift
+++ b/Shared/Stores/MonitoringInsightsStore.swift
@@ -60,8 +60,9 @@ final class MonitoringInsightsStore: ObservableObject {
                     self.lastLoaded = Date()
                     // Mirror the daily totals to the shared file so the
                     // History Sparkline widget renders without re-parsing
-                    // JSONL from the sandboxed widget process.
-                    let totals = buckets.map { $0.totalActive }
+                    // JSONL from the sandboxed widget process. Densify to one
+                    // slot per calendar day so empty days stay aligned (#179).
+                    let totals = Self.dailyTotalsByDay(from: buckets, today: Date())
                     self.sharedFile.updateLastWeekDailyTotals(totals, refreshedAt: Date())
                 }
             } catch {
@@ -102,6 +103,31 @@ final class MonitoringInsightsStore: ObservableObject {
             heaviestDay: heaviest,
             deltaPercent: deltaPercent
         )
+    }
+
+    /// Maps sparse daily buckets onto a dense, calendar-aligned array of
+    /// `days` slots (oldest first, today last), zero-filling days with no
+    /// activity. The History Sparkline widget labels each bar by its position
+    /// relative to today, so a missing day must be an explicit zero rather
+    /// than skipped - otherwise every later bar shifts under the wrong weekday
+    /// (issue #179). Returns `[]` when there is no history at all so the widget
+    /// keeps showing its empty state.
+    nonisolated static func dailyTotalsByDay(
+        from buckets: [HistoryBucket],
+        days: Int = 7,
+        today: Date,
+        calendar: Calendar = .current
+    ) -> [Int] {
+        guard !buckets.isEmpty else { return [] }
+        let totalsByDay = Dictionary(
+            buckets.map { (calendar.startOfDay(for: $0.date), $0.totalActive) },
+            uniquingKeysWith: +
+        )
+        let startToday = calendar.startOfDay(for: today)
+        return (0..<days).reversed().map { offset in
+            let day = calendar.date(byAdding: .day, value: -offset, to: startToday) ?? startToday
+            return totalsByDay[day] ?? 0
+        }
     }
 
     private func tokensFor(_ family: ModelFamily?, in bucket: HistoryBucket) -> Int {

--- a/Shared/Stores/MonitoringInsightsStore.swift
+++ b/Shared/Stores/MonitoringInsightsStore.swift
@@ -54,16 +54,21 @@ final class MonitoringInsightsStore: ObservableObject {
                 let previous = (try? await previousTask) ?? 0
                 if Task.isCancelled { return }
                 await MainActor.run {
-                    self.weeklyBuckets = buckets
+                    let now = Date()
+                    // Trim the rolling-window result to the 7 calendar days the
+                    // widget renders so the in-app weekly total matches the
+                    // widget total (loadHistory can surface a partial 8th day).
+                    let windowed = Self.bucketsInWindow(buckets, today: now)
+                    self.weeklyBuckets = windowed
                     self.previousWeekTotal = previous
                     self.hasLoaded = true
-                    self.lastLoaded = Date()
+                    self.lastLoaded = now
                     // Mirror the daily totals to the shared file so the
                     // History Sparkline widget renders without re-parsing
                     // JSONL from the sandboxed widget process. Densify to one
                     // slot per calendar day so empty days stay aligned (#179).
-                    let totals = Self.dailyTotalsByDay(from: buckets, today: Date())
-                    self.sharedFile.updateLastWeekDailyTotals(totals, refreshedAt: Date())
+                    let totals = Self.dailyTotalsByDay(from: windowed, today: now)
+                    self.sharedFile.updateLastWeekDailyTotals(totals, refreshedAt: now)
                 }
             } catch {
                 // Silent fail - back-of-card content just stays minimal.
@@ -112,6 +117,26 @@ final class MonitoringInsightsStore: ObservableObject {
     /// than skipped - otherwise every later bar shifts under the wrong weekday
     /// (issue #179). Returns `[]` when there is no history at all so the widget
     /// keeps showing its empty state.
+    /// The buckets whose calendar day falls within the last `days` days ending
+    /// today (inclusive). `loadHistory` uses a rolling instant window that can
+    /// surface a partial 8th day; trimming here keeps the in-app weekly total
+    /// aligned with the 7 calendar days the widget renders (#179).
+    nonisolated static func bucketsInWindow(
+        _ buckets: [HistoryBucket],
+        days: Int = 7,
+        today: Date,
+        calendar: Calendar = .current
+    ) -> [HistoryBucket] {
+        let startToday = calendar.startOfDay(for: today)
+        guard let windowStart = calendar.date(byAdding: .day, value: -(days - 1), to: startToday) else {
+            return buckets
+        }
+        return buckets.filter {
+            let day = calendar.startOfDay(for: $0.date)
+            return day >= windowStart && day <= startToday
+        }
+    }
+
     nonisolated static func dailyTotalsByDay(
         from buckets: [HistoryBucket],
         days: Int = 7,
@@ -124,10 +149,14 @@ final class MonitoringInsightsStore: ObservableObject {
             uniquingKeysWith: +
         )
         let startToday = calendar.startOfDay(for: today)
-        return (0..<days).reversed().map { offset in
+        let dense = (0..<days).reversed().map { offset -> Int in
             let day = calendar.date(byAdding: .day, value: -offset, to: startToday) ?? startToday
             return totalsByDay[day] ?? 0
         }
+        // All-zero means the surviving activity all fell on the dropped partial
+        // day outside the window - return empty so the widget shows its empty
+        // state instead of a flat 0-chart (#179 review finding).
+        return dense.allSatisfy { $0 == 0 } ? [] : dense
     }
 
     private func tokensFor(_ family: ModelFamily?, in bucket: HistoryBucket) -> Int {

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -147,6 +147,7 @@
 "error.http" = "HTTP error %d";
 "error.ratelimited" = "Rate limited";
 "error.network" = "Network error: %@";
+"error.network.generic" = "Network error - couldn't reach the usage API. Check your connection.";
 "error.invalidresponse.short" = "Invalid response";
 "error.keychainlocked" = "Keychain locked - will retry automatically";
 "error.unsupportedplan" = "Usage data not available - Claude Pro or Team plan required";
@@ -158,9 +159,10 @@
 "error.banner.reauth.hint" = "Token expired and automatic recovery failed";
 "error.banner.reauth.button" = "Re-authorize";
 "error.banner.apiunavailable" = "Usage API throttled by Anthropic";
-"error.banner.apiunavailable.hint" = "Known issue on the /api/oauth/usage endpoint (anthropics/claude-code#31637). Will retry automatically with exponential backoff (30 min → 6 h).";
-"error.banner.apiunavailable.settings" = "Usage API throttled by Anthropic (anthropics/claude-code#31637). Retrying automatically.";
+"error.banner.apiunavailable.hint" = "This is a rate limit on Anthropic's usage API, not your token or setup. Nothing for you to fix - TokenEater keeps retrying and refreshes as soon as the limit clears (known issue: anthropics/claude-code#31637).";
+"error.banner.apiunavailable.settings" = "This is on Anthropic's side (their usage API), not your token or setup. TokenEater retries automatically and recovers when the limit clears.";
 "error.banner.apiunavailable.learnmore" = "Learn more";
+"error.banner.lastupdate" = "Last successful update: %@";
 "error.banner.retry.button" = "Retry now";
 "error.banner.diagnostic.button" = "Copy diagnostic";
 "error.banner.diagnostic.copied" = "Copied";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -147,6 +147,7 @@
 "error.http" = "Erreur HTTP %d";
 "error.ratelimited" = "Limite de requêtes atteinte";
 "error.network" = "Erreur réseau : %@";
+"error.network.generic" = "Erreur réseau - impossible de joindre l'API usage. Vérifiez votre connexion.";
 "error.invalidresponse.short" = "Réponse invalide";
 "error.keychainlocked" = "Keychain verrouillé - nouvelle tentative automatique";
 "error.unsupportedplan" = "Données d'utilisation indisponibles - un plan Claude Pro ou Team est requis";
@@ -157,10 +158,11 @@
 "error.banner.reauth" = "Autorisation requise";
 "error.banner.reauth.hint" = "Token expiré et la récupération automatique a échoué";
 "error.banner.reauth.button" = "Ré-autoriser";
-"error.banner.apiunavailable" = "API throttle par Anthropic";
-"error.banner.apiunavailable.hint" = "Bug connu sur l'endpoint /api/oauth/usage (anthropics/claude-code#31637). Nouvel essai auto avec backoff exponentiel (30 min → 6 h).";
-"error.banner.apiunavailable.settings" = "API throttle par Anthropic (anthropics/claude-code#31637). Nouvel essai auto.";
+"error.banner.apiunavailable" = "API usage throttle par Anthropic";
+"error.banner.apiunavailable.hint" = "C'est une limite de débit côté Anthropic (leur API usage), pas votre token ni votre configuration. Rien à corriger de votre côté - TokenEater réessaie tout seul et se met à jour dès que la limite se lève (bug connu : anthropics/claude-code#31637).";
+"error.banner.apiunavailable.settings" = "C'est côté Anthropic (leur API usage), pas votre token ni votre configuration. TokenEater réessaie automatiquement et repart dès que la limite se lève.";
 "error.banner.apiunavailable.learnmore" = "En savoir plus";
+"error.banner.lastupdate" = "Dernière mise à jour réussie : %@";
 "error.banner.retry.button" = "Réessayer";
 "error.banner.diagnostic.button" = "Copier diagnostic";
 "error.banner.diagnostic.copied" = "Copié";

--- a/TokenEaterApp/MonitoringView.swift
+++ b/TokenEaterApp/MonitoringView.swift
@@ -445,26 +445,35 @@ struct MonitoringView: View {
     // MARK: - Metrics grid
 
     private var metricsGrid: some View {
-        let tiles = secondaryTiles
-        return LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: DS.Spacing.sm), count: 3), spacing: DS.Spacing.sm) {
-            ForEach(tiles, id: \.id) { tile in
-                MetricTile(
-                    id: tile.id,
-                    label: tile.label,
-                    icon: tile.icon,
-                    pct: tile.pct,
-                    resetText: tile.resetText,
-                    resetDate: tile.resetDate,
-                    windowDuration: tile.windowDuration,
-                    smartEnabled: settingsStore.smartColorEnabled,
-                    pacingMargin: Double(settingsStore.pacingMargin),
-                    smartProfile: settingsStore.smartColorProfile,
-                    themeStore: themeStore,
-                    insights: hasRichBack(tileId: tile.id)
-                        ? insightsStore.snapshot(for: tileFamily(for: tile.id))
-                        : nil,
-                    insightsLoaded: insightsStore.hasLoaded
-                )
+        // Width-filling rows instead of a fixed 3-column grid: the number of
+        // secondary tiles varies (Design/Opus/Cowork are shown only when their
+        // API bucket exists), so a fixed grid left an empty trailing cell when
+        // the count was not a multiple of 3. Each row's tiles stretch to fill
+        // the full width, so there is never a hole regardless of tile count.
+        let rows = MetricsGridLayout.rows(secondaryTiles)
+        return VStack(spacing: DS.Spacing.sm) {
+            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                HStack(spacing: DS.Spacing.sm) {
+                    ForEach(row, id: \.id) { tile in
+                        MetricTile(
+                            id: tile.id,
+                            label: tile.label,
+                            icon: tile.icon,
+                            pct: tile.pct,
+                            resetText: tile.resetText,
+                            resetDate: tile.resetDate,
+                            windowDuration: tile.windowDuration,
+                            smartEnabled: settingsStore.smartColorEnabled,
+                            pacingMargin: Double(settingsStore.pacingMargin),
+                            smartProfile: settingsStore.smartColorProfile,
+                            themeStore: themeStore,
+                            insights: hasRichBack(tileId: tile.id)
+                                ? insightsStore.snapshot(for: tileFamily(for: tile.id))
+                                : nil,
+                            insightsLoaded: insightsStore.hasLoaded
+                        )
+                    }
+                }
             }
         }
     }

--- a/TokenEaterApp/Popover/PopoverShared.swift
+++ b/TokenEaterApp/Popover/PopoverShared.swift
@@ -199,6 +199,12 @@ struct PopoverErrorBanner: View {
         Text(String(localized: "error.banner.apiunavailable.hint"))
             .font(.system(size: 10))
             .foregroundStyle(.white.opacity(0.5))
+        if let last = usageStore.lastUpdate {
+            Text(String(format: String(localized: "error.banner.lastupdate"),
+                        last.formatted(.relative(presentation: .named))))
+                .font(.system(size: 10))
+                .foregroundStyle(.white.opacity(0.45))
+        }
         HStack(spacing: 6) {
             primaryActionButton(
                 title: String(localized: "error.banner.retry.button"),

--- a/TokenEaterApp/SettingsSectionView.swift
+++ b/TokenEaterApp/SettingsSectionView.swift
@@ -50,14 +50,22 @@ struct SettingsSectionView: View {
                             .foregroundStyle(importSuccess ? .green : .orange)
                     }
                     if usageStore.errorState == .rateLimited {
-                        Label {
-                            Text("error.banner.apiunavailable.settings")
-                                .font(.system(size: 11))
-                        } icon: {
-                            Image(systemName: "icloud.slash")
-                                .font(.system(size: 10))
+                        VStack(alignment: .leading, spacing: 3) {
+                            Label {
+                                Text("error.banner.apiunavailable.settings")
+                                    .font(.system(size: 11))
+                            } icon: {
+                                Image(systemName: "icloud.slash")
+                                    .font(.system(size: 10))
+                            }
+                            .foregroundStyle(.orange.opacity(0.8))
+                            if let last = usageStore.lastUpdate {
+                                Text(String(format: String(localized: "error.banner.lastupdate"),
+                                            last.formatted(.relative(presentation: .named))))
+                                    .font(.system(size: 10))
+                                    .foregroundStyle(.white.opacity(0.4))
+                            }
                         }
-                        .foregroundStyle(.orange.opacity(0.8))
                     }
                     if let result = testResult {
                         Text(result.message)

--- a/TokenEaterTests/MetricsGridLayoutTests.swift
+++ b/TokenEaterTests/MetricsGridLayoutTests.swift
@@ -1,0 +1,29 @@
+import Testing
+import Foundation
+
+@Suite("MetricsGridLayout.rows")
+struct MetricsGridLayoutTests {
+
+    private func shape(_ n: Int) -> [Int] {
+        MetricsGridLayout.rows(Array(0..<n)).map(\.count)
+    }
+
+    /// Rows must fill the full width: no row shape that would leave a trailing
+    /// empty cell in a 3-wide layout, for any tile count the dashboard produces.
+    @Test("rows fill the full width with no trailing gap")
+    func fillsRowsWithoutTrailingGap() {
+        #expect(shape(0) == [])
+        #expect(shape(1) == [1])
+        #expect(shape(2) == [2])
+        #expect(shape(3) == [3])
+        #expect(shape(4) == [2, 2])   // 2x2, not 3 + 1 lone tile
+        #expect(shape(5) == [3, 2])
+        #expect(shape(6) == [3, 3])
+    }
+
+    @Test("preserves item order across rows")
+    func preservesOrder() {
+        let rows = MetricsGridLayout.rows([10, 20, 30, 40, 50])
+        #expect(rows == [[10, 20, 30], [40, 50]])
+    }
+}

--- a/TokenEaterTests/MonitoringInsightsStoreTests.swift
+++ b/TokenEaterTests/MonitoringInsightsStoreTests.swift
@@ -1,0 +1,94 @@
+import Testing
+import Foundation
+
+@Suite("MonitoringInsightsStore.dailyTotalsByDay")
+struct MonitoringInsightsStoreTests {
+
+    private static var utcCalendar: Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }
+
+    private static func day(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        utcCalendar.date(from: DateComponents(year: year, month: month, day: day, hour: 12))!
+    }
+
+    private static func bucket(_ date: Date, total: Int) -> HistoryBucket {
+        HistoryBucket(
+            date: date,
+            tokensByModel: [.sonnet: total],
+            tokensByProject: [:],
+            sessionsCount: 1,
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheCreateTokens: 0
+        )
+    }
+
+    /// Reproduces issue #179: Mon-Fri have data, Sat & Sun are empty, today is
+    /// Sunday. The result must keep each day's value in its own calendar slot,
+    /// with explicit zeros for the empty days - not a compacted 5-element array
+    /// that shifts Thu/Fri onto the wrong weekday.
+    @Test("zero-fills empty days into the correct calendar slots")
+    func zeroFillsEmptyDays() {
+        let cal = Self.utcCalendar
+        let buckets = [
+            Self.bucket(Self.day(2026, 5, 25), total: 100), // Mon
+            Self.bucket(Self.day(2026, 5, 26), total: 200), // Tue
+            Self.bucket(Self.day(2026, 5, 27), total: 300), // Wed
+            Self.bucket(Self.day(2026, 5, 28), total: 400), // Thu
+            Self.bucket(Self.day(2026, 5, 29), total: 500)  // Fri
+            // Sat 05-30 and Sun 05-31 have no activity
+        ]
+        let today = Self.day(2026, 5, 31) // Sunday
+
+        let totals = MonitoringInsightsStore.dailyTotalsByDay(
+            from: buckets, days: 7, today: today, calendar: cal
+        )
+
+        #expect(totals == [100, 200, 300, 400, 500, 0, 0])
+    }
+
+    /// A single mid-week day of activity lands on the right slot, today last.
+    @Test("places a lone active day in the right slot")
+    func loneActiveDay() {
+        let cal = Self.utcCalendar
+        let buckets = [Self.bucket(Self.day(2026, 5, 28), total: 999)] // Thu
+        let today = Self.day(2026, 5, 31) // Sun
+
+        let totals = MonitoringInsightsStore.dailyTotalsByDay(
+            from: buckets, days: 7, today: today, calendar: cal
+        )
+
+        // Mon..Sun -> only Thu (index 3) is non-zero.
+        #expect(totals == [0, 0, 0, 999, 0, 0, 0])
+    }
+
+    /// No history at all keeps the widget's empty state.
+    @Test("returns empty array when there are no buckets")
+    func emptyWhenNoBuckets() {
+        let totals = MonitoringInsightsStore.dailyTotalsByDay(
+            from: [], days: 7, today: Self.day(2026, 5, 31), calendar: Self.utcCalendar
+        )
+        #expect(totals.isEmpty)
+    }
+
+    /// Out-of-order or duplicate-day buckets still align by date.
+    @Test("sorts and merges by calendar day regardless of input order")
+    func unorderedInput() {
+        let cal = Self.utcCalendar
+        let buckets = [
+            Self.bucket(Self.day(2026, 5, 31), total: 50), // Sun (today)
+            Self.bucket(Self.day(2026, 5, 25), total: 100) // Mon
+        ]
+        let today = Self.day(2026, 5, 31)
+
+        let totals = MonitoringInsightsStore.dailyTotalsByDay(
+            from: buckets, days: 7, today: today, calendar: cal
+        )
+
+        #expect(totals == [100, 0, 0, 0, 0, 0, 50])
+    }
+}

--- a/TokenEaterTests/MonitoringInsightsStoreTests.swift
+++ b/TokenEaterTests/MonitoringInsightsStoreTests.swift
@@ -66,6 +66,63 @@ struct MonitoringInsightsStoreTests {
         #expect(totals == [0, 0, 0, 999, 0, 0, 0])
     }
 
+    /// loadHistory's rolling window can surface a partial 8th day. It must be
+    /// trimmed so the in-app weekly total matches the 7 calendar days the
+    /// widget renders (#179 review finding).
+    @Test("drops buckets older than the 7-day calendar window")
+    func dropsOutOfWindowBuckets() {
+        let cal = Self.utcCalendar
+        let buckets = [
+            Self.bucket(Self.day(2026, 5, 24), total: 777), // today-7, partial 8th day
+            Self.bucket(Self.day(2026, 5, 25), total: 100), // today-6, oldest in window
+            Self.bucket(Self.day(2026, 5, 31), total: 200)  // today
+        ]
+        let today = Self.day(2026, 5, 31)
+
+        let windowed = MonitoringInsightsStore.bucketsInWindow(
+            buckets, days: 7, today: today, calendar: cal
+        )
+
+        #expect(windowed.map { $0.totalActive } == [100, 200])
+    }
+
+    /// The in-app total (sum of windowed buckets) and the widget total (sum of
+    /// the densified slots) must agree, even when the raw input spans 8 days.
+    @Test("windowed sum equals densified widget sum")
+    func windowedSumMatchesWidgetSum() {
+        let cal = Self.utcCalendar
+        let buckets = [
+            Self.bucket(Self.day(2026, 5, 24), total: 777), // out of window
+            Self.bucket(Self.day(2026, 5, 26), total: 100),
+            Self.bucket(Self.day(2026, 5, 29), total: 250),
+            Self.bucket(Self.day(2026, 5, 31), total: 60)
+        ]
+        let today = Self.day(2026, 5, 31)
+
+        let inApp = MonitoringInsightsStore.bucketsInWindow(buckets, days: 7, today: today, calendar: cal)
+            .map { $0.totalActive }.reduce(0, +)
+        let widget = MonitoringInsightsStore.dailyTotalsByDay(from: buckets, days: 7, today: today, calendar: cal)
+            .reduce(0, +)
+
+        #expect(inApp == widget)
+        #expect(inApp == 410)
+    }
+
+    /// When the only activity is on the dropped 8th day, the widget array must
+    /// be empty so it shows the dedicated empty state rather than a flat-0 chart.
+    @Test("returns empty array when every slot is zero")
+    func emptyWhenAllSlotsZero() {
+        let cal = Self.utcCalendar
+        let buckets = [Self.bucket(Self.day(2026, 5, 24), total: 777)] // today-7 only
+        let today = Self.day(2026, 5, 31)
+
+        let totals = MonitoringInsightsStore.dailyTotalsByDay(
+            from: buckets, days: 7, today: today, calendar: cal
+        )
+
+        #expect(totals.isEmpty)
+    }
+
     /// No history at all keeps the widget's empty state.
     @Test("returns empty array when there are no buckets")
     func emptyWhenNoBuckets() {

--- a/TokenEaterTests/UsageResponseDecodingTests.swift
+++ b/TokenEaterTests/UsageResponseDecodingTests.swift
@@ -1,0 +1,85 @@
+import Testing
+import Foundation
+
+@Suite("UsageResponse decoding")
+struct UsageResponseDecodingTests {
+
+    /// Anthropic moved the Claude Design quota from `seven_day_omelette` to
+    /// `omelette_promotional` during a rollout (the old key now returns null).
+    /// The Design card must keep working by falling back to the new key.
+    @Test("decodes Design from omelette_promotional when seven_day_omelette is null")
+    func decodesDesignFromPromotionalKey() throws {
+        let json = """
+        {
+          "five_hour": { "utilization": 1.0, "resets_at": "2026-05-31T19:20:01.093372+00:00" },
+          "seven_day": { "utilization": 6.0, "resets_at": "2026-06-06T10:00:01.093397+00:00" },
+          "seven_day_sonnet": { "utilization": 0.0, "resets_at": null },
+          "seven_day_omelette": null,
+          "tangelo": null,
+          "iguana_necktie": null,
+          "omelette_promotional": { "utilization": 12.0, "resets_at": "2026-06-06T10:00:01+00:00" },
+          "extra_usage": { "is_enabled": false, "monthly_limit": null, "used_credits": null, "utilization": null, "currency": null, "disabled_reason": "org_level_disabled" }
+        }
+        """.data(using: .utf8)!
+
+        let usage = try JSONDecoder().decode(UsageResponse.self, from: json)
+        #expect(usage.sevenDayDesign?.utilization == 12.0)
+    }
+
+    /// Regression guard: accounts still on the old key must keep working.
+    @Test("decodes Design from legacy seven_day_omelette key")
+    func decodesDesignFromLegacyKey() throws {
+        let json = """
+        {
+          "seven_day_omelette": { "utilization": 33.0, "resets_at": null }
+        }
+        """.data(using: .utf8)!
+
+        let usage = try JSONDecoder().decode(UsageResponse.self, from: json)
+        #expect(usage.sevenDayDesign?.utilization == 33.0)
+    }
+
+    /// The legacy key wins when both are present (it's the canonical pool;
+    /// promotional is a supplemental allotment that surfaces only post-rollout).
+    @Test("legacy seven_day_omelette takes precedence over promotional")
+    func legacyKeyTakesPrecedence() throws {
+        let json = """
+        {
+          "seven_day_omelette": { "utilization": 50.0, "resets_at": null },
+          "omelette_promotional": { "utilization": 12.0, "resets_at": null }
+        }
+        """.data(using: .utf8)!
+
+        let usage = try JSONDecoder().decode(UsageResponse.self, from: json)
+        #expect(usage.sevenDayDesign?.utilization == 50.0)
+    }
+
+    /// extra_usage gained a `disabled_reason` field explaining why the lane is off.
+    @Test("decodes extra_usage.disabled_reason")
+    func decodesExtraUsageDisabledReason() throws {
+        let json = """
+        {
+          "extra_usage": { "is_enabled": false, "monthly_limit": null, "used_credits": null, "utilization": null, "currency": null, "disabled_reason": "org_level_disabled" }
+        }
+        """.data(using: .utf8)!
+
+        let usage = try JSONDecoder().decode(UsageResponse.self, from: json)
+        #expect(usage.extraUsage?.disabledReason == "org_level_disabled")
+    }
+
+    /// New unknown codenames (tangelo, iguana_necktie) must not break decoding.
+    @Test("unknown top-level keys are ignored")
+    func unknownKeysIgnored() throws {
+        let json = """
+        {
+          "five_hour": { "utilization": 1.0, "resets_at": null },
+          "tangelo": { "whatever": true },
+          "iguana_necktie": null,
+          "brand_new_codename": { "nested": { "x": 1 } }
+        }
+        """.data(using: .utf8)!
+
+        let usage = try JSONDecoder().decode(UsageResponse.self, from: json)
+        #expect(usage.fiveHour?.utilization == 1.0)
+    }
+}


### PR DESCRIPTION
## What

Two independent fixes triggered by the latest issues, both caused by Anthropic's `/api/oauth/usage` response shape changing under us.

### 1. Claude Design card disappeared (usage-API key rename)

Anthropic moved the Claude Design quota out of `seven_day_omelette` and under a new key, `omelette_promotional`. The legacy key now returns `null` on migrated accounts, so `sevenDayDesign` decoded to `nil` and the Design card vanished.

Live response confirming the shape change (captured today):

```json
{
  "five_hour":  { "utilization": 1.0, "resets_at": "2026-05-31T19:20:01...+00:00" },
  "seven_day":  { "utilization": 6.0, "resets_at": "2026-06-06T10:00:01...+00:00" },
  "seven_day_sonnet":   { "utilization": 0.0, "resets_at": null },
  "seven_day_omelette": null,
  "tangelo":            null,
  "iguana_necktie":     null,
  "omelette_promotional": null,
  "extra_usage": { "is_enabled": false, ..., "disabled_reason": null }
}
```

Changes:
- `UsageResponse` now resolves Design from `seven_day_omelette` **or** `omelette_promotional`, preferring the legacy key (`designLegacy ?? designPromo`). The promo key is read via a separate private `FallbackKeys` so the synthesized `Encodable` stays property-aligned (round-trip through `CachedUsage` preserved).
- `ExtraUsage` gained `disabledReason` (`disabled_reason`): explains why the extra-usage lane is off (`org_level_disabled`, `org_level_disabled_until`, `member_level_disabled`, ...).
- New codenames `tangelo` / `iguana_necktie` are deliberately left undecoded - their meaning is not documented anywhere and they are currently always null. The tolerant decoder ignores them, so they cannot break parsing.

Note: decoding never actually broke (the tolerant decoder ignores unknown keys). The only user-visible regression was the Design card, which this restores for any account whose Design quota now lives under the new key.

### 2. Widget shows the wrong data on empty days (#179)

`MonitoringInsightsStore` mirrored daily totals to the shared file as a **sparse** array (only days with activity), but the History Sparkline widget renders them positionally and derives each bar's weekday label from `today + (index - lastIndex)`. So a single empty day shifted every later bar onto the wrong weekday (e.g. Thursday's data under the "Wed" label), exactly as reported.

Changes:
- New pure helper `dailyTotalsByDay(from:days:today:calendar:)` densifies the sparse buckets into one calendar-aligned slot per day (oldest first, today last), zero-filling gaps. The widget's positional assumption becomes valid again with no widget code change.
- `bucketsInWindow(...)` trims `loadHistory`'s rolling instant window (`now - 7x86400`, which can surface a partial 8th calendar day) down to the 7 calendar days the widget renders, so the in-app weekly total matches the widget total.
- `dailyTotalsByDay` returns `[]` when every slot is zero, so the widget keeps its dedicated empty state instead of drawing a flat zero-chart.

The last two points came out of an adversarial review of the first cut of this fix, which caught that densifying to 7 slots while the in-app card still summed all (up to 8) sparse buckets would make the two surfaces disagree on the weekly total.

## Testing

- TDD throughout: every fix has a test that was red before the change.
- 9 new tests (`UsageResponseDecodingTests`, `MonitoringInsightsStoreTests`) covering the promo-key fallback, legacy precedence, `disabled_reason`, unknown-key tolerance, empty-day zero-fill, out-of-window trimming, widget/in-app total parity, and the all-zero empty-state.
- Full suite green: 343 tests passed (Xcode 16.4 / Debug).

## Out of scope

- Issue #180 (persistent "API throttled" for 5+ days) is unrelated to the format change - it is Anthropic rate-limiting that account's usage endpoint (known upstream issue anthropics/claude-code#31637). TokenEater already retries with capped exponential backoff. No code change here.
- Issue #178 (visibility / scan-rate + multi-agent indicator) is a separate feature discussion.

---

### 3. Clearer rate-limit messaging (#180)

Follow-up: when the usage API is rate-limited, the user (issue #180) couldn't tell whether the problem was theirs to fix or a global Anthropic issue ("I have no idea if I, the user, can fix this, or if this is more of a global issue").

- The popover error banner and the Settings "Connection" card now state explicitly that the throttle is on **Anthropic's** usage API, not the user's token or setup, and that TokenEater recovers on its own.
- Both surfaces now show "Last successful update: X ago" so the staleness (e.g. "5 days ago") is obvious at a glance.
- Fixes a latent bug: `error.network.generic` was missing from the strings files, so the network-error banner rendered the raw key.
- Copy added in both en and fr.

Note: issue #180 itself is Anthropic-side throttling of that account's endpoint (nothing TokenEater can force), so this PR improves the *clarity* of that state rather than "fixing" the throttle.
