### PR TITLE
feat: configurable watcher scan rate + visibility (#178)

### DIFF
--- a/Shared/Models/WatcherScanInterval.swift
+++ b/Shared/Models/WatcherScanInterval.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// How often the local session watcher rescans running processes + JSONL tails.
+/// Lower = snappier overlay, more local CPU. There is no sub-2s option on
+/// purpose: each tick enumerates the whole process table, so 1s is materially
+/// heavier for little perceived gain.
+enum WatcherScanInterval: Int, CaseIterable, Sendable {
+    case twoSeconds = 2
+    case fiveSeconds = 5
+    case tenSeconds = 10
+
+    var seconds: TimeInterval { TimeInterval(rawValue) }
+
+    /// Compact, locale-neutral chip label ("2s", "5s", "10s").
+    var label: String { "\(rawValue)s" }
+}

--- a/Shared/Models/WatcherVisibility.swift
+++ b/Shared/Models/WatcherVisibility.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// How long a session stays visible in the watcher overlay after Claude stops
+/// writing to its JSONL. Longer windows keep more (cold) project directories in
+/// the per-tick scan, so they cost more local CPU. Capped at 7 days on purpose
+/// (no "always") to keep the steady-state scan bounded.
+enum WatcherVisibility: Int, CaseIterable, Sendable {
+    case thirtyMinutes = 1800
+    case twoHours = 7200
+    case eightHours = 28800
+    case oneDay = 86400
+    case sevenDays = 604800
+
+    var seconds: TimeInterval { TimeInterval(rawValue) }
+
+    /// Compact, locale-neutral chip label.
+    var label: String {
+        switch self {
+        case .thirtyMinutes: return "30m"
+        case .twoHours: return "2h"
+        case .eightHours: return "8h"
+        case .oneDay: return "1d"
+        case .sevenDays: return "7d"
+        }
+    }
+}

--- a/Shared/Services/Protocols/SessionMonitorServiceProtocol.swift
+++ b/Shared/Services/Protocols/SessionMonitorServiceProtocol.swift
@@ -5,4 +5,8 @@ protocol SessionMonitorServiceProtocol: AnyObject {
     var sessionsPublisher: AnyPublisher<[ClaudeSession], Never> { get }
     func startMonitoring()
     func stopMonitoring()
+    /// Update the scan cadence (seconds). Takes effect live if monitoring.
+    func setScanInterval(_ interval: TimeInterval)
+    /// Update how long a cold session stays in the scan window (seconds).
+    func setVisibility(_ freshness: TimeInterval)
 }

--- a/Shared/Services/SessionMonitorService.swift
+++ b/Shared/Services/SessionMonitorService.swift
@@ -9,8 +9,10 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
 
     private var timer: DispatchSourceTimer?
     private let queue = DispatchQueue(label: "com.tokeneater.session-monitor", qos: .utility)
-    private let scanInterval: TimeInterval
-    private let projectDirFreshness: TimeInterval
+    // Mutated only on `queue` (see setScanInterval/setVisibility) so they stay
+    // race-free despite the @unchecked Sendable conformance.
+    private var scanInterval: TimeInterval
+    private var projectDirFreshness: TimeInterval
     private let claudeProjectsDirOverride: URL?
     private let processProvider: @Sendable () -> [ClaudeProcessInfo]
 
@@ -38,9 +40,21 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
     }
 
     func startMonitoring() {
-        timer?.cancel()
-        timer = nil
+        queue.async { [weak self] in self?.startTimerLocked() }
+    }
 
