### PR TITLE
Resolve five open issues: Fable history, pace marker, menu bar label, re-auth banner, background launch

### DIFF
--- a/Shared/Components/PacingBar.swift
+++ b/Shared/Components/PacingBar.swift
@@ -10,8 +10,13 @@ struct PacingBar: View {
     let offDayRanges: [ClosedRange<Double>]
     /// True when "now" falls on an off-day - mutes the ideal marker.
     let nowInOffDay: Bool
+    /// Calendar-time x-fraction (0...1) to place the "now" marker at, used when a
+    /// workweek schedule is active so the marker stays in the same coordinate
+    /// space as `offDayRanges` (sits solid on active days, dashed on off days).
+    /// nil keeps the classic `expected`-based (active-time %) marker position.
+    let markerFraction: Double?
 
-    init(actual: Double, expected: Double, zone: PacingZone, gradient: LinearGradient, compact: Bool = false, offDayRanges: [ClosedRange<Double>] = [], nowInOffDay: Bool = false) {
+    init(actual: Double, expected: Double, zone: PacingZone, gradient: LinearGradient, compact: Bool = false, offDayRanges: [ClosedRange<Double>] = [], nowInOffDay: Bool = false, markerFraction: Double? = nil) {
         self.actual = actual
         self.expected = expected
         self.zone = zone
@@ -19,6 +24,7 @@ struct PacingBar: View {
         self.compact = compact
         self.offDayRanges = offDayRanges
         self.nowInOffDay = nowInOffDay
+        self.markerFraction = markerFraction
     }
 
     @State private var animatedActual: Double = 0
@@ -41,7 +47,7 @@ struct PacingBar: View {
                     .frame(width: max(0, geo.size.width * CGFloat(min(animatedActual, 100)) / 100), height: compact ? 4 : 8)
 
                 idealMarker
-                    .offset(x: geo.size.width * CGFloat(min(expected, 100)) / 100 - (compact ? 3 : 5))
+                    .offset(x: markerOffsetX(width: geo.size.width))
 
                 if !compact {
                     Circle()
@@ -68,6 +74,17 @@ struct PacingBar: View {
                 animatedActual = newValue
             }
         }
+    }
+
+    /// X offset for the ideal/now marker. When `markerFraction` is set (workweek
+    /// active) the marker follows calendar time so it aligns with the off-day
+    /// hatch; otherwise it follows the active-time `expected` percentage (#194).
+    private func markerOffsetX(width: CGFloat) -> CGFloat {
+        let nudge: CGFloat = compact ? 3 : 5
+        if let f = markerFraction {
+            return width * CGFloat(min(max(f, 0), 1)) - nudge
+        }
+        return width * CGFloat(min(expected, 100)) / 100 - nudge
     }
 
     private var idealMarker: some View {

--- a/Shared/Helpers/MenuBarRenderer.swift
+++ b/Shared/Helpers/MenuBarRenderer.swift
@@ -108,13 +108,24 @@ enum MenuBarRenderer {
         return data.themeColors.pacingNSColor(for: zone)
     }
 
+    /// Default colour for the period label ("5h" / "7d") when the user has not
+    /// picked a custom hex. Secondary (~55%) rather than tertiary (~26%) so the
+    /// label stays legible on a *light* menu bar (the old tertiary grey was
+    /// nearly invisible there) while still ranking below the bold, colour-coded
+    /// value. See #196.
+    static let defaultPeriodLabelColor: NSColor = .secondaryLabelColor
+
+    /// Resolves the period-label colour. The user's custom hex wins in BOTH
+    /// modes, including monochrome, so a monochrome user on a light menu bar can
+    /// still tune the "5h" / "7d" label colour (#196). With no custom hex it
+    /// falls back to the legible `defaultPeriodLabelColor`. Kept internal and
+    /// `RenderData`-free so it is unit-testable in isolation.
+    static func periodLabelColor(hex: String) -> NSColor {
+        MenuBarTextColorResolver.resolve(hex: hex, fallback: defaultPeriodLabelColor)
+    }
+
     private static func periodColor(_ data: RenderData) -> NSColor {
-        data.menuBarMonochrome
-            ? NSColor.tertiaryLabelColor
-            : MenuBarTextColorResolver.resolve(
-                hex: data.sessionPeriodColorHex,
-                fallback: .tertiaryLabelColor
-            )
+        periodLabelColor(hex: data.sessionPeriodColorHex)
     }
 
     /// Reset countdown text color. Honors the Themes setting priority:

--- a/Shared/Models/PacingModels.swift
+++ b/Shared/Models/PacingModels.swift
@@ -123,4 +123,17 @@ struct PacingSchedule: Equatable, Sendable {
         }
         return ranges
     }
+
+    /// Linear calendar-time x-fraction (0...1) of `now` within the window
+    /// `[resetDate - period, resetDate]`. Same coordinate space as
+    /// `offDayRanges`, so a "now" marker drawn at this fraction always sits on
+    /// the correct solid (active) / dashed (off) segment. This is deliberately
+    /// NOT `expectedUsage`: that is an active-time fraction (off-days compressed
+    /// out) driving the delta/zone math, and using it to place the marker is the
+    /// bug behind #194: on a restricted schedule the two spaces diverge, so the
+    /// marker drifts onto a hatched off-day segment while `now` is an active day.
+    func nowFraction(resetDate: Date, now: Date = Date(), period: TimeInterval = 7 * 24 * 3600) -> Double {
+        let windowStart = resetDate.addingTimeInterval(-period)
+        return min(max(now.timeIntervalSince(windowStart) / period, 0), 1)
+    }
 }

--- a/Shared/Models/UsageHistoryModels.swift
+++ b/Shared/Models/UsageHistoryModels.swift
@@ -36,11 +36,13 @@ enum HistoryRange: String, CaseIterable, Codable, Sendable {
 
 // MARK: - Model classification
 
-/// Coarse model identity used for chart colouring + filter chips. Opus 4.7 and
-/// 4.6 are kept distinct (the user might run both back-to-back), Sonnet/Haiku
+/// Coarse model identity used for chart colouring + filter chips. Fable is the
+/// Mythos-class tier above Opus and gets its own family; Opus 4.8/4.7/4.6 are
+/// kept distinct (the user might run several back-to-back), Sonnet/Haiku
 /// collapse all minor versions, anything unrecognised lands in `.other`. Design
 /// intentionally absent: it never appears in Claude Code JSONL files.
 enum ModelKind: String, CaseIterable, Codable, Hashable, Sendable {
+    case fable
     case opus48
     case opus47
     case opus46
@@ -50,7 +52,10 @@ enum ModelKind: String, CaseIterable, Codable, Hashable, Sendable {
 
     init(rawModel: String) {
         let lower = rawModel.lowercased()
-        if lower.contains("opus-4-8") || lower.contains("opus-4.8") {
+        if lower.contains("fable") {
+            // Fable 5 (and any future Fable minor) maps to the Fable family.
+            self = .fable
+        } else if lower.contains("opus-4-8") || lower.contains("opus-4.8") {
             self = .opus48
         } else if lower.contains("opus-4-7") || lower.contains("opus-4.7") {
             self = .opus47
@@ -72,6 +77,7 @@ enum ModelKind: String, CaseIterable, Codable, Hashable, Sendable {
 
     var displayName: String {
         switch self {
+        case .fable:  return "Fable 5"
         case .opus48: return "Opus 4.8"
         case .opus47: return "Opus 4.7"
         case .opus46: return "Opus 4.6"
@@ -82,9 +88,11 @@ enum ModelKind: String, CaseIterable, Codable, Hashable, Sendable {
     }
 
     /// Family used by the filter chips. Opus 4.8, 4.7 and 4.6 fold into `.opus`
-    /// since users typically think "Opus" not "Opus 4.8 vs 4.7 vs 4.6".
+    /// since users typically think "Opus" not "Opus 4.8 vs 4.7 vs 4.6". Fable is
+    /// its own family (no minor-version split yet).
     var family: ModelFamily {
         switch self {
+        case .fable:                    return .fable
         case .opus48, .opus47, .opus46: return .opus
         case .sonnet:                   return .sonnet
         case .haiku:                    return .haiku
@@ -92,17 +100,25 @@ enum ModelKind: String, CaseIterable, Codable, Hashable, Sendable {
         }
     }
 
-    /// Stable order for chart stacking (heaviest at the top of the bar).
+    /// Stable order for chart stacking (`.other` stays on top as the catch-all).
+    /// Fable sits with the Opus tier. Not a strict weight ordering; only the
+    /// `stackOrderContainsEveryCase` test guards completeness (the array is not
+    /// compiler-checked for missing cases).
     static var stackOrder: [ModelKind] {
-        [.haiku, .opus46, .opus47, .opus48, .sonnet, .other]
+        [.haiku, .opus46, .opus47, .opus48, .fable, .sonnet, .other]
     }
 }
 
 enum ModelFamily: String, CaseIterable, Codable, Hashable, Sendable {
-    case opus, sonnet, haiku, other
+    // Declaration order drives the History filter-chip row. Fable sits after the
+    // established families (it is a rare research-preview tier) but before the
+    // `.other` catch-all, so it never jumps ahead of Opus for users with no
+    // Fable history.
+    case opus, sonnet, haiku, fable, other
 
     var displayName: String {
         switch self {
+        case .fable:  return "Fable"
         case .opus:   return "Opus"
         case .sonnet: return "Sonnet"
         case .haiku:  return "Haiku"
@@ -251,6 +267,9 @@ struct HistoryCache: Codable, Sendable {
     var version: Int
     var entries: [String: HistoryFileCacheEntry]
 
-    static let currentVersion = 1
+    /// v2: bumped so existing caches that bucketed `claude-fable-5` under
+    /// `.other` (before Fable had its own `ModelKind`) are discarded and
+    /// re-scanned, reclassifying Fable history immediately on update (#199).
+    static let currentVersion = 2
     static let empty = HistoryCache(version: currentVersion, entries: [:])
 }

--- a/Shared/Models/UsageHistoryModels.swift
+++ b/Shared/Models/UsageHistoryModels.swift
@@ -110,11 +110,10 @@ enum ModelKind: String, CaseIterable, Codable, Hashable, Sendable {
 }
 
 enum ModelFamily: String, CaseIterable, Codable, Hashable, Sendable {
-    // Declaration order drives the History filter-chip row. Fable sits after the
-    // established families (it is a rare research-preview tier) but before the
-    // `.other` catch-all, so it never jumps ahead of Opus for users with no
-    // Fable history.
-    case opus, sonnet, haiku, fable, other
+    // Declaration order drives the History filter-chip row (rendered right after
+    // the "All" chip). Fable leads as the top tier, then Opus / Sonnet / Haiku,
+    // with `.other` last as the catch-all.
+    case fable, opus, sonnet, haiku, other
 
     var displayName: String {
         switch self {

--- a/Shared/Stores/SettingsStore.swift
+++ b/Shared/Stores/SettingsStore.swift
@@ -8,6 +8,13 @@ final class SettingsStore: ObservableObject {
     @Published var showMenuBar: Bool {
         didSet { UserDefaults.standard.set(showMenuBar, forKey: "showMenuBar") }
     }
+    /// When true, the app starts in the menu bar only and skips auto-opening the
+    /// dashboard window at launch (incl. at login). The window stays reachable
+    /// from the menu bar (right-click > Open). Onboarding always force-opens
+    /// regardless of this flag so a fresh install is never left with no UI (#198).
+    @Published var launchInBackground: Bool {
+        didSet { UserDefaults.standard.set(launchInBackground, forKey: "launchInBackground") }
+    }
     @Published var pinnedMetrics: Set<MetricID> {
         didSet { savePinnedMetrics() }
     }
@@ -323,6 +330,7 @@ final class SettingsStore: ObservableObject {
         self.sharedFileService = sharedFileService
 
         self.showMenuBar = UserDefaults.standard.object(forKey: "showMenuBar") as? Bool ?? true
+        self.launchInBackground = Self.boolDefault(key: "launchInBackground", default: false)
         self.hasCompletedOnboarding = UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
         self.proxyEnabled = UserDefaults.standard.bool(forKey: "proxyEnabled")
         self.proxyHost = UserDefaults.standard.string(forKey: "proxyHost") ?? "127.0.0.1"

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -118,6 +118,8 @@
 "settings.general.title" = "General";
 "settings.launchAtLogin" = "Launch at login";
 "settings.launchAtLogin.hint" = "Open TokenEater automatically when you sign in to macOS. You can toggle this from System Settings → General → Login Items as well.";
+"settings.launchInBackground" = "Launch in background";
+"settings.launchInBackground.hint" = "Start in the menu bar only and skip opening the dashboard window. Open it any time from the menu bar (right-click the icon, then Open).";
 "settings.general.replayOnboarding" = "Replay onboarding";
 "settings.general.replayOnboarding.hint" = "Restart the welcome flow from the beginning. Useful to reconnect, review notification permissions, or rediscover features.";
 "settings.general.replayOnboarding.action" = "Replay";
@@ -151,8 +153,6 @@
 "error.invalidresponse.short" = "Invalid response";
 "error.keychainlocked" = "Keychain locked - will retry automatically";
 "error.unsupportedplan" = "Usage data not available - Claude Pro or Team plan required";
-"error.banner.expired" = "Token expired";
-"error.banner.expired.hint" = "Run /login in Claude Code - TokenEater will pick it up automatically";
 "error.banner.keychain" = "Keychain locked";
 "error.banner.keychain.hint" = "Will retry automatically - or open Settings to re-authorize";
 "error.banner.reauth" = "Authorization needed";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -118,6 +118,8 @@
 "settings.general.title" = "Général";
 "settings.launchAtLogin" = "Lancer au démarrage";
 "settings.launchAtLogin.hint" = "Ouvre TokenEater automatiquement quand vous vous connectez à macOS. Vous pouvez aussi gérer ce réglage depuis Réglages système → Général → Éléments de connexion.";
+"settings.launchInBackground" = "Lancer en arrière-plan";
+"settings.launchInBackground.hint" = "Démarre uniquement dans la barre des menus, sans ouvrir la fenêtre du tableau de bord. Ouvrez-la quand vous voulez depuis la barre des menus (clic droit sur l'icône, puis Ouvrir).";
 "settings.general.replayOnboarding" = "Rejouer l'onboarding";
 "settings.general.replayOnboarding.hint" = "Relance le tutoriel depuis le début. Utile pour te reconnecter, revoir les permissions de notifications, ou redécouvrir les features.";
 "settings.general.replayOnboarding.action" = "Rejouer";
@@ -151,8 +153,6 @@
 "error.invalidresponse.short" = "Réponse invalide";
 "error.keychainlocked" = "Keychain verrouillé - nouvelle tentative automatique";
 "error.unsupportedplan" = "Données d'utilisation indisponibles - un plan Claude Pro ou Team est requis";
-"error.banner.expired" = "Token expiré";
-"error.banner.expired.hint" = "Lancez /login dans Claude Code - TokenEater le récupérera automatiquement";
 "error.banner.keychain" = "Keychain verrouillé";
 "error.banner.keychain.hint" = "Nouvelle tentative automatique - ou ouvrez les Réglages pour ré-autoriser";
 "error.banner.reauth" = "Autorisation requise";

--- a/TokenEaterApp/DisplaySectionView.swift
+++ b/TokenEaterApp/DisplaySectionView.swift
@@ -251,21 +251,27 @@ struct DisplaySectionView: View {
                     }
                 }
 
+                Divider().opacity(0.12)
+                // Reset-countdown colour is non-monochrome only (in monochrome
+                // it is driven by the system label / smart colour).
                 if !themeStore.menuBarMonochrome {
-                    Divider().opacity(0.12)
                     menuBarColorRow(
                         label: "settings.reset.color",
                         hex: $settingsStore.resetTextColorHex,
                         fallback: .white,
                         disabled: settingsStore.smartColorEnabled
                     )
-                    menuBarColorRow(
-                        label: "settings.session.periodcolor",
-                        hex: $settingsStore.sessionPeriodColorHex,
-                        fallback: .white.opacity(0.4),
-                        disabled: false
-                    )
                 }
+                // Period-label ("5h" / "7d") colour is tweakable in BOTH modes,
+                // including monochrome, so a light-menu-bar user can fix its
+                // legibility (#196). The swatch mirrors the secondary (~55%)
+                // default in MenuBarRenderer.defaultPeriodLabelColor.
+                menuBarColorRow(
+                    label: "settings.session.periodcolor",
+                    hex: $settingsStore.sessionPeriodColorHex,
+                    fallback: .white.opacity(0.55),
+                    disabled: false
+                )
             }
             .animation(.spring(response: 0.32, dampingFraction: 0.85), value: themeStore.menuBarMonochrome)
         }

--- a/TokenEaterApp/HistoryView.swift
+++ b/TokenEaterApp/HistoryView.swift
@@ -843,6 +843,7 @@ struct HistoryView: View {
     /// better readability for back-to-back stacked segments.
     private func gradient(for kind: ModelKind) -> Color {
         switch kind {
+        case .fable:  return Color(hex: "#E86FC4")
         case .opus48: return Color(hex: "#F2B968")
         case .opus47: return Color(hex: "#E8A24A")
         case .opus46: return Color(hex: "#C2792B")
@@ -854,6 +855,7 @@ struct HistoryView: View {
 
     private func chipColor(for family: ModelFamily) -> Color {
         switch family {
+        case .fable:  return Color(hex: "#E86FC4")
         case .opus:   return Color(hex: "#E8A24A")
         case .sonnet: return Color(hex: "#5BC489")
         case .haiku:  return Color(hex: "#4FB7B0")

--- a/TokenEaterApp/MonitoringView.swift
+++ b/TokenEaterApp/MonitoringView.swift
@@ -559,6 +559,11 @@ struct MonitoringView: View {
             ? (pacing.resetDate.map { schedule.offDayRanges(resetDate: $0) } ?? [])
             : []
         let nowInOffDay = showWorkweekBadge && schedule.isOffDay(Date())
+        // Calendar-time position for the "now" marker so it aligns with the
+        // off-day hatch (#194). nil keeps the active-time expected position.
+        let markerFraction: Double? = (showWorkweekBadge && schedule.isActive)
+            ? pacing.resetDate.map { schedule.nowFraction(resetDate: $0) }
+            : nil
         return VStack(alignment: .leading, spacing: DS.Spacing.sm) {
             HStack(alignment: .top, spacing: DS.Spacing.xs) {
                 VStack(alignment: .leading, spacing: DS.Spacing.xxs) {
@@ -595,7 +600,7 @@ struct MonitoringView: View {
                     .animation(DS.Motion.springLiquid, value: pacing.delta)
             }
 
-            pacingTrack(actual: pacing.actualUsage, expected: pacing.expectedUsage, tint: tint, offDayRanges: offRanges, nowInOffDay: nowInOffDay)
+            pacingTrack(actual: pacing.actualUsage, expected: pacing.expectedUsage, tint: tint, offDayRanges: offRanges, nowInOffDay: nowInOffDay, markerFraction: markerFraction)
 
             if !pacing.message.isEmpty {
                 Text(pacing.message)
@@ -627,7 +632,7 @@ struct MonitoringView: View {
         .dsShadow(DS.Shadow.subtle)
     }
 
-    private func pacingTrack(actual: Double, expected: Double, tint: Color, offDayRanges: [ClosedRange<Double>] = [], nowInOffDay: Bool = false) -> some View {
+    private func pacingTrack(actual: Double, expected: Double, tint: Color, offDayRanges: [ClosedRange<Double>] = [], nowInOffDay: Bool = false, markerFraction: Double? = nil) -> some View {
         let clampedActual = min(max(actual, 0), 100)
         let clampedExpected = min(max(expected, 0), 100)
         return GeometryReader { geo in
@@ -646,7 +651,7 @@ struct MonitoringView: View {
                 Rectangle()
                     .fill(Color.white.opacity(nowInOffDay ? 0.4 : 0.85))
                     .frame(width: 2, height: 12)
-                    .offset(x: geo.size.width * CGFloat(clampedExpected) / 100 - 1, y: -3)
+                    .offset(x: (markerFraction.map { geo.size.width * CGFloat(min(max($0, 0), 1)) } ?? (geo.size.width * CGFloat(clampedExpected) / 100)) - 1, y: -3)
                     .dsGlow(.white, radius: 2, opacity: nowInOffDay ? 0.15 : 0.4)
             }
         }

--- a/TokenEaterApp/Popover/PopoverShared.swift
+++ b/TokenEaterApp/Popover/PopoverShared.swift
@@ -176,20 +176,32 @@ struct PopoverErrorBanner: View {
         .padding(.bottom, 8)
     }
 
+    /// Deliberately discreet single-line banner (#160): a soft warning glyph, a
+    /// short label, and one subtle inline action. No long hint sentence and no
+    /// diagnostic button: re-auth is a one-tap recovery, not a debug surface.
     @ViewBuilder private var expiredContent: some View {
-        Label(String(localized: "error.banner.expired"), systemImage: "exclamationmark.triangle.fill")
-            .font(.system(size: 11, weight: .semibold))
-            .foregroundStyle(.red)
-        Text(String(localized: "error.banner.expired.hint"))
-            .font(.system(size: 10))
-            .foregroundStyle(.white.opacity(0.5))
-        HStack(spacing: 6) {
-            primaryActionButton(title: String(localized: "error.banner.reauth.button")) {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(Color(red: 0.97, green: 0.44, blue: 0.44))
+            Text(String(localized: "error.banner.reauth"))
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.white.opacity(0.7))
+                .lineLimit(1)
+            Spacer(minLength: 8)
+            Button {
                 Task { await usageStore.reauthenticate() }
+            } label: {
+                Text(String(localized: "error.banner.reauth.button"))
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.85))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 3)
+                    .background(Color.white.opacity(0.08))
+                    .clipShape(Capsule())
             }
-            CopyDiagnosticButton()
+            .buttonStyle(.plain)
         }
-        .padding(.top, 2)
     }
 
     @ViewBuilder private var rateLimitedContent: some View {
@@ -434,6 +446,11 @@ struct PopoverPacingRow: View {
             ? (pacing.resetDate.map { schedule.offDayRanges(resetDate: $0) } ?? [])
             : []
         let nowInOffDay = showWorkweekBadge && schedule.isOffDay(Date())
+        // Calendar-time position for the "now" marker so it aligns with the
+        // off-day hatch (#194). nil keeps the active-time expected position.
+        let markerFraction: Double? = (showWorkweekBadge && schedule.isActive)
+            ? pacing.resetDate.map { schedule.nowFraction(resetDate: $0) }
+            : nil
         return VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 5) {
                 Text(label)
@@ -452,7 +469,8 @@ struct PopoverPacingRow: View {
                     gradient: PopoverColors.zoneGradient(pacing.zone, theme: themeStore),
                     compact: true,
                     offDayRanges: offRanges,
-                    nowInOffDay: nowInOffDay
+                    nowInOffDay: nowInOffDay,
+                    markerFraction: markerFraction
                 )
                 .frame(maxWidth: .infinity)
 

--- a/TokenEaterApp/SettingsSectionView.swift
+++ b/TokenEaterApp/SettingsSectionView.swift
@@ -125,6 +125,12 @@ struct SettingsSectionView: View {
                         .foregroundStyle(.white.opacity(0.4))
                         .fixedSize(horizontal: false, vertical: true)
 
+                    darkToggle(String(localized: "settings.launchInBackground"), isOn: $settingsStore.launchInBackground)
+                    Text(String(localized: "settings.launchInBackground.hint"))
+                        .font(.system(size: 11))
+                        .foregroundStyle(.white.opacity(0.4))
+                        .fixedSize(horizontal: false, vertical: true)
+
                     Divider().opacity(0.12)
 
                     HStack(alignment: .center, spacing: 12) {

--- a/TokenEaterApp/StatusBarController.swift
+++ b/TokenEaterApp/StatusBarController.swift
@@ -48,8 +48,16 @@ final class StatusBarController: NSObject {
             observeOnboardingForRefresh()
         }
 
-        DispatchQueue.main.async { [weak self] in
-            self?.showDashboard()
+        // Auto-open the dashboard at launch unless the user opted into a
+        // background (menu-bar-only) launch. Onboarding ALWAYS opens: the
+        // window hosts the onboarding flow and, being an LSUIElement app with
+        // no Dock icon, suppressing it on a fresh install would strand the user
+        // with no reachable UI (#198). The window stays reachable from the menu
+        // bar's right-click "Open" item afterwards.
+        if !settingsStore.hasCompletedOnboarding || !settingsStore.launchInBackground {
+            DispatchQueue.main.async { [weak self] in
+                self?.showDashboard()
+            }
         }
     }
 

--- a/TokenEaterApp/StatusBarController.swift
+++ b/TokenEaterApp/StatusBarController.swift
@@ -485,6 +485,12 @@ final class StatusBarController: NSObject {
         popover.contentViewController = nil
         stopEventMonitor()
 
+        // Promote to a regular app (Dock icon + app menu) while the dashboard
+        // is open so it feels like a real window; windowShouldClose drops back
+        // to .accessory (menu-bar-only) when the window is closed, so the Dock
+        // icon is only present while the window actually is.
+        NSApp.setActivationPolicy(.regular)
+
         if let window = dashboardWindow {
             window.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
@@ -626,14 +632,17 @@ extension StatusBarController: NSWindowDelegate {
     nonisolated func windowShouldClose(_ sender: NSWindow) -> Bool {
         MainActor.assumeIsolated {
             if !self.settingsStore.hasCompletedOnboarding {
-                // User closed during onboarding - quit the app so they're not stuck
-                // (LSUIElement app has no Dock icon, no Force Quit entry)
+                // User closed during onboarding: quit rather than sit
+                // half-onboarded and unconnected in the menu bar.
                 NSApp.terminate(nil)
                 return
             }
             sender.contentViewController = nil
             sender.orderOut(nil)
             self.dashboardWindow = nil
+            // Closing the dashboard (not quitting) returns the app to
+            // menu-bar-only: drop the Dock icon + app menu.
+            NSApp.setActivationPolicy(.accessory)
         }
         return false
     }

--- a/TokenEaterTests/MenuBarRendererTests.swift
+++ b/TokenEaterTests/MenuBarRendererTests.swift
@@ -80,3 +80,32 @@ struct MenuBarRendererTests {
         #expect(observed != red, "80% / 90min should no longer match the threshold-mode red color")
     }
 }
+
+@Suite("MenuBarRenderer.periodLabelColor")
+struct MenuBarPeriodLabelColorTests {
+
+    @Test("default (no custom hex) is the legible secondary colour, not the faint tertiary")
+    func defaultIsLegible() {
+        let resolved = MenuBarRenderer.periodLabelColor(hex: "")
+        #expect(resolved == MenuBarRenderer.defaultPeriodLabelColor)
+        // Regression guard for #196: the "5h" / "7d" label used to default to
+        // tertiary (~26%), nearly invisible on a light menu bar. It must not
+        // revert to that faint grey.
+        #expect(MenuBarRenderer.defaultPeriodLabelColor != NSColor.tertiaryLabelColor)
+    }
+
+    /// A user-picked hex wins. The resolver is mode-agnostic, so the same colour
+    /// applies in monochrome too (the #196 promise: tweakable in monochrome).
+    @Test("a valid custom hex overrides the default")
+    func customHexWins() {
+        let resolved = MenuBarRenderer.periodLabelColor(hex: "#3366FF")
+        #expect(resolved == MenuBarTextColorResolver.resolve(hex: "#3366FF", fallback: .clear))
+        #expect(resolved != MenuBarRenderer.defaultPeriodLabelColor)
+    }
+
+    @Test("empty or malformed hex falls back to the legible default")
+    func malformedHexFallsBack() {
+        #expect(MenuBarRenderer.periodLabelColor(hex: "   ") == MenuBarRenderer.defaultPeriodLabelColor)
+        #expect(MenuBarRenderer.periodLabelColor(hex: "not-a-color") == MenuBarRenderer.defaultPeriodLabelColor)
+    }
+}

--- a/TokenEaterTests/ModelKindTests.swift
+++ b/TokenEaterTests/ModelKindTests.swift
@@ -28,6 +28,23 @@ struct ModelKindTests {
         #expect(ModelKind(rawModel: "opus") == .opus48)
     }
 
+    // MARK: - Fable
+
+    /// Fable 5 must not fall through to `.other` (#199); it is its own family,
+    /// not an Opus variant.
+    @Test func fableIsRecognised() {
+        #expect(ModelKind(rawModel: "claude-fable-5") == .fable)
+        #expect(ModelKind(rawModel: "claude-fable-5[1m]") == .fable)
+        #expect(ModelKind(rawModel: "fable") == .fable)
+    }
+
+    @Test func fableIsItsOwnFamily() {
+        #expect(ModelKind.fable.family == .fable)
+        #expect(ModelKind.fable.displayName == "Fable 5")
+        #expect(ModelFamily.fable.displayName == "Fable")
+        #expect(ModelFamily.allCases.contains(.fable))
+    }
+
     // MARK: - Other families
 
     @Test func sonnetAndHaiku() {

--- a/TokenEaterTests/PacingCalculatorTests.swift
+++ b/TokenEaterTests/PacingCalculatorTests.swift
@@ -509,4 +509,81 @@ struct PacingCalculatorTests {
         #expect(s.isOffDay(mon7, calendar: cal) == true)
         #expect(s.isOffDay(mon12, calendar: cal) == false)
     }
+
+    // MARK: - Off-day ranges + now marker (#194)
+
+    /// A Mon-aligned 7-day window so day fractions are exact: Mon..Fri = [0, 5/7],
+    /// Sat+Sun = [5/7, 1]. `resetDate` is the window END (next Monday).
+    private static func mondayAlignedWindow() -> (windowStart: Date, resetDate: Date, calendar: Calendar) {
+        let cal = utcCalendar
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
+        let monday = cal.startOfDay(for: cal.nextDate(after: base, matching: DateComponents(weekday: 2), matchingPolicy: .nextTime)!)
+        return (monday, monday.addingTimeInterval(7 * 86_400), cal)
+    }
+
+    @Test("offDayRanges covers exactly the weekend (~2/7) for a Mon-Fri window")
+    func offDayRangesWeekendWidth() {
+        let (_, resetDate, cal) = Self.mondayAlignedWindow()
+        let s = PacingSchedule(enabled: true, activeDays: PacingSchedule.workweek)
+        let ranges = s.offDayRanges(resetDate: resetDate, calendar: cal)
+        let total = ranges.reduce(0.0) { $0 + ($1.upperBound - $1.lowerBound) }
+        #expect(abs(total - 2.0 / 7.0) < 0.001)
+    }
+
+    @Test("nowFraction is the linear calendar fraction of now in the window")
+    func nowFractionIsLinear() {
+        let (windowStart, resetDate, _) = Self.mondayAlignedWindow()
+        let s = PacingSchedule(enabled: true, activeDays: PacingSchedule.workweek)
+        // Friday noon = 4.5 days into a 7-day window.
+        let fridayNoon = windowStart.addingTimeInterval(4 * 86_400 + 12 * 3600)
+        #expect(abs(s.nowFraction(resetDate: resetDate, now: fridayNoon) - 4.5 / 7.0) < 0.0001)
+        // Clamps outside the window.
+        #expect(s.nowFraction(resetDate: resetDate, now: windowStart.addingTimeInterval(-86_400)) == 0)
+        #expect(s.nowFraction(resetDate: resetDate, now: resetDate.addingTimeInterval(86_400)) == 1)
+    }
+
+    /// The core invariant: a "now" marker drawn at `nowFraction` lands on a
+    /// dashed (off) segment exactly when `isOffDay(now)` is true. Interior
+    /// instants (noon) avoid the ClosedRange endpoint ambiguity at day borders.
+    @Test("nowFraction lands in an offDayRange iff now is an off day")
+    func nowMarkerAgreesWithOffDayHatch() {
+        let (windowStart, resetDate, cal) = Self.mondayAlignedWindow()
+        let s = PacingSchedule(enabled: true, activeDays: PacingSchedule.workweek)
+        let ranges = s.offDayRanges(resetDate: resetDate, calendar: cal)
+
+        let fridayNoon = windowStart.addingTimeInterval(4 * 86_400 + 12 * 3600)
+        let saturdayNoon = windowStart.addingTimeInterval(5 * 86_400 + 12 * 3600)
+
+        let fFri = s.nowFraction(resetDate: resetDate, now: fridayNoon)
+        let fSat = s.nowFraction(resetDate: resetDate, now: saturdayNoon)
+
+        #expect(s.isOffDay(fridayNoon, calendar: cal) == false)
+        #expect(ranges.contains { $0.contains(fFri) } == false)
+
+        #expect(s.isOffDay(saturdayNoon, calendar: cal) == true)
+        #expect(ranges.contains { $0.contains(fSat) } == true)
+    }
+
+    /// Regression guard for #194: with Mon/Wed/Fri active and now on Friday, the
+    /// OLD active-time marker (expectedUsage) lands on a dashed off-day segment,
+    /// while the calendar-time `nowFraction` correctly sits on Friday's solid band.
+    @Test("active-time marker mislands on the hatch but nowFraction does not (#194)")
+    func nowFractionFixesMislandedMarker() {
+        let (windowStart, resetDate, cal) = Self.mondayAlignedWindow()
+        let mwf = PacingSchedule(enabled: true, activeDays: [2, 4, 6]) // Mon, Wed, Fri
+        let ranges = mwf.offDayRanges(resetDate: resetDate, calendar: cal)
+        let fridayNoon = windowStart.addingTimeInterval(4 * 86_400 + 12 * 3600)
+
+        // Old marker position = active-time fraction (off-days compressed out).
+        let activeElapsed = PacingCalculator.activeSeconds(from: windowStart, to: fridayNoon, activeDays: [2, 4, 6], calendar: cal)
+        let activeTotal = PacingCalculator.activeSeconds(from: windowStart, to: resetDate, activeDays: [2, 4, 6], calendar: cal)
+        let oldMarker = activeElapsed / activeTotal
+        let newMarker = mwf.nowFraction(resetDate: resetDate, now: fridayNoon)
+
+        // The bug: the active-time marker fell inside a dashed off-day range.
+        #expect(ranges.contains { $0.contains(oldMarker) } == true)
+        // The fix: the calendar-time marker sits on the active (solid) segment.
+        #expect(mwf.isOffDay(fridayNoon, calendar: cal) == false)
+        #expect(ranges.contains { $0.contains(newMarker) } == false)
+    }
 }

--- a/TokenEaterTests/SettingsStoreTests.swift
+++ b/TokenEaterTests/SettingsStoreTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import UserNotifications
 
 private let settingsKeys = [
-    "showMenuBar", "pinnedMetrics", "pacingDisplayMode",
+    "showMenuBar", "launchInBackground", "pinnedMetrics", "pacingDisplayMode",
     "hasCompletedOnboarding", "proxyEnabled", "proxyHost", "proxyPort",
     "overlayEnabled", "watcherStyle", "watcherScanInterval", "watcherVisibility"
 ]
@@ -210,6 +210,31 @@ struct SettingsStoreTests {
         let saved = UserDefaults.standard.stringArray(forKey: "pinnedMetrics") ?? []
         #expect(saved.contains("sonnet"))
         #expect(saved.contains("weeklyPacing"))
+    }
+
+    // MARK: - Launch in background (#198)
+
+    @Test("launchInBackground defaults to false")
+    func launchInBackgroundDefaults() {
+        let (store, _, _) = makeStore()
+        #expect(store.launchInBackground == false)
+    }
+
+    @Test("launchInBackground persists to UserDefaults")
+    func launchInBackgroundPersists() {
+        let (store, _, _) = makeStore()
+        store.launchInBackground = true
+        #expect(UserDefaults.standard.object(forKey: "launchInBackground") as? Bool == true)
+    }
+
+    @Test("launchInBackground reads back on a fresh store instance")
+    func launchInBackgroundReadsBack() {
+        let (store, _, _) = makeStore()
+        store.launchInBackground = true
+        // A new store built against the same UserDefaults picks the value up
+        // (makeStore would wipe it, so construct directly here).
+        let fresh = SettingsStore(notificationService: MockNotificationService(), tokenProvider: MockTokenProvider())
+        #expect(fresh.launchInBackground == true)
     }
 
     // MARK: - Overlay


### PR DESCRIPTION
Batch PR closing five open issues. Each is self-contained; the only shared files are `PopoverShared.swift` (#194 + #160) and the `Localizable.strings` (#160 + #198).

## What's in it

### #199 (fix) Fable 5 classified as "Other" in History
`ModelKind.init(rawModel:)` had no `fable` branch, so `claude-fable-5` fell through to `.other`. Added a `fable` case to `ModelKind` and a new `ModelFamily.fable` (its own filter chip, slotted before `.other` so it never jumps ahead of Opus for users with no Fable data). Chart colour `#E86FC4`, deliberately distinct from the `.other` lavender `#9B8BD9` since the two can stack adjacently. **`HistoryCache.currentVersion` bumped 1 -> 2** so existing caches that bucketed Fable under `.other` are discarded and re-scanned, reclassifying past Fable history immediately on update (no decode failure either way).

> Design choice to confirm: the `#E86FC4` magenta. Pick whatever reads best against the existing palette; it's a one-line change in `HistoryView.gradient/chipColor`.

### #194 (fix) Pace-line "now" marker on the wrong (dashed) segment
Root cause: the marker used active-time `expectedUsage` while the off-day hatch is calendar-time, so on a workweek schedule the two spaces diverge and the marker drifts onto a hatched off-day segment while "now" is actually an active day. Added `PacingSchedule.nowFraction` (calendar-time) and an optional `markerFraction` passed to `PacingBar` / `MonitoringView.pacingTrack` / `PopoverPacingRow`. `nil` default means classic (no schedule) rendering is byte-for-byte unchanged. `HeroPacingGraph` is intentionally untouched (no hatch, different chart model).

> **Tradeoff to eyeball in a Release build.** This places the marker at calendar-now (so it sits correctly solid/dashed), but `expectedUsage` still drives the delta/zone/copy. On an *active* day, calendar-now is left of the active-time ideal, so a user who is exactly on pace (+0%) will see the usage fill end ~19-26% of the bar width to the right of the marker. The fill-vs-marker gap no longer equals the displayed delta. This matches the issue's literal ask (marker = "now", solid on active days / dashed on off days) and fixes the weekend case cleanly, but it is a conscious semantic shift. If you don't like it on testing, the alternatives are (a) keep the triangle at `expected%` and just clamp it out of the hatch, or (b) draw the calendar-now position as a visually distinct tick separate from the pace marker.

### #196 (feat) Menu bar period label unreadable on light background
The "5h"/"7d" label defaulted to `tertiaryLabelColor` (~26%, near-invisible on a light menu bar) and in monochrome you couldn't pick a colour at all. Now: the default is the legible `secondaryLabelColor` (~55%, ranks below the bold value), and the custom `sessionPeriodColorHex` is honored in **every mode including monochrome**, with the picker surfaced in monochrome in `DisplaySectionView`. This delivers the "tweak even in monochrome" follow-up promised on the issue.

> **Builds on community PR #197** (@pulkitxm), now merged. #197 fixed the default legibility (secondary vs tertiary); #201 keeps that and extends it so a custom hex is honored in monochrome too, with the picker exposed in monochrome mode. Thanks @pulkitxm.

### #160 (feat) Re-authorize banner too heavy
`PopoverErrorBanner.expiredContent` redesigned from title + long hint + two buttons into a discreet single line: soft warning glyph, a short label (`error.banner.reauth`), and one subtle inline `Re-authorize` action. The diagnostic button stays in the two genuinely debug-relevant states (rate-limited, network). Removed the now-orphaned `error.banner.expired` / `.expired.hint` strings from both locales.

### #198 (feat) Launch in background (menu bar only)
The dashboard window auto-opens at every launch because `StatusBarController.init` force-calls `showDashboard()` (there is no `WindowGroup`, so `open -gj` can't suppress it). Added a `launchInBackground` `SettingsStore` flag (default off) that gates the auto-open. **Onboarding always opens regardless** (it lives in this window, and this is an `LSUIElement` app with no Dock icon, so suppressing it on a fresh install would strand the user). The window stays reachable from the menu bar right-click > Open. New toggle in Settings > General, EN + FR.

## Not addressed
- **#200** (auto-ping to start the 5h timer): deliberately not implemented. It is rate-limit gaming via automated dummy prompts, the reporter themselves flags possible ToS conflict, and it would turn a passive tracker into something that sends requests to Claude. Recommend declining.

## Testing
- 392 unit tests pass (Swift Testing), new coverage for Fable classification, `nowFraction`/`offDayRanges`, `periodLabelColor`, and `launchInBackground`.
- Release build clean on Xcode 16.4.
- Manual Release testing still needed (per AGENTS.md, SwiftUI/widget changes aren't unit-testable): the #194 marker across day combinations, the monochrome label picker on a light wallpaper, the redesigned banner in all three popover layouts (force a token-unavailable state), and the background-launch path (toggle on, relaunch, confirm menu-bar-only + reopen from the menu bar, and that a fresh install still shows onboarding).

## Also added (window/dock UX, #198-adjacent)
The app stays `LSUIElement` (launches with no Dock icon), but now switches to `.regular` while the dashboard window is open (Dock icon + app menu, feels like a real app) and back to `.accessory` when the window is closed (not quit), so the Dock icon is present only while the window is. Onboarding still quits on close. Pairs naturally with the #198 background-launch flag (launch with no window = no Dock icon).

Closes #199
Closes #198
Closes #194
Closes #160
