### PR TITLE
fix: clarify pacing notifications (pace-relative + window-specific) (#187)

### DIFF
--- a/Shared/Services/NotificationService.swift
+++ b/Shared/Services/NotificationService.swift
@@ -221,21 +221,34 @@ final class NotificationService: NotificationServiceProtocol {
         switch zone {
         case .hot:
             guard toggles.pacingHot else { return }
-            firePacing(zone: .hot)
+            firePacing(zone: .hot, surface: surface)
         case .warning:
             guard toggles.pacingWarning else { return }
-            firePacing(zone: .warning)
+            firePacing(zone: .warning, surface: surface)
         case .chill, .onTrack:
             return
         }
     }
 
-    private func firePacing(zone: PacingZone) {
+    /// Builds the localization keys + dedupe id for a pacing alert. `window` is
+    /// the surface's `bodyFamily` ("weekly" / "fivehour") so the weekly and 5h
+    /// session pace alerts read distinctly, name their window, and don't dedupe
+    /// against each other.
+    static func pacingNotificationKeys(zone: PacingZone, window: String) -> (title: String, body: String, id: String) {
+        (
+            title: "notif.title.pacing.\(zone.rawValue).\(window)",
+            body: "notif.body.pacing.\(zone.rawValue).\(window)",
+            id: "pacing_\(window)_\(zone.rawValue)"
+        )
+    }
+
+    private func firePacing(zone: PacingZone, surface: Surface) {
+        let keys = Self.pacingNotificationKeys(zone: zone, window: surface.bodyFamily)
         let content = UNMutableNotificationContent()
         content.sound = .default
-        content.title = NSLocalizedString("notif.title.pacing.\(zone.rawValue)", comment: "")
-        content.body = NSLocalizedString("notif.body.pacing.\(zone.rawValue)", comment: "")
-        send(id: "pacing_\(zone.rawValue)", content: content)
+        content.title = NSLocalizedString(keys.title, comment: "")
+        content.body = NSLocalizedString(keys.body, comment: "")
+        send(id: keys.id, content: content)
     }
 
     // MARK: - Extra credits

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -216,10 +216,14 @@
 "notif.title.token" = "Token's stale";
 "notif.body.token" = "Reconnect to keep tracking";
 
-"notif.title.pacing.hot" = "Burning hot";
-"notif.body.pacing.hot" = "Way ahead of pace, pump the brakes";
-"notif.title.pacing.warning" = "Drifting fast";
-"notif.body.pacing.warning" = "A touch faster than ideal, keep an eye";
+"notif.title.pacing.hot.weekly" = "Week running hot";
+"notif.body.pacing.hot.weekly" = "You're well ahead of an even weekly pace, fine if intentional, otherwise worth easing off";
+"notif.title.pacing.warning.weekly" = "Week picking up";
+"notif.body.pacing.warning.weekly" = "A little ahead of an even weekly pace, just a heads up";
+"notif.title.pacing.hot.fivehour" = "Session running hot";
+"notif.body.pacing.hot.fivehour" = "You're well ahead of an even pace for this 5h session, fine if intentional, otherwise ease off";
+"notif.title.pacing.warning.fivehour" = "Session picking up";
+"notif.body.pacing.warning.fivehour" = "A little ahead of an even pace for this 5h session, just a heads up";
 
 "notif.title.reminder.session" = "Session resets in %@";
 "notif.body.reminder.session" = "Save your spot or send it";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -216,10 +216,14 @@
 "notif.title.token" = "Token périmé";
 "notif.body.token" = "Reconnecte pour reprendre le suivi";
 
-"notif.title.pacing.hot" = "Surchauffe";
-"notif.body.pacing.hot" = "Largement en avance, lève le pied";
-"notif.title.pacing.warning" = "Ça dérive";
-"notif.body.pacing.warning" = "Un poil rapide, garde l'œil";
+"notif.title.pacing.hot.weekly" = "Semaine qui chauffe";
+"notif.body.pacing.hot.weekly" = "Tu es bien au-dessus d'un rythme hebdo régulier, rien d'alarmant si c'est voulu, sinon lève un peu le pied";
+"notif.title.pacing.warning.weekly" = "Semaine qui accélère";
+"notif.body.pacing.warning.weekly" = "Un peu au-dessus d'un rythme hebdo régulier, juste pour info";
+"notif.title.pacing.hot.fivehour" = "Session qui chauffe";
+"notif.body.pacing.hot.fivehour" = "Tu es bien au-dessus d'un rythme régulier pour cette fenêtre 5h, lève un peu le pied pour la faire durer";
+"notif.title.pacing.warning.fivehour" = "Session qui accélère";
+"notif.body.pacing.warning.fivehour" = "Un peu au-dessus d'un rythme régulier pour cette fenêtre 5h, juste pour info";
 
 "notif.title.reminder.session" = "Reset session dans %@";
 "notif.body.reminder.session" = "Sauve ton truc ou envoie";

--- a/TokenEaterTests/NotificationServicePacingTests.swift
+++ b/TokenEaterTests/NotificationServicePacingTests.swift
@@ -1,0 +1,37 @@
+import Testing
+import Foundation
+
+@Suite("NotificationService pacing keys")
+struct NotificationServicePacingTests {
+
+    @Test("pacing keys name the window so weekly and session read distinctly")
+    func keysAreWindowSpecific() {
+        let weekly = NotificationService.pacingNotificationKeys(zone: .hot, window: "weekly")
+        let session = NotificationService.pacingNotificationKeys(zone: .hot, window: "fivehour")
+
+        #expect(weekly.title == "notif.title.pacing.hot.weekly")
+        #expect(weekly.body == "notif.body.pacing.hot.weekly")
+        #expect(session.title == "notif.title.pacing.hot.fivehour")
+        #expect(session.body == "notif.body.pacing.hot.fivehour")
+    }
+
+    @Test("weekly and session pacing alerts use distinct dedupe ids")
+    func idsDoNotCollideAcrossWindows() {
+        let weekly = NotificationService.pacingNotificationKeys(zone: .hot, window: "weekly")
+        let session = NotificationService.pacingNotificationKeys(zone: .hot, window: "fivehour")
+
+        #expect(weekly.id != session.id)
+        #expect(weekly.id == "pacing_weekly_hot")
+        #expect(session.id == "pacing_fivehour_hot")
+    }
+
+    @Test("warning and hot produce different keys and ids for the same window")
+    func zoneIsEncodedInKeys() {
+        let warning = NotificationService.pacingNotificationKeys(zone: .warning, window: "weekly")
+        let hot = NotificationService.pacingNotificationKeys(zone: .hot, window: "weekly")
+
+        #expect(warning.title != hot.title)
+        #expect(warning.id == "pacing_weekly_warning")
+        #expect(hot.id == "pacing_weekly_hot")
+    }
+}


### PR DESCRIPTION
Closes #187

## Problem

A user at 58% of their weekly capacity received a "take it slow" pacing notification and reasonably read it as wrong.

The pacing math is actually correct: the weekly alert fires when usage runs ahead of an **even burn rate** over the window (58% used before ~38% of the week has elapsed is genuinely ahead of pace). The defect is the copy:

- it never said the alert is **pace-relative**, so seeing 58% on the gauge made it look like a false absolute over-limit warning
- it never named the **window**, so a hot 5h session and a hot weekly window produced identical text
- weekly and session pacing alerts shared a single dedupe id (`pacing_<zone>`), so they could overwrite each other and gave no clue which one fired

## Fix

- `firePacing` now threads the surface through a small, testable `pacingNotificationKeys(zone:window:)` helper, producing window-named keys (`notif.*.pacing.<zone>.weekly` / `.fivehour`) and distinct dedupe ids (`pacing_weekly_hot` vs `pacing_fivehour_hot`).
- Reworded EN + FR copy so it states the alert is relative to an even pace and is fine if intentional, and names the window (week vs 5h session).

No behavior change to *when* alerts fire (the math and thresholds are untouched); this is purely clarity. Users who don't want pace nudges at all can still disable them under Settings > Notifications > Pacing.

## Tests

- New `NotificationService pacing keys` suite: keys are window-specific, weekly/session ids don't collide, zone is encoded in keys/ids.
- Full suite green (356 tests, 33 suites).