### PR TITLE
fix: legible default for menu bar period label on light backgrounds (#196)

### DIFF
--- a/Shared/Helpers/MenuBarRenderer.swift
+++ b/Shared/Helpers/MenuBarRenderer.swift
@@ -108,13 +108,24 @@ enum MenuBarRenderer {
         return data.themeColors.pacingNSColor(for: zone)
     }
 
+    /// Default colour for the period label ("5h" / "7d") when the user hasn't
+    /// picked a custom hex. Secondary (~55%) rather than tertiary (~26%) so the
+    /// label stays legible on a *light* menu bar - on a light background the old
+    /// tertiary grey was nearly invisible while the bold, colour-coded value
+    /// remained readable. See issue #196. The value still outranks the label
+    /// (bold `.labelColor` / gauge colour vs. secondary), so the hierarchy holds.
+    static let defaultPeriodLabelColor: NSColor = .secondaryLabelColor
+
+    /// Resolves the period-label colour. Monochrome and "no custom hex" both
+    /// fall back to `defaultPeriodLabelColor`; a valid custom hex wins. Kept
+    /// internal (and free of `RenderData`) so it is unit-testable in isolation.
+    static func periodLabelColor(hex: String, monochrome: Bool) -> NSColor {
+        if monochrome { return defaultPeriodLabelColor }
+        return MenuBarTextColorResolver.resolve(hex: hex, fallback: defaultPeriodLabelColor)
+    }
+
     private static func periodColor(_ data: RenderData) -> NSColor {
-        data.menuBarMonochrome
-            ? NSColor.tertiaryLabelColor
-            : MenuBarTextColorResolver.resolve(
-                hex: data.sessionPeriodColorHex,
-                fallback: .tertiaryLabelColor
-            )
+        periodLabelColor(hex: data.sessionPeriodColorHex, monochrome: data.menuBarMonochrome)
     }
 
     /// Reset countdown text color. Honors the Themes setting priority:

--- a/TokenEaterApp/DisplaySectionView.swift
+++ b/TokenEaterApp/DisplaySectionView.swift
@@ -261,8 +261,10 @@ struct DisplaySectionView: View {
                     )
                     menuBarColorRow(
                         label: "settings.session.periodcolor",
+                        // Swatch preview mirrors `MenuBarRenderer.defaultPeriodLabelColor`
+                        // (secondary, ~55%) so the picker is honest about the real default.
                         hex: $settingsStore.sessionPeriodColorHex,
-                        fallback: .white.opacity(0.4),
+                        fallback: .white.opacity(0.55),
                         disabled: false
                     )
                 }

--- a/TokenEaterTests/MenuBarRendererTests.swift
+++ b/TokenEaterTests/MenuBarRendererTests.swift
@@ -80,3 +80,42 @@ struct MenuBarRendererTests {
         #expect(observed != red, "80% / 90min should no longer match the threshold-mode red color")
     }
 }
+
+@Suite("MenuBarRenderer.periodLabelColor")
+struct MenuBarPeriodLabelColorTests {
+
+    @Test("default (no custom hex) is the legible secondary colour")
+    func defaultIsSecondary() {
+        // Regression guard for issue #196: the "5h" / "7d" period label used
+        // to default to tertiary (~26%), which is nearly invisible on a light
+        // menu bar. It now defaults to secondary (~55%).
+        let resolved = MenuBarRenderer.periodLabelColor(hex: "", monochrome: false)
+        #expect(resolved == MenuBarRenderer.defaultPeriodLabelColor)
+        // The default is `.secondaryLabelColor`; the load-bearing guard is that
+        // it is no longer the faint `.tertiaryLabelColor` that issue #196 hit.
+        // (Compared by name to avoid relying on dynamic-colour reflexivity.)
+        #expect(MenuBarRenderer.defaultPeriodLabelColor != NSColor.tertiaryLabelColor,
+                "default must not regress back to the faint tertiary grey")
+    }
+
+    @Test("monochrome falls back to the same legible default")
+    func monochromeIsSecondary() {
+        // Monochrome ignores any picked hex; it should still be legible.
+        let resolved = MenuBarRenderer.periodLabelColor(hex: "#FF0000", monochrome: true)
+        #expect(resolved == MenuBarRenderer.defaultPeriodLabelColor)
+    }
+
+    @Test("a valid custom hex overrides the default")
+    func customHexWins() {
+        let resolved = MenuBarRenderer.periodLabelColor(hex: "#3366FF", monochrome: false)
+        #expect(resolved.hexString() == "#3366FF")
+    }
+
+    @Test("an empty / malformed hex falls back to the default")
+    func malformedHexFallsBack() {
+        #expect(MenuBarRenderer.periodLabelColor(hex: "   ", monochrome: false)
+                == MenuBarRenderer.defaultPeriodLabelColor)
+        #expect(MenuBarRenderer.periodLabelColor(hex: "not-a-color", monochrome: false)
+                == MenuBarRenderer.defaultPeriodLabelColor)
+    }
+}


### PR DESCRIPTION
## Problem

Fixes #196.

On a **light** menu bar the `5h` / `7d` period labels are nearly invisible. They default to `.tertiaryLabelColor` (~26% alpha) — fine on a dark menu bar, washed out on a light one — while the percentage stays readable because it uses the saturated gauge color.

The app already exposes a manual override (**Display → Colors → "Period label (5h / 7d)"**, `sessionPeriodColorHex`), but the out-of-box **default** was the actual bug, so most users hit the unreadable state before discovering the setting.

## Fix

Bump the default period-label color from tertiary (~26%) → **`.secondaryLabelColor` (~55%)** in `MenuBarRenderer`. It's legible on both light and dark menu bars, and still ranks below the bold, color-coded value, so the `label < value` hierarchy is preserved. Monochrome mode gets the same lift (value stays `.labelColor`, label becomes secondary).

The existing custom-hex override path is untouched — a user-picked color still wins.

## Changes

- **`Shared/Helpers/MenuBarRenderer.swift`** — add `defaultPeriodLabelColor` (`.secondaryLabelColor`) and extract a testable `periodLabelColor(hex:monochrome:)`; `periodColor(_:)` now delegates to it.
- **`TokenEaterApp/DisplaySectionView.swift`** — nudge the settings swatch preview (`.white.opacity(0.4)` → `0.55`) so the picker honestly reflects the new default. Cosmetic only.
- **`TokenEaterTests/MenuBarRendererTests.swift`** — new `MenuBarRenderer.periodLabelColor` suite: default resolves to the legible color (and is no longer tertiary), monochrome falls back to it, a valid custom hex wins, and malformed/empty hex falls back.

## Scope

Deliberately minimal — no new settings, no new UI rows, no menu-bar appearance detection. Badge style is unaffected (it has no separate label); the reset countdown (`.labelColor`) and gauge percentages were already legible and are left as-is.

## Testing

`swiftc -parse` clean on all three files. I don't have a full Xcode locally (only Command Line Tools), so I could not run `xcodebuild test` — relying on CI (`ci.yml`) for the build + Swift Testing run. Happy to iterate if anything's red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)