### PR TITLE
fix: classify Opus 4.8 as Opus instead of Other (#188)

### DIFF
--- a/Shared/Models/UsageHistoryModels.swift
+++ b/Shared/Models/UsageHistoryModels.swift
@@ -41,6 +41,7 @@ enum HistoryRange: String, CaseIterable, Codable, Sendable {
 /// collapse all minor versions, anything unrecognised lands in `.other`. Design
 /// intentionally absent: it never appears in Claude Code JSONL files.
 enum ModelKind: String, CaseIterable, Codable, Hashable, Sendable {
+    case opus48
     case opus47
     case opus46
     case sonnet
@@ -49,10 +50,17 @@ enum ModelKind: String, CaseIterable, Codable, Hashable, Sendable {
 
     init(rawModel: String) {
         let lower = rawModel.lowercased()
-        if lower.contains("opus-4-7") || lower.contains("opus-4.7") {
+        if lower.contains("opus-4-8") || lower.contains("opus-4.8") {
+            self = .opus48
+        } else if lower.contains("opus-4-7") || lower.contains("opus-4.7") {
             self = .opus47
         } else if lower.contains("opus-4-6") || lower.contains("opus-4.6") {
             self = .opus46
+        } else if lower.contains("opus") {
+            // Bare "opus" alias and any unversioned Opus string map to the
+            // current shipping version. Future minor versions need their own
+            // explicit case above to get a distinct label and color.
+            self = .opus48
         } else if lower.contains("sonnet") {
             self = .sonnet
         } else if lower.contains("haiku") {
@@ -64,6 +72,7 @@ enum ModelKind: String, CaseIterable, Codable, Hashable, Sendable {
 
     var displayName: String {
         switch self {
+        case .opus48: return "Opus 4.8"
         case .opus47: return "Opus 4.7"
         case .opus46: return "Opus 4.6"
         case .sonnet: return "Sonnet"
@@ -72,20 +81,20 @@ enum ModelKind: String, CaseIterable, Codable, Hashable, Sendable {
         }
     }
 
-    /// Family used by the filter chips. Opus 4.7 and 4.6 fold into `.opus`
-    /// since users typically think "Opus" not "Opus 4.7 vs 4.6".
+    /// Family used by the filter chips. Opus 4.8, 4.7 and 4.6 fold into `.opus`
+    /// since users typically think "Opus" not "Opus 4.8 vs 4.7 vs 4.6".
     var family: ModelFamily {
         switch self {
-        case .opus47, .opus46: return .opus
-        case .sonnet:          return .sonnet
-        case .haiku:           return .haiku
-        case .other:           return .other
+        case .opus48, .opus47, .opus46: return .opus
+        case .sonnet:                   return .sonnet
+        case .haiku:                    return .haiku
+        case .other:                    return .other
         }
     }
 
     /// Stable order for chart stacking (heaviest at the top of the bar).
     static var stackOrder: [ModelKind] {
-        [.haiku, .opus46, .opus47, .sonnet, .other]
+        [.haiku, .opus46, .opus47, .opus48, .sonnet, .other]
     }
 }
 

--- a/TokenEaterApp/HistoryView.swift
+++ b/TokenEaterApp/HistoryView.swift
@@ -843,6 +843,7 @@ struct HistoryView: View {
     /// better readability for back-to-back stacked segments.
     private func gradient(for kind: ModelKind) -> Color {
         switch kind {
+        case .opus48: return Color(hex: "#F2B968")
         case .opus47: return Color(hex: "#E8A24A")
         case .opus46: return Color(hex: "#C2792B")
         case .sonnet: return Color(hex: "#5BC489")

--- a/TokenEaterTests/ModelKindTests.swift
+++ b/TokenEaterTests/ModelKindTests.swift
@@ -1,0 +1,58 @@
+import Testing
+import Foundation
+
+@Suite("ModelKind")
+struct ModelKindTests {
+
+    // MARK: - Opus version mapping
+
+    @Test func opus48IsRecognised() {
+        #expect(ModelKind(rawModel: "claude-opus-4-8") == .opus48)
+        #expect(ModelKind(rawModel: "claude-opus-4-8[1m]") == .opus48)
+        #expect(ModelKind(rawModel: "opus-4.8") == .opus48)
+    }
+
+    @Test func opus47IsRecognised() {
+        #expect(ModelKind(rawModel: "claude-opus-4-7") == .opus47)
+        #expect(ModelKind(rawModel: "opus-4.7") == .opus47)
+    }
+
+    @Test func opus46IsRecognised() {
+        #expect(ModelKind(rawModel: "claude-opus-4-6") == .opus46)
+        #expect(ModelKind(rawModel: "opus-4.6") == .opus46)
+    }
+
+    /// The bare "opus" alias appears in JSONL for the default model and must not
+    /// fall through to `.other`; it maps to the current shipping Opus version.
+    @Test func bareOpusAliasMapsToCurrentVersion() {
+        #expect(ModelKind(rawModel: "opus") == .opus48)
+    }
+
+    // MARK: - Other families
+
+    @Test func sonnetAndHaiku() {
+        #expect(ModelKind(rawModel: "claude-sonnet-4-6") == .sonnet)
+        #expect(ModelKind(rawModel: "claude-haiku-4-5") == .haiku)
+    }
+
+    @Test func unknownModelFallsToOther() {
+        #expect(ModelKind(rawModel: "gpt-5") == .other)
+        #expect(ModelKind(rawModel: "") == .other)
+    }
+
+    // MARK: - Family folding
+
+    @Test func everyOpusVersionFoldsIntoOpusFamily() {
+        #expect(ModelKind.opus48.family == .opus)
+        #expect(ModelKind.opus47.family == .opus)
+        #expect(ModelKind.opus46.family == .opus)
+    }
+
+    @Test func displayNameMatchesVersion() {
+        #expect(ModelKind.opus48.displayName == "Opus 4.8")
+    }
+
+    @Test func stackOrderContainsEveryCase() {
+        #expect(Set(ModelKind.stackOrder) == Set(ModelKind.allCases))
+    }
+}


### PR DESCRIPTION
Closes #188

## Problem

Sessions run on Opus 4.8 were bucketed as **Other** in the History chart, filter chips, and the Monitoring "top model" line, instead of under **Opus**.

`ModelKind.init(rawModel:)` only matched `opus-4-7` and `opus-4-6`, so `claude-opus-4-8` (and the bare `opus` alias that also appears in the JSONL for the default model) fell through to `.other`.

## Fix

- Add an `.opus48` case, matched first in `init(rawModel:)`.
- Add a generic `opus` fallback so the bare alias and any unversioned Opus string map to the current shipping version instead of `.other` (future minor versions still get their own explicit case for a distinct label/color).
- Fold `.opus48` into the `.opus` family, so chips and filtering stay correct with no change to `chipColor`.
- Add `.opus48` to `displayName`, `stackOrder`, and the History chart gradient (`#F2B968`, a lighter gold extending the existing 4.7/4.6 ramp).
- Add `ModelKindTests` covering 4.8/4.7/4.6, the bare `opus` alias, family folding, and stack-order completeness.

## Scope

Classification only affects the History + Monitoring views (parsed from local JSONL). The usage-API quota buckets are separate and unaffected.

## Test

Full suite green (362 tests, 33 suites).