### PR TITLE
fix: keep tab selector in sync and refresh History on tab entry

### DIFF
--- a/TokenEaterApp/HistoryView.swift
+++ b/TokenEaterApp/HistoryView.swift
@@ -39,10 +39,12 @@ struct HistoryView: View {
         }
         .animation(DS.Motion.easeInOut, value: isLoaderActive)
         .onAppear {
-            // Cache hit makes this a no-op when we already loaded recently.
-            if !store.hasLoadedOnce {
-                store.reload()
-            }
+            // Refresh on every entry to the tab, not just the first. The
+            // store is hoisted in `MainAppView`, so it survives navigation
+            // and would otherwise keep showing the last load until the user
+            // changed the range. Previously loaded buckets stay visible while
+            // the reload runs, so there's no flash of empty state.
+            store.reload()
         }
         .onChange(of: store.filter) { _, _ in
             triggerChartReveal()

--- a/TokenEaterApp/MainAppView.swift
+++ b/TokenEaterApp/MainAppView.swift
@@ -136,8 +136,10 @@ struct MainAppView: View {
     private func performSpaceTransition(to newSpace: AppSpace) {
         guard newSpace != displayedSpace else { return }
 
-        // Ignore rapid clicks during a transition; the current run
-        // completes against the latest `selectedSpace`.
+        // A transition is already in flight. Don't start a second one - it
+        // reconciles against the latest `selectedSpace` when it finishes
+        // (see the swap and the tail re-check below), so rapid clicks never
+        // leave the pill nav and the content showing different spaces.
         if isTransitioningSpace { return }
         isTransitioningSpace = true
 
@@ -150,8 +152,12 @@ struct MainAppView: View {
         }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + rampUp) {
+            // Swap to the *current* selection, not the value captured when
+            // this run started - the user may have clicked again during the
+            // ramp-up, and the pill nav already reflects that newer choice.
+            let target = self.selectedSpace
             withTransaction(Transaction(animation: nil)) {
-                self.displayedSpace = newSpace
+                self.displayedSpace = target
             }
 
             withAnimation(.easeOut(duration: rampDown)) {
@@ -160,6 +166,11 @@ struct MainAppView: View {
 
             DispatchQueue.main.asyncAfter(deadline: .now() + rampDown) {
                 self.isTransitioningSpace = false
+                // If the selection moved on again after our swap, run once
+                // more to catch up so content and selector stay in sync.
+                if self.selectedSpace != self.displayedSpace {
+                    self.performSpaceTransition(to: self.selectedSpace)
+                }
             }
         }
     }


### PR DESCRIPTION
## What this PR does

  Fixes two main-window navigation bugs: the tab selector and the displayed
  content could desync during rapid tab switching, and the History tab showed
  stale data until the timeframe was changed.
  
  ## Why

  - **Tab/content desync:** `performSpaceTransition` captured its target at the
    start of the blur transition and ignored any selection made during the
    ramp-up. A second click mid-transition advanced the pill selector but left
    `displayedSpace` on the earlier target — selector said X, content showed Y.
  - **Stale History:** `HistoryStore` is hoisted in `MainAppView` and survives
    navigation, so `HistoryView.onAppear` only reloaded on the first visit
    (`!hasLoadedOnce`). Re-entering the tab kept showing the last load until the
    range changed, which forced a `reload()`.
  
  ## How to test

  1. Open the main window. Rapidly click Monitoring → History → Settings and
     back. Confirm the pill selector always matches the visible content (no
     state where the selector shows one tab and a different one is displayed).
  2. Open History and note the totals. Generate some Claude Code usage (or wait
     for new session activity), switch to another tab, then return to History —
     confirm the data refreshes on entry without having to change the timeframe.
     Previously loaded data stays visible during the reload (no empty-state flash).

  ## Checklist

  - [x] Tests pass locally
  - [x] If you changed SwiftUI or the widget, you tested it manually in a Release build
  - [x] Branch is rebased on the latest `main`

  ---
  
  **Notes for reviewers:**
  - `reload()` on every History entry is a local `~/.claude/projects` JSONL
    re-scan (no network/API); the service caches per-file by path+mtime and only
    re-parses changed files, so repeated opens are cheap. The one visible cost is
    a possible brief loader flash on entry — happy to add a staleness guard
    (skip reload if the last load is <N seconds old) if preferred.
  - The desync fix adds a tail re-check that can run one extra blur transition
    when the selection changes during ramp-down; it always swaps to the current
    selection, so it converges and can't loop.