+    func stopMonitoring() {
+        queue.async { [weak self] in
+            self?.timer?.cancel()
+            self?.timer = nil
+            self?.sessionsSubject.send([])
+        }
+    }
+
+    /// Builds (or rebuilds) the repeating scan timer. MUST run on `queue`,
+    /// which owns `timer`, `scanInterval` and `projectDirFreshness`.
+    private func startTimerLocked() {
+        timer?.cancel()
         let timer = DispatchSource.makeTimerSource(queue: queue)
         timer.schedule(deadline: .now(), repeating: scanInterval)
         timer.setEventHandler { [weak self] in
@@ -50,10 +64,22 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
         self.timer = timer
     }
 
-    func stopMonitoring() {
-        timer?.cancel()
-        timer = nil
-        sessionsSubject.send([])
+    /// Change the scan cadence at runtime. Rebuilds the live timer when
+    /// monitoring is active; otherwise the new value is picked up by the next
+    /// `startMonitoring`. Routed through `queue` to stay ordered with start/stop.
+    func setScanInterval(_ interval: TimeInterval) {
+        queue.async { [weak self] in
+            guard let self, interval != self.scanInterval else { return }
+            self.scanInterval = interval
+            if self.timer != nil { self.startTimerLocked() }
+        }
+    }
+
+    /// Change how long a cold session stays inside the scan window at runtime.
+    func setVisibility(_ freshness: TimeInterval) {
+        queue.async { [weak self] in
+            self?.projectDirFreshness = freshness
+        }
     }
 
     /// Internal for perf tests. Must stay safe to call synchronously off the timer queue.

--- a/Shared/Stores/SessionStore.swift
+++ b/Shared/Stores/SessionStore.swift
@@ -37,4 +37,14 @@ final class SessionStore: ObservableObject {
         monitorService.stopMonitoring()
         cancellable = nil
     }
+
+    /// Push the user's watcher scan cadence to the monitor service.
+    func setScanInterval(_ seconds: TimeInterval) {
+        monitorService.setScanInterval(seconds)
+    }
+
+    /// Push the user's watcher visibility window to the monitor service.
+    func setVisibility(_ seconds: TimeInterval) {
+        monitorService.setVisibility(seconds)
+    }
 }

--- a/Shared/Stores/SettingsStore.swift
+++ b/Shared/Stores/SettingsStore.swift
@@ -125,6 +125,12 @@ final class SettingsStore: ObservableObject {
     @Published var watcherDisplayMode: WatcherDisplayMode {
         didSet { UserDefaults.standard.set(watcherDisplayMode.rawValue, forKey: "watcherDisplayMode") }
     }
+    @Published var watcherScanInterval: WatcherScanInterval {
+        didSet { UserDefaults.standard.set(watcherScanInterval.rawValue, forKey: "watcherScanInterval") }
+    }
+    @Published var watcherVisibility: WatcherVisibility {
+        didSet { UserDefaults.standard.set(watcherVisibility.rawValue, forKey: "watcherVisibility") }
+    }
 
     // Performance
     @Published var watcherAnimationsEnabled: Bool {
@@ -290,6 +296,10 @@ final class SettingsStore: ObservableObject {
         self.watcherDisplayMode = WatcherDisplayMode(
             rawValue: UserDefaults.standard.string(forKey: "watcherDisplayMode") ?? "branchPriority"
         ) ?? .branchPriority
+        self.watcherScanInterval = (UserDefaults.standard.object(forKey: "watcherScanInterval") as? Int)
+            .flatMap(WatcherScanInterval.init(rawValue:)) ?? .twoSeconds
+        self.watcherVisibility = (UserDefaults.standard.object(forKey: "watcherVisibility") as? Int)
+            .flatMap(WatcherVisibility.init(rawValue:)) ?? .thirtyMinutes
         self.watcherAnimationsEnabled = UserDefaults.standard.object(forKey: "watcherAnimationsEnabled") as? Bool ?? true
         // Reconcile the stored toggle with the actual SMAppService state - user
         // might have flipped it from System Settings without going through the

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -523,6 +523,8 @@
 "settings.watchers.display" = "Display mode";
 "settings.watchers.display.branchPriority" = "Branch priority";
 "settings.watchers.display.projectAndBranch" = "Project + Branch";
+"settings.watchers.scanrate" = "Scan rate";
+"settings.watchers.visibility" = "Visibility";
 "settings.watchers.display.branchPriority.hint" = "Shows the git branch as the title when on a non-default branch, otherwise the project name.";
 "settings.watchers.display.projectAndBranch.hint" = "Always shows the project name as the title, with the branch displayed next to the status.";
 

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -523,6 +523,8 @@
 "settings.watchers.display" = "Mode d'affichage";
 "settings.watchers.display.branchPriority" = "Branche prioritaire";
 "settings.watchers.display.projectAndBranch" = "Projet + Branche";
+"settings.watchers.scanrate" = "Fréquence de scan";
+"settings.watchers.visibility" = "Visibilité";
 "settings.watchers.display.branchPriority.hint" = "Affiche la branche git en titre quand elle n'est pas par défaut, sinon le nom du projet.";
 "settings.watchers.display.projectAndBranch.hint" = "Affiche toujours le nom du projet en titre, avec la branche à côté du statut.";
 

--- a/TokenEaterApp/AgentWatchersSectionView.swift
+++ b/TokenEaterApp/AgentWatchersSectionView.swift
@@ -91,6 +91,36 @@ struct AgentWatchersSectionView: View {
                     }
                 }
 
+                // Scan rate -> chips (how often the watcher rescans)
+                groupLabel("settings.watchers.scanrate")
+                    .padding(.top, 4)
+                HStack(spacing: 6) {
+                    ForEach(WatcherScanInterval.allCases, id: \.self) { interval in
+                        BinaryChoiceChip(
+                            label: interval.label,
+                            icon: "arrow.clockwise",
+                            isActive: settingsStore.watcherScanInterval == interval
+                        ) {
+                            settingsStore.watcherScanInterval = interval
+                        }
+                    }
+                }
+
+                // Visibility -> chips (how long a session stays shown when idle)
+                groupLabel("settings.watchers.visibility")
+                    .padding(.top, 4)
+                HStack(spacing: 6) {
+                    ForEach(WatcherVisibility.allCases, id: \.self) { visibility in
+                        BinaryChoiceChip(
+                            label: visibility.label,
+                            icon: "eye",
+                            isActive: settingsStore.watcherVisibility == visibility
+                        ) {
+                            settingsStore.watcherVisibility = visibility
+                        }
+                    }
+                }
+
                 // Side + dock effect + animations -> chip row
                 HStack(spacing: 8) {
                     ClickChip(
@@ -289,6 +319,8 @@ struct AgentWatchersSectionView: View {
         settingsStore.watchersDetailedMode = true
         settingsStore.watcherStyle = .frost
         settingsStore.watcherDisplayMode = .branchPriority
+        settingsStore.watcherScanInterval = .twoSeconds
+        settingsStore.watcherVisibility = .thirtyMinutes
         settingsStore.watcherAnimationsEnabled = true
     }
 

--- a/TokenEaterApp/TokenEaterApp.swift
+++ b/TokenEaterApp/TokenEaterApp.swift
@@ -11,6 +11,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var statusBarController: StatusBarController?
     private var overlayWindowController: OverlayWindowController?
     private var monitorCancellable: AnyCancellable?
+    private var cancellables = Set<AnyCancellable>()
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         false
@@ -40,6 +41,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             updateStore: updateStore,
             sessionStore: sessionStore
         )
+        // Apply persisted watcher scan settings before the first tick uses them.
+        sessionStore.setScanInterval(settingsStore.watcherScanInterval.seconds)
+        sessionStore.setVisibility(settingsStore.watcherVisibility.seconds)
         if settingsStore.overlayEnabled {
             sessionStore.startMonitoring()
         }
@@ -61,6 +65,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     self.sessionStore.stopMonitoring()
                 }
             }
+
+        settingsStore.$watcherScanInterval
+            .dropFirst()
+            .removeDuplicates()
+            .sink { [weak self] interval in
+                self?.sessionStore.setScanInterval(interval.seconds)
+            }
+            .store(in: &cancellables)
+
+        settingsStore.$watcherVisibility
+            .dropFirst()
+            .removeDuplicates()
+            .sink { [weak self] visibility in
+                self?.sessionStore.setVisibility(visibility.seconds)
+            }
+            .store(in: &cancellables)
     }
 }
 

