### PR TITLE
fix: detect Keychain account swaps to stop stale wrong-account data (#153)

### DIFF
--- a/Shared/Services/Protocols/TokenProviderProtocol.swift
+++ b/Shared/Services/Protocols/TokenProviderProtocol.swift
@@ -6,6 +6,12 @@ protocol TokenProviderProtocol: Sendable {
     func hasTokenSource() -> Bool
     /// Clear cached token - call after 401 so next read re-checks Keychain
     func invalidateToken()
+    /// Re-reads the token from its sources (Keychain/files), bypassing the
+    /// in-memory cache, and updates the cache. Returns true when the token
+    /// changed since the last read - i.e. an account swap (`cswap`, `claude
+    /// /login`) or token rotation that the file watcher cannot observe because
+    /// the active token lives in the Keychain, not in a watched file.
+    func refreshTokenIfChanged() -> Bool
     var isBootstrapped: Bool { get }
     func bootstrap() throws
 }

--- a/Shared/Services/TokenProvider.swift
+++ b/Shared/Services/TokenProvider.swift
@@ -56,30 +56,54 @@ final class TokenProvider: TokenProviderProtocol, @unchecked Sendable {
     ///    whitelist us directly, but kept for defence-in-depth)
     func currentToken() -> String? {
         if let token = cachedToken { return token }
+        let token = readFromSources()
+        cachedToken = token
+        return token
+    }
 
+    /// Reads the token from all sources in priority order, bypassing the
+    /// in-memory cache. Returns the freshest token currently on the system.
+    private func readFromSources() -> String? {
         if let token = securityCLIReader.readToken() {
-            cachedToken = token
             logger.info("Token read via /usr/bin/security")
             return token
         }
 
         if let token = credentialsFileReader.readToken() {
-            cachedToken = token
             return token
         }
 
         if let token = tokenFromConfigJSON() {
-            cachedToken = token
             return token
         }
 
         if let token = keychainReader(true) {
-            cachedToken = token
-            logger.info("Token read from Keychain (silent) and cached in memory")
+            logger.info("Token read from Keychain (silent)")
             return token
         }
 
         return nil
+    }
+
+    /// Re-reads the token from its sources and updates the cache when it
+    /// changed. The file watcher only sees `config.json` / `.credentials.json`,
+    /// but on modern macOS the active token lives in the Keychain - so a
+    /// `cswap`/`claude login` account swap rotates the Keychain item with no
+    /// filesystem event and the cache would otherwise keep serving the previous
+    /// account's token until a 401. Polling here (on the auto-refresh tick)
+    /// closes that gap. Returns true only on an actual change between two
+    /// non-nil tokens; first population and transient read failures return false
+    /// so a working token is never dropped.
+    func refreshTokenIfChanged() -> Bool {
+        guard let fresh = readFromSources() else { return false }
+        let previous = cachedToken
+        cachedToken = fresh
+        guard let previous else { return false }
+        if previous != fresh {
+            logger.info("Token changed on Keychain/disk - cache refreshed for new account")
+            return true
+        }
+        return false
     }
 
     /// Try to decrypt config.json. If key is missing, attempt silent re-bootstrap.

--- a/Shared/Stores/UsageStore.swift
+++ b/Shared/Stores/UsageStore.swift
@@ -250,6 +250,24 @@ final class UsageStore: ObservableObject {
         switchToFastMode()
     }
 
+    /// Detects an OAuth token rotation that the file watcher cannot see: on
+    /// modern macOS the active token lives in the Keychain, so a `cswap` /
+    /// `claude login` account swap rotates it with no filesystem event and the
+    /// cached token (hence the displayed usage and plan badge) keeps belonging
+    /// to the previous account until a 401. Polling the token source on each
+    /// auto-refresh tick closes that gap. When a rotation is detected, the
+    /// stale state is dropped: clear the rate-limit backoff, force a profile
+    /// re-fetch, and switch to fast mode so the new account's data shows up
+    /// promptly. Returns true when the caller should force a usage refresh.
+    func reconcileTokenIfChanged() -> Bool {
+        guard tokenProvider.refreshTokenIfChanged() else { return false }
+        retryAfterDate = nil
+        consecutiveRateLimits = 0
+        lastProfileFetch = nil
+        switchToFastMode()
+        return true
+    }
+
     func loadCached() {
         if let cached = cachedUsage {
             updateUI(from: cached.usage)
@@ -285,7 +303,11 @@ final class UsageStore: ObservableObject {
             if let self { await self.refreshProfile() }
             while !Task.isCancelled {
                 guard let self else { return }
-                await self.refresh(thresholds: thresholds)
+                // Catch account swaps (cswap / claude login) the file watcher
+                // misses because the token rotates in the Keychain.
+                let rotated = self.reconcileTokenIfChanged()
+                await self.refresh(thresholds: thresholds, force: rotated)
+                if rotated { await self.refreshProfile() }
                 let delay = self.effectiveInterval
                 try? await Task.sleep(for: .seconds(delay))
             }

--- a/TokenEaterTests/Mocks/MockTokenProvider.swift
+++ b/TokenEaterTests/Mocks/MockTokenProvider.swift
@@ -8,6 +8,10 @@ final class MockTokenProvider: TokenProviderProtocol, @unchecked Sendable {
     var bootstrapCallCount = 0
     var currentTokenCallCount = 0
     var invalidateCallCount = 0
+    var refreshTokenIfChangedCallCount = 0
+    /// What `refreshTokenIfChanged()` returns. Tests flip this to simulate an
+    /// account swap detected on the Keychain.
+    var tokenDidChange = false
 
     var isBootstrapped: Bool { _isBootstrapped }
 
@@ -22,6 +26,11 @@ final class MockTokenProvider: TokenProviderProtocol, @unchecked Sendable {
 
     func invalidateToken() {
         invalidateCallCount += 1
+    }
+
+    func refreshTokenIfChanged() -> Bool {
+        refreshTokenIfChangedCallCount += 1
+        return tokenDidChange
     }
 
     func bootstrap() throws {

--- a/TokenEaterTests/TokenProviderTests.swift
+++ b/TokenEaterTests/TokenProviderTests.swift
@@ -254,4 +254,51 @@ struct TokenProviderTests {
 
         #expect(token == "keychain-fallback")
     }
+
+    // MARK: - refreshTokenIfChanged (account swap detection)
+
+    @Test("refreshTokenIfChanged detects a rotated Keychain token and updates the cache")
+    func refreshTokenIfChangedDetectsRotation() {
+        let (provider, securityCLI, _, _, _) = makeSUT(securityCLIToken: "tok-A")
+
+        // Prime the cache with account A's token.
+        #expect(provider.currentToken() == "tok-A")
+
+        // cswap rotates the Keychain item to account B's token.
+        securityCLI.token = "tok-B"
+
+        #expect(provider.refreshTokenIfChanged() == true)
+        #expect(provider.currentToken() == "tok-B")
+    }
+
+    @Test("refreshTokenIfChanged returns false when the token is unchanged")
+    func refreshTokenIfChangedNoChange() {
+        let (provider, _, _, _, _) = makeSUT(securityCLIToken: "tok-A")
+
+        #expect(provider.currentToken() == "tok-A")
+        #expect(provider.refreshTokenIfChanged() == false)
+        #expect(provider.currentToken() == "tok-A")
+    }
+
+    @Test("refreshTokenIfChanged keeps the cached token when all sources momentarily miss")
+    func refreshTokenIfChangedKeepsCacheOnTransientMiss() {
+        let (provider, securityCLI, _, _, _) = makeSUT(securityCLIToken: "tok-A")
+
+        #expect(provider.currentToken() == "tok-A")
+
+        // A transient read failure (no source available) must not drop a
+        // working token.
+        securityCLI.token = nil
+        #expect(provider.refreshTokenIfChanged() == false)
+        #expect(provider.currentToken() == "tok-A")
+    }
+
+    @Test("refreshTokenIfChanged treats first population as not-a-rotation")
+    func refreshTokenIfChangedFirstReadIsNotRotation() {
+        let (provider, _, _, _, _) = makeSUT(securityCLIToken: "tok-A")
+
+        // No prior currentToken() call, so the cache is empty: the first read
+        // establishes a baseline rather than signalling a swap.
+        #expect(provider.refreshTokenIfChanged() == false)
+    }
 }

--- a/TokenEaterTests/UsageStoreTests.swift
+++ b/TokenEaterTests/UsageStoreTests.swift
@@ -637,4 +637,40 @@ struct UsageStoreTests {
         #expect(store.fiveHourPct == 42)
         #expect(tokenProvider.invalidateCallCount == 1)
     }
+
+    // MARK: - reconcileTokenIfChanged (account swap detection)
+
+    @Test("reconcileTokenIfChanged clears stale state and signals a forced refresh on swap")
+    func reconcileTokenIfChangedDetectsSwap() async {
+        let (store, _, tokenProvider, _, _) = makeSUT(
+            shouldFail: true,
+            failWith: .rateLimited(retryAfter: 3600, retryAfterRaw: "3600", endpoint: "/api/oauth/usage")
+        )
+
+        // Put the store into a rate-limited, backed-off state on account A.
+        await store.refresh()
+        #expect(store.retryAfterDate != nil)
+
+        // The underlying Keychain token rotates to account B.
+        tokenProvider.tokenDidChange = true
+
+        let rotated = store.reconcileTokenIfChanged()
+
+        #expect(rotated == true)
+        #expect(store.retryAfterDate == nil)
+        #expect(store.currentSpeed == .fast)
+        #expect(tokenProvider.refreshTokenIfChangedCallCount == 1)
+    }
+
+    @Test("reconcileTokenIfChanged is a no-op when the token is unchanged")
+    func reconcileTokenIfChangedNoChange() {
+        let (store, _, tokenProvider, _, _) = makeSUT()
+        tokenProvider.tokenDidChange = false
+
+        let rotated = store.reconcileTokenIfChanged()
+
+        #expect(rotated == false)
+        #expect(store.currentSpeed == .normal)
+        #expect(tokenProvider.refreshTokenIfChangedCallCount == 1)
+    }
 }


### PR DESCRIPTION
Closes #153

## Problem

When switching between Claude accounts (for example a Team Max and a Personal Max via `cswap --switch` or `claude /login`), TokenEater kept showing the previous account's usage, limits, and reset values until a 401 or an app restart.

### Root cause

On modern macOS the active OAuth token lives in the Keychain item `Claude Code-credentials`. The token file watcher (`TokenFileMonitor`) only observes `config.json` and `.credentials.json`, so a `cswap` / `claude login` account swap rotates the Keychain item with **no filesystem event**. `TokenProvider` caches the token in memory and only clears it on a 401 or a watched-file change, so after a swap it kept serving the old account's (still-valid) token. Every refresh used that stale token, hence the wrong account's data, until the old token expired (401) or the app was reopened, which matches the report.

## Fix

- `TokenProvider.refreshTokenIfChanged()` re-reads the token from its sources in priority order (bypassing the in-memory cache) and updates the cache. It returns `true` only on an actual change between two non-nil tokens; first population and transient read failures return `false` so a working token is never dropped. Reads stay silent (`/usr/bin/security`, `kSecUseAuthenticationUISkip`), so no new Keychain prompts.
- `UsageStore.reconcileTokenIfChanged()` polls it on every auto-refresh tick. On a detected swap it clears the rate-limit backoff, forces a profile re-fetch (so the PRO/MAX/TEAM badge updates), switches to fast mode, and the loop forces a fresh usage refresh.

The `currentToken()` source chain is unchanged (extracted into a shared `readFromSources()` with identical priority and logging).

## Tests

- `TokenProvider`: rotation detected + cache updated, unchanged returns false, transient miss keeps the cache, first read is not a rotation.
- `UsageStore`: `reconcileTokenIfChanged` clears stale state and signals a forced refresh on swap, no-op when unchanged.
- Full suite green (359 tests, 32 suites).