### PR TITLE
feat: add Extra Credits metric across menu bar, popover, widgets, and dashboard

### DIFF
--- a/Shared/Helpers/MenuBarRenderer.swift
+++ b/Shared/Helpers/MenuBarRenderer.swift
@@ -42,6 +42,8 @@ enum MenuBarRenderer {
         let pacingShape: PacingShape
         let designPct: Int
         let hasDesign: Bool
+        let extraCreditsPct: Int
+        let hasExtraCredits: Bool
     }
 
     private static var cachedImage: NSImage?
@@ -71,18 +73,54 @@ enum MenuBarRenderer {
     // MARK: - Color helpers
 
     private static func colorForPct(_ pct: Int, resetDate: Date?, windowDuration: TimeInterval, data: RenderData) -> NSColor {
-        if data.menuBarMonochrome { return .labelColor }
-        if data.smartResetColor {
-            return data.themeColors.smartGaugeNSColor(
+        gaugeColor(
+            pct: pct,
+            resetDate: resetDate,
+            windowDuration: windowDuration,
+            monochrome: data.menuBarMonochrome,
+            smartEnabled: data.smartResetColor,
+            themeColors: data.themeColors,
+            thresholds: data.thresholds,
+            pacingMargin: data.pacingMargin,
+            smartColorProfile: data.smartColorProfile
+        )
+    }
+
+    /// Resolves the gauge colour for a flat percentage.
+    ///
+    /// Smart Color is a *time-aware* risk model: it projects current usage
+    /// against the time left in a reset window. A metric with no reset window
+    /// (e.g. the Extra Credits pool) has nothing to project against, so it
+    /// falls back to the static warning/critical threshold ladder. This is the
+    /// rule that keeps Extra Credits coloured identically in the menu bar, the
+    /// popover, the dashboard and the widgets. Internal (not private) so the
+    /// windowless-fallback rule is unit-testable in isolation; `now` is
+    /// injectable for deterministic tests.
+    static func gaugeColor(
+        pct: Int,
+        resetDate: Date?,
+        windowDuration: TimeInterval,
+        monochrome: Bool,
+        smartEnabled: Bool,
+        themeColors: ThemeColors,
+        thresholds: UsageThresholds,
+        pacingMargin: Double,
+        smartColorProfile: SmartColorProfile,
+        now: Date = Date()
+    ) -> NSColor {
+        if monochrome { return .labelColor }
+        if smartEnabled, let resetDate, windowDuration > 0 {
+            return themeColors.smartGaugeNSColor(
                 utilization: Double(pct),
                 resetDate: resetDate,
                 windowDuration: windowDuration,
-                thresholds: data.thresholds,
-                pacingMargin: data.pacingMargin,
-                profile: data.smartColorProfile
+                thresholds: thresholds,
+                pacingMargin: pacingMargin,
+                now: now,
+                profile: smartColorProfile
             )
         }
-        return data.themeColors.gaugeNSColor(for: Double(pct), thresholds: data.thresholds)
+        return themeColors.gaugeNSColor(for: Double(pct), thresholds: thresholds)
     }
 
     private static func resetDate(for metric: MetricID, data: RenderData) -> Date? {
@@ -200,11 +238,12 @@ enum MenuBarRenderer {
         }()
 
         let ordered: [MetricID] = [
-            .sessionReset, .fiveHour, .sessionPacing, .sevenDay, .weeklyPacing, .sonnet, .design
+            .sessionReset, .fiveHour, .sessionPacing, .sevenDay, .weeklyPacing, .sonnet, .design, .extraCredits
         ].filter {
             guard data.pinnedMetrics.contains($0) else { return false }
-            // Sonnet / Design visibility in the menu bar is purely driven
-            // by pinnedMetrics. Popover visibility has its own toggles.
+            // Sonnet / Design / Extra Credits visibility in the menu bar is
+            // purely driven by pinnedMetrics. Popover visibility has its own
+            // toggles.
             if $0 == .design && !data.hasDesign { return false }
             switch $0 {
             // Session-scoped pins stay visible as long as the API returned a
@@ -214,6 +253,9 @@ enum MenuBarRenderer {
             case .sessionReset, .sessionPacing: return data.hasFiveHourBucket
             case .weeklyPacing: return data.hasWeeklyPacing
             case .design: return data.hasDesign
+            // Extra Credits only renders when the paid pool is provisioned and
+            // enabled. Hidden otherwise so non-overage users never see "EC 0%".
+            case .extraCredits: return data.hasExtraCredits
             default: return true
             }
         }
@@ -256,13 +298,14 @@ enum MenuBarRenderer {
                     mode: data.weeklyPacingDisplayMode,
                     data: data
                 )
-            case .fiveHour, .sevenDay, .sonnet, .design:
+            case .fiveHour, .sevenDay, .sonnet, .design, .extraCredits:
                 let value: Int
                 switch metric {
                 case .fiveHour: value = data.fiveHourPct
                 case .sevenDay: value = data.sevenDayPct
                 case .sonnet: value = data.sonnetPct
                 case .design: value = data.designPct
+                case .extraCredits: value = data.extraCreditsPct
                 default: value = 0
                 }
                 appendPercentMetric(
@@ -375,16 +418,18 @@ enum MenuBarRenderer {
 
     private static func buildBadgePills(_ data: RenderData) -> [BadgePill] {
         let ordered: [MetricID] = [
-            .sessionReset, .fiveHour, .sessionPacing, .sevenDay, .weeklyPacing, .sonnet, .design
+            .sessionReset, .fiveHour, .sessionPacing, .sevenDay, .weeklyPacing, .sonnet, .design, .extraCredits
         ].filter {
             guard data.pinnedMetrics.contains($0) else { return false }
-            // Sonnet / Design visibility in the menu bar is purely driven
-            // by pinnedMetrics. Popover visibility has its own toggles.
+            // Sonnet / Design / Extra Credits visibility in the menu bar is
+            // purely driven by pinnedMetrics. Popover visibility has its own
+            // toggles.
             if $0 == .design && !data.hasDesign { return false }
             switch $0 {
             case .sessionReset, .sessionPacing: return data.hasFiveHourBucket
             case .weeklyPacing: return data.hasWeeklyPacing
             case .design: return data.hasDesign
+            case .extraCredits: return data.hasExtraCredits
             default: return true
             }
         }
@@ -416,6 +461,13 @@ enum MenuBarRenderer {
                 return BadgePill(
                     text: "\(data.designPct)%",
                     tint: colorForPct(data.designPct, resetDate: data.designResetDate, windowDuration: 7 * 86_400, data: data)
+                )
+            case .extraCredits:
+                // No reset window: pass nil/0 so colorForPct falls back to the
+                // static threshold colour instead of risk-based smart colour.
+                return BadgePill(
+                    text: "\(data.extraCreditsPct)%",
+                    tint: colorForPct(data.extraCreditsPct, resetDate: nil, windowDuration: 0, data: data)
                 )
             case .sessionPacing:
                 return pacingBadgePill(

--- a/Shared/Models/MetricModels.swift
+++ b/Shared/Models/MetricModels.swift
@@ -6,6 +6,7 @@ enum MetricID: String, CaseIterable {
     case sevenDay = "sevenDay"
     case sonnet = "sonnet"
     case design = "design"
+    case extraCredits = "extraCredits"
     case sessionPacing = "sessionPacing"
     case weeklyPacing = "weeklyPacing"
 
@@ -16,6 +17,7 @@ enum MetricID: String, CaseIterable {
         case .sevenDay: return String(localized: "metric.weekly")
         case .sonnet: return String(localized: "metric.sonnet")
         case .design: return String(localized: "metric.design")
+        case .extraCredits: return String(localized: "metric.extraCredits")
         case .sessionPacing: return String(localized: "pacing.session.label")
         case .weeklyPacing: return String(localized: "pacing.weekly.label")
         }
@@ -28,6 +30,7 @@ enum MetricID: String, CaseIterable {
         case .sevenDay: return "7d"
         case .sonnet: return "S"
         case .design: return "D"
+        case .extraCredits: return "EC"
         case .sessionPacing: return "5hP"
         case .weeklyPacing: return "7dP"
         }

--- a/Shared/Models/UsageModels.swift
+++ b/Shared/Models/UsageModels.swift
@@ -130,6 +130,17 @@ struct ExtraUsage: Codable, Equatable {
         case currency
         case disabledReason = "disabled_reason"
     }
+
+    /// Utilization as a whole-number percentage. Prefers the API-provided
+    /// `utilization`; falls back to `used / limit` when it is omitted but both
+    /// amounts are present. 0 when there is no limit to divide by. Shared by
+    /// the menu bar, the dashboard and the widgets so they never disagree.
+    var percent: Int {
+        if let util = utilization { return Int(util) }
+        let used = usedCredits ?? 0
+        let limit = monthlyLimit ?? 0
+        return limit > 0 ? Int((used / limit) * 100) : 0
+    }
 }
 
 // MARK: - Cached Usage (for offline support)

--- a/Shared/Stores/SettingsStore.swift
+++ b/Shared/Stores/SettingsStore.swift
@@ -83,6 +83,11 @@ final class SettingsStore: ObservableObject {
     @Published var displayDesign: Bool {
         didSet { UserDefaults.standard.set(displayDesign, forKey: "displayDesign") }
     }
+    /// Same as `displayDesign` but for the paid Extra Credits pool. Only
+    /// surfaced in settings when `UsageStore.hasExtraCredits` is true.
+    @Published var displayExtraCredits: Bool {
+        didSet { UserDefaults.standard.set(displayExtraCredits, forKey: "displayExtraCredits") }
+    }
 
     // MARK: - Popover
     /// Full layout configuration for the menu-bar popover. 3 variants share this
@@ -498,6 +503,9 @@ final class SettingsStore: ObservableObject {
         }
         self.displayDesign = UserDefaults.standard.object(forKey: "displayDesign") != nil
             ? UserDefaults.standard.bool(forKey: "displayDesign")
+            : false
+        self.displayExtraCredits = UserDefaults.standard.object(forKey: "displayExtraCredits") != nil
+            ? UserDefaults.standard.bool(forKey: "displayExtraCredits")
             : false
 
         // Popover layout config. Fresh install or decode failure -> defaults

--- a/Shared/Stores/UsageStore.swift
+++ b/Shared/Stores/UsageStore.swift
@@ -50,6 +50,15 @@ final class UsageStore: ObservableObject {
         errorState == .tokenUnavailable
     }
 
+    /// True when the paid Extra Credits pool is provisioned and turned on for
+    /// this account. Mirrors `hasDesign`/`hasOpus`: drives whether the metric
+    /// can be pinned to the menu bar and shown in the widgets.
+    var hasExtraCredits: Bool { extraUsage?.isEnabled == true }
+
+    /// Extra Credits utilization as a whole-number percentage (see
+    /// `ExtraUsage.percent`). 0 when the pool is absent.
+    var extraCreditsPct: Int { extraUsage?.percent ?? 0 }
+
     var pacingMargin: Int = 10
     /// Workweek pacing schedule (from settings). Wired by StatusBarController.
     /// Drives whether off-days count toward the expected pace.

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -16,6 +16,7 @@
 "dashboard.extra.separator" = "/";
 "dashboard.extra.monthly" = "this month";
 "dashboard.extra.noLimit" = "Monthly limit not set";
+"metric.extraCredits" = "Extra Credits";
 "metric.sessionReset" = "Session reset countdown";
 "settings.pacing.style" = "Pacing style";
 "settings.group.session" = "Session (5h)";
@@ -54,6 +55,10 @@
 "widget.pacing.session" = "5h";
 "widget.pacing.weekly" = "7d";
 "widget.design" = "Design";
+"widget.extra" = "Extra Credits";
+"widget.title.extraCredits" = "Extra Credits";
+"widget.description.extraCredits" = "Track your paid Extra Credits pool: spend, monthly limit and percentage used";
+"widget.extra.disabled" = "Extra Credits not enabled";
 "widget.history.title" = "History";
 "widget.history.last7days" = "Last 7 days";
 "widget.history.total" = "Total";
@@ -630,6 +635,7 @@
 "popover.option.showRefreshButton" = "Show manual refresh button";
 "popover.option.showSonnet" = "Show Sonnet ring (Classic variant)";
 "popover.option.showDesign" = "Show Design ring (Classic variant)";
+"popover.option.showExtraCredits" = "Show Extra Credits ring";
 "settings.group.extra" = "Extra metrics in menu bar";
 
 "popoverVariant.classic" = "Classic";

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -16,6 +16,7 @@
 "dashboard.extra.separator" = "/";
 "dashboard.extra.monthly" = "ce mois-ci";
 "dashboard.extra.noLimit" = "Limite mensuelle non définie";
+"metric.extraCredits" = "Crédits sup.";
 "metric.sessionReset" = "Compte à rebours de session";
 "settings.pacing.style" = "Style du pacing";
 "settings.group.session" = "Session (5h)";
@@ -54,6 +55,10 @@
 "widget.pacing.session" = "5h";
 "widget.pacing.weekly" = "7j";
 "widget.design" = "Design";
+"widget.extra" = "Crédits sup.";
+"widget.title.extraCredits" = "Crédits supplémentaires";
+"widget.description.extraCredits" = "Suivez votre pool de crédits supplémentaires payants : dépenses, limite mensuelle et pourcentage utilisé";
+"widget.extra.disabled" = "Crédits supplémentaires non activés";
 "widget.history.title" = "Historique";
 "widget.history.last7days" = "7 derniers jours";
 "widget.history.total" = "Total";
@@ -630,6 +635,7 @@
 "popover.option.showRefreshButton" = "Afficher le bouton de rafraîchissement manuel";
 "popover.option.showSonnet" = "Afficher l'anneau Sonnet (variant Classic)";
 "popover.option.showDesign" = "Afficher l'anneau Design (variant Classic)";
+"popover.option.showExtraCredits" = "Afficher l'anneau Crédits sup.";
 "settings.group.extra" = "Métriques supplémentaires dans la barre de menus";
 
 "popoverVariant.classic" = "Classique";

--- a/TokenEaterApp/DisplaySectionView.swift
+++ b/TokenEaterApp/DisplaySectionView.swift
@@ -16,6 +16,7 @@ struct DisplaySectionView: View {
     @State private var showWeeklyPacing: Bool
     @State private var showSonnet: Bool
     @State private var showDesign: Bool
+    @State private var showExtraCredits: Bool
 
     init(initialMetrics: Set<MetricID>) {
         _showFiveHour = State(initialValue: initialMetrics.contains(.fiveHour))
@@ -25,6 +26,7 @@ struct DisplaySectionView: View {
         _showWeeklyPacing = State(initialValue: initialMetrics.contains(.weeklyPacing))
         _showSonnet = State(initialValue: initialMetrics.contains(.sonnet))
         _showDesign = State(initialValue: initialMetrics.contains(.design))
+        _showExtraCredits = State(initialValue: initialMetrics.contains(.extraCredits))
     }
 
     var body: some View {
@@ -81,6 +83,7 @@ struct DisplaySectionView: View {
         }
         .onChange(of: showSonnet) { _, new in syncMetric(.sonnet, on: new, revert: { showSonnet = true }) }
         .onChange(of: showDesign) { _, new in syncMetric(.design, on: new, revert: { showDesign = true }) }
+        .onChange(of: showExtraCredits) { _, new in syncMetric(.extraCredits, on: new, revert: { showExtraCredits = true }) }
         // Sync: store -> local toggles (external changes, e.g. pin/unpin from popover)
         .onChange(of: settingsStore.pinnedMetrics) { _, metrics in
             if showFiveHour != metrics.contains(.fiveHour) { showFiveHour = metrics.contains(.fiveHour) }
@@ -95,6 +98,7 @@ struct DisplaySectionView: View {
                 withAnimation(.easeInOut(duration: 0.2)) { showWeeklyPacing = metrics.contains(.weeklyPacing) }
             }
             if showSonnet != metrics.contains(.sonnet) { showSonnet = metrics.contains(.sonnet) }
+            if showExtraCredits != metrics.contains(.extraCredits) { showExtraCredits = metrics.contains(.extraCredits) }
         }
     }
 
@@ -156,6 +160,15 @@ struct DisplaySectionView: View {
                             isActive: showDesign,
                             accent: .purple
                         ) { showDesign.toggle() }
+                    }
+
+                    if usageStore.hasExtraCredits {
+                        MetricPinChip(
+                            label: String(localized: "metric.extraCredits"),
+                            icon: "creditcard.fill",
+                            isActive: showExtraCredits,
+                            accent: .yellow
+                        ) { showExtraCredits.toggle() }
                     }
                 }
 
@@ -425,6 +438,7 @@ struct DisplaySectionView: View {
         showSonnet = settingsStore.pinnedMetrics.contains(.sonnet)
         showWeeklyPacing = settingsStore.pinnedMetrics.contains(.weeklyPacing)
         showDesign = settingsStore.pinnedMetrics.contains(.design)
+        showExtraCredits = settingsStore.pinnedMetrics.contains(.extraCredits)
     }
 
     private func syncMetric(_ metric: MetricID, on: Bool, revert: @escaping () -> Void) {

--- a/TokenEaterApp/MonitoringView.swift
+++ b/TokenEaterApp/MonitoringView.swift
@@ -667,9 +667,10 @@ struct MonitoringView: View {
         let limit = extra.monthlyLimit ?? 0
         let pct = extra.utilization.map { Int($0) } ?? (limit > 0 ? Int(used / limit * 100) : 0)
         let currency = extra.currency ?? "USD"
-        let tint = pct >= 85 ? DS.Palette.semanticError
-                 : pct >= 60 ? DS.Palette.semanticWarning
-                             : DS.Palette.semanticSuccess
+        // Same threshold ladder + theme palette as the menu bar / popover /
+        // widgets. Extra Credits has no reset window, so it never uses Smart
+        // Color; the static gauge thresholds keep every surface in agreement.
+        let tint = themeStore.current.gaugeColor(for: Double(pct), thresholds: themeStore.thresholds)
 
         return VStack(alignment: .leading, spacing: DS.Spacing.sm) {
             HStack {

--- a/TokenEaterApp/Popover/ClassicLayoutView.swift
+++ b/TokenEaterApp/Popover/ClassicLayoutView.swift
@@ -44,7 +44,8 @@ struct ClassicLayoutView: View {
 
         let showSonnetSat = settingsStore.displaySonnet
         let showDesignSat = settingsStore.displayDesign && usageStore.hasDesign
-        let hasExtraSatellites = showSonnetSat || showDesignSat
+        let showExtraCreditsSat = settingsStore.displayExtraCredits && usageStore.hasExtraCredits
+        let hasExtraSatellites = showSonnetSat || showDesignSat || showExtraCreditsSat
 
         if !sessionVisible && !weeklyVisible {
             EmptyView()
@@ -79,6 +80,15 @@ struct ClassicLayoutView: View {
                         pct: usageStore.designPct,
                         resetDate: usageStore.lastUsage?.sevenDayDesign?.resetsAtDate,
                         windowDuration: 7 * 86_400
+                    )
+                }
+                if showExtraCreditsSat {
+                    // No reset window → threshold-coloured (see PopoverColors.gauge).
+                    PopoverSatelliteRing(
+                        label: String(localized: "metric.extraCredits"),
+                        pct: usageStore.extraCreditsPct,
+                        resetDate: nil,
+                        windowDuration: 0
                     )
                 }
             }

--- a/TokenEaterApp/Popover/CompactLayoutView.swift
+++ b/TokenEaterApp/Popover/CompactLayoutView.swift
@@ -31,7 +31,8 @@ struct CompactLayoutView: View {
     private var extraSatellitesRow: some View {
         let showSonnet = settingsStore.displaySonnet
         let showDesign = settingsStore.displayDesign && usageStore.hasDesign
-        if showSonnet || showDesign {
+        let showExtraCredits = settingsStore.displayExtraCredits && usageStore.hasExtraCredits
+        if showSonnet || showDesign || showExtraCredits {
             HStack(spacing: 8) {
                 if showSonnet {
                     CompactExtraChip(
@@ -49,6 +50,16 @@ struct CompactLayoutView: View {
                         pct: usageStore.designPct,
                         resetDate: usageStore.lastUsage?.sevenDayDesign?.resetsAtDate,
                         windowDuration: 7 * 86_400,
+                        theme: themeStore,
+                        settings: settingsStore
+                    )
+                }
+                if showExtraCredits {
+                    CompactExtraChip(
+                        label: String(localized: "metric.extraCredits"),
+                        pct: usageStore.extraCreditsPct,
+                        resetDate: nil,
+                        windowDuration: 0,
                         theme: themeStore,
                         settings: settingsStore
                     )

--- a/TokenEaterApp/Popover/FocusLayoutView.swift
+++ b/TokenEaterApp/Popover/FocusLayoutView.swift
@@ -61,7 +61,8 @@ struct FocusLayoutView: View {
     private var extraSatellitesRow: some View {
         let showSonnet = settingsStore.displaySonnet
         let showDesign = settingsStore.displayDesign && usageStore.hasDesign
-        if showSonnet || showDesign {
+        let showExtraCredits = settingsStore.displayExtraCredits && usageStore.hasExtraCredits
+        if showSonnet || showDesign || showExtraCredits {
             HStack(spacing: 8) {
                 if showSonnet {
                     CompactExtraChip(
@@ -79,6 +80,16 @@ struct FocusLayoutView: View {
                         pct: usageStore.designPct,
                         resetDate: usageStore.lastUsage?.sevenDayDesign?.resetsAtDate,
                         windowDuration: 7 * 86_400,
+                        theme: themeStore,
+                        settings: settingsStore
+                    )
+                }
+                if showExtraCredits {
+                    CompactExtraChip(
+                        label: String(localized: "metric.extraCredits"),
+                        pct: usageStore.extraCreditsPct,
+                        resetDate: nil,
+                        windowDuration: 0,
                         theme: themeStore,
                         settings: settingsStore
                     )

--- a/TokenEaterApp/Popover/PopoverShared.swift
+++ b/TokenEaterApp/Popover/PopoverShared.swift
@@ -8,7 +8,12 @@ import SwiftUI
 @MainActor
 enum PopoverColors {
     static func gauge(pct: Int, resetDate: Date?, windowDuration: TimeInterval, theme: ThemeStore, settings: SettingsStore) -> Color {
-        if settings.smartColorEnabled {
+        // Smart Color is a time-aware risk model: without a reset window
+        // (e.g. the Extra Credits pool) it has nothing to project against, so
+        // we fall back to the static warning/critical threshold ladder. This
+        // keeps Extra Credits coloured identically across the menu bar,
+        // popover, dashboard and widgets.
+        if settings.smartColorEnabled, let resetDate, windowDuration > 0 {
             return theme.current.smartGaugeColor(
                 utilization: Double(pct),
                 resetDate: resetDate,
@@ -22,7 +27,7 @@ enum PopoverColors {
     }
 
     static func gaugeGradient(pct: Int, resetDate: Date?, windowDuration: TimeInterval, theme: ThemeStore, settings: SettingsStore) -> LinearGradient {
-        if settings.smartColorEnabled {
+        if settings.smartColorEnabled, let resetDate, windowDuration > 0 {
             return theme.current.smartGaugeGradient(
                 utilization: Double(pct),
                 resetDate: resetDate,

--- a/TokenEaterApp/PopoverSectionView.swift
+++ b/TokenEaterApp/PopoverSectionView.swift
@@ -134,6 +134,12 @@ struct PopoverSectionView: View {
                     label: String(localized: "popover.option.showDesign")
                 )
             }
+            if usageStore.hasExtraCredits {
+                generalToggleRow(
+                    isOn: $settingsStore.displayExtraCredits,
+                    label: String(localized: "popover.option.showExtraCredits")
+                )
+            }
         }
     }
 

--- a/TokenEaterApp/StatusBarController.swift
+++ b/TokenEaterApp/StatusBarController.swift
@@ -297,7 +297,9 @@ final class StatusBarController: NSObject {
             menuBarStyle: settingsStore.menuBarStyle,
             pacingShape: settingsStore.pacingShape,
             designPct: usageStore.designPct,
-            hasDesign: usageStore.hasDesign
+            hasDesign: usageStore.hasDesign,
+            extraCreditsPct: usageStore.extraCreditsPct,
+            hasExtraCredits: usageStore.hasExtraCredits
         ))
         statusItem.button?.image = image
     }

--- a/TokenEaterTests/Fixtures/UsageResponse+Fixture.swift
+++ b/TokenEaterTests/Fixtures/UsageResponse+Fixture.swift
@@ -20,12 +20,35 @@ extension UsageResponse {
         sonnetUtil: Double = 30,
         fiveHourResetsAt: String? = nil,
         sevenDayResetsAt: String? = nil,
-        sonnetResetsAt: String? = nil
+        sonnetResetsAt: String? = nil,
+        extraUsage: ExtraUsage? = nil
     ) -> UsageResponse {
         UsageResponse(
             fiveHour: .fixture(utilization: fiveHourUtil, resetsAt: fiveHourResetsAt),
             sevenDay: .fixture(utilization: sevenDayUtil, resetsAt: sevenDayResetsAt),
-            sevenDaySonnet: .fixture(utilization: sonnetUtil, resetsAt: sonnetResetsAt)
+            sevenDaySonnet: .fixture(utilization: sonnetUtil, resetsAt: sonnetResetsAt),
+            extraUsage: extraUsage
+        )
+    }
+}
+
+extension ExtraUsage {
+    /// Test-only convenience builder for the paid Extra Credits pool.
+    static func fixture(
+        isEnabled: Bool = true,
+        monthlyLimit: Double? = 40000,
+        usedCredits: Double? = 27000,
+        utilization: Double? = 67.5,
+        currency: String? = "USD",
+        disabledReason: String? = nil
+    ) -> ExtraUsage {
+        ExtraUsage(
+            isEnabled: isEnabled,
+            monthlyLimit: monthlyLimit,
+            usedCredits: usedCredits,
+            utilization: utilization,
+            currency: currency,
+            disabledReason: disabledReason
         )
     }
 }

--- a/TokenEaterTests/MenuBarRendererTests.swift
+++ b/TokenEaterTests/MenuBarRendererTests.swift
@@ -109,3 +109,137 @@ struct MenuBarPeriodLabelColorTests {
         #expect(MenuBarRenderer.periodLabelColor(hex: "not-a-color") == MenuBarRenderer.defaultPeriodLabelColor)
     }
 }
+
+/// Covers the windowless-metric colouring rule that keeps Extra Credits in
+/// agreement across the menu bar, popover, dashboard and widgets: Smart Color
+/// is time-aware, so a metric with no reset window must use the static
+/// threshold ladder instead of the profile-based absolute-risk colour.
+@Suite("MenuBarRenderer.gaugeColor (windowless fallback)")
+struct MenuBarGaugeColorTests {
+
+    private let theme = ThemeColors.default
+    private let thresholds = UsageThresholds.default // warning 60, critical 85
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @Test("windowless metric uses the threshold ladder even when Smart Color is on")
+    func windowlessUsesThresholds() {
+        // Extra Credits has no reset window (resetDate nil, windowDuration 0).
+        let observed = MenuBarRenderer.gaugeColor(
+            pct: 67, resetDate: nil, windowDuration: 0,
+            monochrome: false, smartEnabled: true,
+            themeColors: theme, thresholds: thresholds,
+            pacingMargin: 10, smartColorProfile: .balanced, now: now
+        )
+        // 67% is past the 60 warning threshold → warning colour.
+        #expect(observed == theme.gaugeNSColor(for: 67, thresholds: thresholds))
+        // Regression guard for the green-vs-orange bug: the old code routed
+        // windowless metrics through Smart Color, which reads a calmer colour
+        // at 67% because the profile bounds (≈0.50/1.00) differ from the user's
+        // 60/85 thresholds. Those two colours must NOT be equal here.
+        let smartWindowless = theme.smartGaugeNSColor(
+            utilization: 67, resetDate: nil, windowDuration: 0,
+            thresholds: thresholds, pacingMargin: 10, now: now, profile: .balanced
+        )
+        #expect(observed != smartWindowless)
+    }
+
+    @Test("windowed metric still uses Smart Color when enabled")
+    func windowedUsesSmart() {
+        let reset = now.addingTimeInterval(180 * 60) // 3h left on a 5h window
+        let observed = MenuBarRenderer.gaugeColor(
+            pct: 80, resetDate: reset, windowDuration: 5 * 3600,
+            monochrome: false, smartEnabled: true,
+            themeColors: theme, thresholds: thresholds,
+            pacingMargin: 10, smartColorProfile: .balanced, now: now
+        )
+        let expectedSmart = theme.smartGaugeNSColor(
+            utilization: 80, resetDate: reset, windowDuration: 5 * 3600,
+            thresholds: thresholds, pacingMargin: 10, now: now, profile: .balanced
+        )
+        #expect(observed == expectedSmart)
+    }
+
+    @Test("smart disabled always uses the threshold ladder")
+    func smartDisabledUsesThresholds() {
+        let reset = now.addingTimeInterval(180 * 60)
+        let observed = MenuBarRenderer.gaugeColor(
+            pct: 80, resetDate: reset, windowDuration: 5 * 3600,
+            monochrome: false, smartEnabled: false,
+            themeColors: theme, thresholds: thresholds,
+            pacingMargin: 10, smartColorProfile: .balanced, now: now
+        )
+        #expect(observed == theme.gaugeNSColor(for: 80, thresholds: thresholds))
+    }
+
+    @Test("monochrome wins over everything")
+    func monochromeWins() {
+        let observed = MenuBarRenderer.gaugeColor(
+            pct: 67, resetDate: nil, windowDuration: 0,
+            monochrome: true, smartEnabled: true,
+            themeColors: theme, thresholds: thresholds,
+            pacingMargin: 10, smartColorProfile: .balanced, now: now
+        )
+        #expect(observed == NSColor.labelColor)
+    }
+}
+
+/// Covers the pin gating: Extra Credits renders in the menu bar only when the
+/// paid pool is enabled, otherwise the item must not silently vanish.
+@Suite("MenuBarRenderer Extra Credits gating")
+struct MenuBarExtraCreditsRenderTests {
+
+    /// Full RenderData with neutral defaults; tests override only what matters.
+    private func data(
+        pinned: Set<MetricID> = [.extraCredits],
+        hasExtraCredits: Bool = true,
+        extraCreditsPct: Int = 67,
+        style: MenuBarStyle = .classic
+    ) -> MenuBarRenderer.RenderData {
+        MenuBarRenderer.RenderData(
+            pinnedMetrics: pinned,
+            displaySonnet: false,
+            fiveHourPct: 0, sevenDayPct: 0, sonnetPct: 0,
+            weeklyPacingDelta: 0, weeklyPacingZone: .onTrack, hasWeeklyPacing: false,
+            sessionPacingDelta: 0, sessionPacingZone: .onTrack, hasSessionPacing: false,
+            sessionPacingDisplayMode: .dotDelta, weeklyPacingDisplayMode: .dotDelta,
+            hasConfig: true, hasError: false,
+            themeColors: .default, thresholds: .default,
+            menuBarMonochrome: false,
+            fiveHourReset: "", fiveHourResetAbsolute: "",
+            fiveHourResetDate: nil, sevenDayResetDate: nil, sonnetResetDate: nil, designResetDate: nil,
+            hasFiveHourBucket: false,
+            resetDisplayFormat: .relative,
+            resetTextColorHex: "", sessionPeriodColorHex: "",
+            smartResetColor: false, smartColorProfile: .balanced,
+            pacingMargin: 10,
+            menuBarStyle: style,
+            pacingShape: .circle,
+            designPct: 0, hasDesign: false,
+            extraCreditsPct: extraCreditsPct, hasExtraCredits: hasExtraCredits
+        )
+    }
+
+    @Test("EC pinned + pool enabled renders a value (non-template image)")
+    func renderedWhenEnabled() {
+        let image = MenuBarRenderer.renderUncached(data(hasExtraCredits: true))
+        // The pinned-metrics path produces a non-template text image; the
+        // logo fallback is a template. So a non-template image proves EC drew.
+        #expect(image.isTemplate == false)
+        #expect(image.size.width > 0)
+    }
+
+    @Test("EC pinned but pool disabled falls back to the logo (template image)")
+    func logoFallbackWhenDisabled() {
+        // Only EC is pinned and it's filtered out → ordered list is empty →
+        // the renderer returns the template logo instead of a 0-width sliver.
+        let image = MenuBarRenderer.renderUncached(data(hasExtraCredits: false))
+        #expect(image.isTemplate == true)
+    }
+
+    @Test("EC renders in badge style too")
+    func renderedInBadgeStyle() {
+        let image = MenuBarRenderer.renderUncached(data(hasExtraCredits: true, style: .badge))
+        #expect(image.isTemplate == false)
+        #expect(image.size.width > 0)
+    }
+}

--- a/TokenEaterTests/MetricIDTests.swift
+++ b/TokenEaterTests/MetricIDTests.swift
@@ -1,0 +1,21 @@
+import Testing
+import Foundation
+
+@Suite("MetricID")
+struct MetricIDTests {
+
+    @Test("extraCredits has a stable raw value for persistence")
+    func extraCreditsRawValue() {
+        // pinnedMetrics persists raw values to UserDefaults, so this string is
+        // a storage contract — changing it would silently drop users' pins.
+        #expect(MetricID.extraCredits.rawValue == "extraCredits")
+        #expect(MetricID(rawValue: "extraCredits") == .extraCredits)
+    }
+
+    @Test("extraCredits is enumerable and labelled")
+    func extraCreditsLabels() {
+        #expect(MetricID.allCases.contains(.extraCredits))
+        #expect(MetricID.extraCredits.shortLabel == "EC")
+        #expect(!MetricID.extraCredits.label.isEmpty)
+    }
+}

--- a/TokenEaterTests/UsageResponseDecodingTests.swift
+++ b/TokenEaterTests/UsageResponseDecodingTests.swift
@@ -67,6 +67,38 @@ struct UsageResponseDecodingTests {
         #expect(usage.extraUsage?.disabledReason == "org_level_disabled")
     }
 
+    /// `percent` prefers the API-provided utilization when present. Drives the
+    /// menu-bar "EC %", the widget ring, and the dashboard tile, so it must
+    /// round the same way everywhere.
+    @Test("ExtraUsage.percent prefers API utilization")
+    func extraPercentPrefersUtilization() {
+        let extra = ExtraUsage(
+            isEnabled: true, monthlyLimit: 50000, usedCredits: 18000,
+            utilization: 36.0, currency: "USD", disabledReason: nil
+        )
+        #expect(extra.percent == 36)
+    }
+
+    /// When the API omits `utilization`, `percent` falls back to used / limit.
+    @Test("ExtraUsage.percent falls back to used / limit")
+    func extraPercentFallsBackToRatio() {
+        let extra = ExtraUsage(
+            isEnabled: true, monthlyLimit: 50000, usedCredits: 18000,
+            utilization: nil, currency: "USD", disabledReason: nil
+        )
+        #expect(extra.percent == 36)
+    }
+
+    /// No limit to divide by → 0, never a divide-by-zero / NaN.
+    @Test("ExtraUsage.percent is 0 with no limit")
+    func extraPercentZeroWithoutLimit() {
+        let extra = ExtraUsage(
+            isEnabled: true, monthlyLimit: nil, usedCredits: 18000,
+            utilization: nil, currency: "USD", disabledReason: nil
+        )
+        #expect(extra.percent == 0)
+    }
+
     /// New unknown codenames (tangelo, iguana_necktie) must not break decoding.
     @Test("unknown top-level keys are ignored")
     func unknownKeysIgnored() throws {

--- a/TokenEaterTests/UsageStoreTests.swift
+++ b/TokenEaterTests/UsageStoreTests.swift
@@ -98,6 +98,42 @@ struct UsageStoreTests {
         #expect(store.sonnetPct == 30)
     }
 
+    // MARK: - refresh — extra credits
+
+    @Test("refresh exposes an enabled extra-credits pool")
+    func refreshExposesEnabledExtraCredits() async {
+        let (store, _, _, _, _) = makeSUT(
+            usage: .fixture(extraUsage: .fixture(isEnabled: true, utilization: 67.5))
+        )
+
+        await store.refresh()
+
+        #expect(store.hasExtraCredits == true)
+        // 67.5 truncates to 67, matching the dashboard / widget / menu bar.
+        #expect(store.extraCreditsPct == 67)
+    }
+
+    @Test("a disabled extra-credits pool is not surfaced")
+    func disabledExtraCreditsNotSurfaced() async {
+        let (store, _, _, _, _) = makeSUT(
+            usage: .fixture(extraUsage: .fixture(isEnabled: false, utilization: nil))
+        )
+
+        await store.refresh()
+
+        #expect(store.hasExtraCredits == false)
+    }
+
+    @Test("no extra-credits pool means hasExtraCredits is false and pct is 0")
+    func noExtraCreditsPool() async {
+        let (store, _, _, _, _) = makeSUT(usage: .fixture(extraUsage: nil))
+
+        await store.refresh()
+
+        #expect(store.hasExtraCredits == false)
+        #expect(store.extraCreditsPct == 0)
+    }
+
     @Test("refresh sets lastUpdate on success")
     func refreshSetsLastUpdate() async {
         let (store, _, _, _, _) = makeSUT()

--- a/TokenEaterWidget/ExtraCreditsWidgetView.swift
+++ b/TokenEaterWidget/ExtraCreditsWidgetView.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+import WidgetKit
+
+// =====================================================================
+// MARK: - Extra Credits (Small + Medium)
+//
+// Dedicated widget for the paid Extra Credits pool, for accounts (e.g.
+// Enterprise) whose primary signal is overage spend rather than the
+// 5h / 7d quotas. The pool has no reset window, so colouring is purely
+// threshold-based (no Smart Color risk model).
+// =====================================================================
+
+struct ExtraCreditsWidgetView: View {
+    let entry: UsageEntry
+
+    @Environment(\.widgetFamily) var family
+    private var theme: ThemeColors { WidgetTheme.theme }
+    private var thresholds: UsageThresholds { WidgetTheme.thresholds }
+
+    var body: some View {
+        Group {
+            if entry.error != nil, entry.usage == nil {
+                ErrorContent(message: entry.error ?? String(localized: "error.nodata"))
+            } else if let extra = entry.usage?.extraUsage, extra.isEnabled {
+                switch family {
+                case .systemMedium: mediumContent(extra)
+                default: smallContent(extra)
+                }
+            } else if entry.usage != nil {
+                // Connected, but the pool isn't provisioned/enabled for this
+                // account. Say so explicitly rather than showing a fake 0%.
+                disabledContent
+            } else {
+                PlaceholderContent()
+            }
+        }
+        .widgetURL(URL(string: "tokeneater://open"))
+        .modifier(WidgetBackgroundModifier())
+    }
+
+    // MARK: - Small : hero ring + spend
+
+    private func smallContent(_ extra: ExtraUsage) -> some View {
+        let pct = extra.percent
+        let color = theme.gaugeColor(for: Double(pct), thresholds: thresholds)
+        let gradient = theme.gaugeGradient(for: Double(pct), thresholds: thresholds)
+
+        return VStack(spacing: 0) {
+            WidgetHeader("widget.extra")
+            Spacer(minLength: 8)
+            ZStack {
+                Circle()
+                    .stroke(.white.opacity(WidgetTokens.trackOpacity), lineWidth: WidgetTokens.ringSmall)
+                Circle()
+                    .trim(from: 0, to: min(Double(pct), 100) / 100)
+                    .stroke(gradient, style: StrokeStyle(lineWidth: WidgetTokens.ringSmall, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                    .shadow(color: color.opacity(0.32), radius: 5)
+                HeroPercent(pct)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 6)
+            Spacer(minLength: 8)
+            Text(amountText(extra))
+                .font(WidgetTokens.microMono)
+                .foregroundStyle(Color(hex: theme.widgetText).opacity(WidgetTokens.secondary))
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
+    }
+
+    // MARK: - Medium : hero number + bar + spend
+
+    private func mediumContent(_ extra: ExtraUsage) -> some View {
+        let pct = extra.percent
+        let color = theme.gaugeColor(for: Double(pct), thresholds: thresholds)
+        let gradient = theme.gaugeGradient(
+            for: Double(pct), thresholds: thresholds, startPoint: .leading, endPoint: .trailing
+        )
+
+        return VStack(alignment: .leading, spacing: 10) {
+            WidgetHeader("widget.extra")
+
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("\(pct)%")
+                    .font(.system(size: 32, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundStyle(color)
+                Image(systemName: "creditcard.fill")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(color.opacity(0.85))
+                    .baselineOffset(2)
+                Spacer(minLength: 0)
+                Text(amountText(extra))
+                    .font(WidgetTokens.bodyMono)
+                    .foregroundStyle(Color(hex: theme.widgetText).opacity(WidgetTokens.secondary))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+            }
+
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(.white.opacity(WidgetTokens.trackOpacity))
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(gradient)
+                        .frame(width: max(0, geo.size.width * min(Double(pct), 100) / 100))
+                }
+            }
+            .frame(height: 6)
+
+            Spacer(minLength: 0)
+
+            Text("dashboard.extra.monthly")
+                .font(WidgetTokens.micro)
+                .foregroundStyle(Color(hex: theme.widgetText).opacity(WidgetTokens.tertiary))
+        }
+    }
+
+    // MARK: - Disabled state
+
+    private var disabledContent: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "creditcard.trianglebadge.exclamationmark")
+                .font(.title3)
+                .foregroundStyle(Color(hex: theme.widgetText).opacity(WidgetTokens.tertiary))
+            Text("widget.extra.disabled")
+                .font(.system(size: 11, weight: .medium, design: .rounded))
+                .foregroundStyle(Color(hex: theme.widgetText).opacity(WidgetTokens.secondary))
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+    }
+
+    // MARK: - Helpers
+
+    /// "$180 / $500" with a limit, otherwise just the spend ("$180").
+    private func amountText(_ extra: ExtraUsage) -> String {
+        let used = CurrencyFormatter.formatMinorUnits(extra.usedCredits ?? 0, currencyCode: extra.currency)
+        guard let limit = extra.monthlyLimit, limit > 0 else { return used }
+        return "\(used) / \(CurrencyFormatter.formatMinorUnits(limit, currencyCode: extra.currency))"
+    }
+}

--- a/TokenEaterWidget/TokenEaterWidget.swift
+++ b/TokenEaterWidget/TokenEaterWidget.swift
@@ -55,6 +55,21 @@ struct PacingGraphWidget: Widget {
     }
 }
 
+/// Small + medium widget : the paid Extra Credits pool on its own, for
+/// accounts whose primary signal is overage spend (e.g. Enterprise).
+struct ExtraCreditsWidget: Widget {
+    let kind: String = "ExtraCreditsWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: StaticProvider()) { entry in
+            ExtraCreditsWidgetView(entry: entry)
+        }
+        .configurationDisplayName(String(localized: "widget.title.extraCredits"))
+        .description(String(localized: "widget.description.extraCredits"))
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
 /// Large widget : last 7 days tokens-over-time bar chart with delta vs yesterday.
 struct HistorySparklineWidget: Widget {
     let kind: String = "HistorySparklineWidget"
@@ -77,5 +92,6 @@ struct TokenEaterWidgetBundle: WidgetBundle {
         SessionRingWidget()
         PacingGraphWidget()
         HistorySparklineWidget()
+        ExtraCreditsWidget()
     }
 }

--- a/TokenEaterWidget/UsageWidgetView.swift
+++ b/TokenEaterWidget/UsageWidgetView.swift
@@ -94,6 +94,16 @@ struct UsageWidgetView: View {
                 if let pacing = PacingCalculator.calculate(from: usage, activeDays: WidgetTheme.pacingSchedule.effectiveActiveDays, activeHours: WidgetTheme.pacingSchedule.effectiveHours) {
                     CircularPacingView(pacing: pacing)
                 }
+                if let extra = usage.extraUsage, extra.isEnabled {
+                    CircularUsageView(
+                        label: String(localized: "widget.extra"),
+                        resetInfo: extraCreditsAmount(extra),
+                        utilization: Double(extra.percent),
+                        resetDate: nil,
+                        windowDuration: 0,
+                        smartEnabled: false
+                    )
+                }
             }
 
             Spacer(minLength: 6)
@@ -165,6 +175,23 @@ struct UsageWidgetView: View {
                     utilization: design.utilization,
                     resetDate: design.resetsAtDate,
                     windowDuration: 7 * 86_400
+                )
+            }
+            if let extra = usage.extraUsage, extra.isEnabled {
+                // No reset window: resetDate nil + windowDuration 0 makes the
+                // bar fall back to the static threshold colour. `displayText`
+                // shows spend rather than the raw "%", which reads better for a
+                // monetary pool.
+                LargeUsageBarView(
+                    icon: "creditcard.fill",
+                    label: String(localized: "widget.extra"),
+                    resetInfo: "",
+                    utilization: Double(extra.percent),
+                    displayText: extraCreditsAmount(extra),
+                    windowDuration: 0,
+                    // No reset window → Smart Color can't project; use the
+                    // static threshold ladder so EC matches the app's colour.
+                    smartEnabled: false
                 )
             }
 
@@ -256,6 +283,14 @@ struct UsageWidgetView: View {
     private func formatResetDate(_ date: Date?) -> String {
         guard let date = date else { return "" }
         return Self.resetDateFormatter.string(from: date)
+    }
+
+    /// "$180 / $500" when a monthly limit is set, otherwise just the spend
+    /// ("$180"). Mirrors the dashboard's Extra Credits tile formatting.
+    private func extraCreditsAmount(_ extra: ExtraUsage) -> String {
+        let used = CurrencyFormatter.formatMinorUnits(extra.usedCredits ?? 0, currencyCode: extra.currency)
+        guard let limit = extra.monthlyLimit, limit > 0 else { return used }
+        return "\(used) / \(CurrencyFormatter.formatMinorUnits(limit, currencyCode: extra.currency))"
     }
 }
 


### PR DESCRIPTION
Closes  #209


## What this PR does

Surfaces the paid Extra Credits pool as a first-class metric (MetricID.extraCredits): pinnable in the menu bar, shown as a satellite ring in all three popover layouts, displayed in the main dashboard, and available as a standalone WidgetKit widget.

Extra Credits has no reset window, so Smart Color always falls back to the static warning/critical threshold ladder on every surface — ensuring the colour is consistent across the menu bar, popover, dashboard, and widgets.

## Why

Folks on the Enterprise plan need mostly 'Extra Credits' information which is relevant for them.


## How to test
Test cases have been added for the changes

## Screenshots / recordings
<img width="342" height="339" alt="image" src="https://github.com/user-attachments/assets/d0c4d402-7065-4454-9a70-5cbed5c39892" />
<img width="351" height="169" alt="image" src="https://github.com/user-attachments/assets/9aaf47f6-89dd-45de-8128-63585e66aceb" />
<img width="356" height="359" alt="image" src="https://github.com/user-attachments/assets/9a99dc21-dc29-448c-b928-6b085b8772d6" />
<img width="337" height="429" alt="image" src="https://github.com/user-attachments/assets/84b0ab46-3d98-4e46-a500-edd55a7fbfb1" />
<img width="324" height="503" alt="image" src="https://github.com/user-attachments/assets/0bfb5bc8-5e21-4761-a01f-1fe4ce7ad7f2" />



## Checklist
- [x] Tests pass locally
- [x] If you changed SwiftUI or the widget, you tested it manually in a Release build
- [x] Branch is rebased on the latest `main`