--- a/TokenEaterTests/Mocks/MockSessionMonitorService.swift
+++ b/TokenEaterTests/Mocks/MockSessionMonitorService.swift
@@ -9,9 +9,13 @@ final class MockSessionMonitorService: SessionMonitorServiceProtocol {
 
     var startMonitoringCallCount = 0
     var stopMonitoringCallCount = 0
+    var lastScanInterval: TimeInterval?
+    var lastVisibility: TimeInterval?
 
     func startMonitoring() { startMonitoringCallCount += 1 }
     func stopMonitoring() { stopMonitoringCallCount += 1 }
+    func setScanInterval(_ interval: TimeInterval) { lastScanInterval = interval }
+    func setVisibility(_ freshness: TimeInterval) { lastVisibility = freshness }
 
     func emit(_ sessions: [ClaudeSession]) {
         subject.send(sessions)

--- a/TokenEaterTests/SettingsStoreTests.swift
+++ b/TokenEaterTests/SettingsStoreTests.swift
@@ -5,7 +5,7 @@ import UserNotifications
 private let settingsKeys = [
     "showMenuBar", "pinnedMetrics", "pacingDisplayMode",
     "hasCompletedOnboarding", "proxyEnabled", "proxyHost", "proxyPort",
-    "overlayEnabled", "watcherStyle"
+    "overlayEnabled", "watcherStyle", "watcherScanInterval", "watcherVisibility"
 ]
 
 private func cleanDefaults() {
@@ -52,6 +52,34 @@ struct SettingsStoreTests {
         #expect(config.enabled == false)
         #expect(config.host == "127.0.0.1")
         #expect(config.port == 1080)
+    }
+
+    // MARK: - Watcher scan settings
+
+    @Test("watcher scan interval defaults to 2s and visibility to 30 min")
+    func watcherScanDefaults() {
+        let (store, _, _) = makeStore()
+        #expect(store.watcherScanInterval == .twoSeconds)
+        #expect(store.watcherVisibility == .thirtyMinutes)
+    }
+
+    @Test("watcher scan interval persists across store instances")
+    func watcherScanIntervalPersists() {
+        let (store, _, _) = makeStore()
+        store.watcherScanInterval = .tenSeconds
+
+        // A fresh store (same UserDefaults) must read the persisted value.
+        let reloaded = SettingsStore(notificationService: MockNotificationService(), tokenProvider: MockTokenProvider())
+        #expect(reloaded.watcherScanInterval == .tenSeconds)
+    }
+
+    @Test("watcher visibility persists across store instances")
+    func watcherVisibilityPersists() {
+        let (store, _, _) = makeStore()
+        store.watcherVisibility = .sevenDays
+
+        let reloaded = SettingsStore(notificationService: MockNotificationService(), tokenProvider: MockTokenProvider())
+        #expect(reloaded.watcherVisibility == .sevenDays)
     }
 
     // MARK: - Toggle Metric

--- a/TokenEaterTests/WatcherScanSettingsTests.swift
+++ b/TokenEaterTests/WatcherScanSettingsTests.swift
@@ -1,0 +1,50 @@
+import Testing
+import Foundation
+
+@Suite("WatcherScanInterval / WatcherVisibility")
+struct WatcherScanSettingsTests {
+
+    @Test("scan interval seconds match raw values and there is no sub-2s option")
+    func scanIntervalSeconds() {
+        #expect(WatcherScanInterval.twoSeconds.seconds == 2)
+        #expect(WatcherScanInterval.fiveSeconds.seconds == 5)
+        #expect(WatcherScanInterval.tenSeconds.seconds == 10)
+        #expect(WatcherScanInterval.allCases.map(\.rawValue).min() == 2)
+    }
+
+    @Test("scan interval labels are compact")
+    func scanIntervalLabels() {
+        #expect(WatcherScanInterval.twoSeconds.label == "2s")
+        #expect(WatcherScanInterval.tenSeconds.label == "10s")
+    }
+
+    @Test("visibility seconds cover 30 min through 7 days, no 'always'")
+    func visibilitySeconds() {
+        #expect(WatcherVisibility.thirtyMinutes.seconds == 1800)
+        #expect(WatcherVisibility.sevenDays.seconds == 604_800)
+        // Capped at 7 days on purpose (no unbounded "always" option).
+        #expect(WatcherVisibility.allCases.map(\.rawValue).max() == 604_800)
+        #expect(WatcherVisibility.allCases.count == 5)
+    }
+}
+
+@Suite("SessionStore watcher settings delegation")
+@MainActor
+struct SessionStoreWatcherSettingsTests {
+
+    @Test("setScanInterval is forwarded to the monitor service")
+    func forwardsScanInterval() {
+        let mock = MockSessionMonitorService()
+        let store = SessionStore(monitorService: mock)
+        store.setScanInterval(5)
+        #expect(mock.lastScanInterval == 5)
+    }
+
+    @Test("setVisibility is forwarded to the monitor service")
+    func forwardsVisibility() {
+        let mock = MockSessionMonitorService()
+        let store = SessionStore(monitorService: mock)
+        store.setVisibility(7200)
+        #expect(mock.lastVisibility == 7200)
+    }
+}


### PR DESCRIPTION
## What

Adds two user settings for the local Agent Watchers overlay, under **Settings > Agent Watchers > Behavior** (requested in #178):

- **Scan rate** - how often the watcher rescans running sessions: **2s / 5s / 10s**, default **2s**. No sub-2s option: each tick enumerates the whole process table, so 1s is materially heavier for little perceived gain.
- **Visibility** - how long a session stays shown after Claude stops writing to its JSONL: **30m / 2h / 8h / 1d / 7d**, default **30m**. Capped at 7 days on purpose (no unbounded "always"): a longer window keeps more cold project directories in the per-tick scan, so this bounds steady-state CPU.

## Why this shape

Issue #178 was inspired by a fork that also added an "always" visibility option and a cross-LLM (Gemini / agy) presence indicator. Two deliberate decisions here:

1. **No "always" visibility.** It removes the freshness decay that keeps the per-tick scan cheap. The capped range gives the same usefulness without the unbounded CPU cost.
2. **No cross-LLM indicator (yet).** The fork's version showed a magenta tile with a hardcoded `.idle` state (no real status), which reads as a status it doesn't actually have. Better to leave it out now and do real multi-agent support properly later than ship a misleading indicator.

## Implementation

- `WatcherScanInterval` / `WatcherVisibility` enums (raw `Int` seconds, `CaseIterable`).
- `SessionMonitorService`: `scanInterval` and `projectDirFreshness` became queue-owned `var`s. `startMonitoring` / `stopMonitoring` / new `setScanInterval` / `setVisibility` all dispatch onto the service's existing serial queue, which is now the sole owner of the timer + those vars (race-free under `@unchecked Sendable`). `setScanInterval` rebuilds the live `DispatchSourceTimer` only while monitoring; otherwise the value is picked up by the next `startMonitoring`.
- `SettingsStore`: two `@Published` settings persisted to `UserDefaults`.
- `AppDelegate`: pushes the persisted values to the service at launch (before the first tick) and on change via `Combine` sinks. Values are applied even when the overlay starts later.
- `AgentWatchersSectionView`: two chip pickers matching the existing `BinaryChoiceChip` rows. Strings in en + fr.

This touches **only** the local process watcher. It does not go near the Anthropic usage API, its polling, or the 429 backoff. The single per-tick process enumeration is unchanged (no CPU doubling).

## Testing

- 9 new tests: enum data (ranges/labels/no-sub-2s/no-always), `SettingsStore` persistence + defaults, `SessionStore` -> service delegation.
- Full suite green (339); Release app build verified (Xcode 16.4).
- Adversarial multi-agent review of the diff (concurrency / wiring / regressions): 11 candidate findings raised, 0 confirmed after verification.

> Note: not yet verified live via build + nuke + install (SwiftUI rendering of the two new pickers). Recommend a quick visual check before merge.
