### PR TITLE
feat: show user-set session names on Agent Watcher tiles

### DIFF
--- a/Shared/Components/SessionTraitView.swift
+++ b/Shared/Components/SessionTraitView.swift
@@ -403,7 +403,7 @@ struct SessionTraitView: View {
                         .foregroundStyle(activeColor.opacity(0.85))
 
                 case .projectAndBranch:
-                    Text(session.projectName)
+                    Text(session.userSessionName ?? session.projectName)
                         .font(.system(size: 11.5 * scale, weight: .semibold, design: fontDesign))
                         .foregroundStyle(.white)
                         .lineLimit(1)

--- a/Shared/Models/SessionModels.swift
+++ b/Shared/Models/SessionModels.swift
@@ -29,10 +29,16 @@ struct ClaudeSession: Identifiable, Sendable {
         return branch
     }
 
-    /// Title for branch-priority mode: shows branch when non-default, otherwise project name
+    /// Title for branch-priority mode: user-set session name first, then
+    /// branch when non-default, otherwise project name
     var displayName: String {
-        visibleBranch ?? projectName
+        userSessionName ?? visibleBranch ?? projectName
     }
+    /// User-set session name from `~/.claude/sessions/<pid>.json`
+    /// (`nameSource == "user"`, i.e. renamed via `/rename`). Nil when the
+    /// session only has an auto-derived name or no registry entry exists.
+    var userSessionName: String?
+
     var model: String?
     var state: SessionState
     var lastUpdate: Date

--- a/Shared/Services/SessionMonitorService.swift
+++ b/Shared/Services/SessionMonitorService.swift
@@ -14,6 +14,7 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
     private var scanInterval: TimeInterval
     private var projectDirFreshness: TimeInterval
     private let claudeProjectsDirOverride: URL?
+    private let claudeSessionsDirOverride: URL?
     private let processProvider: @Sendable () -> [ClaudeProcessInfo]
 
     private var claudeProjectsDir: URL {
@@ -27,15 +28,28 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
         return URL(fileURLWithPath: home).appendingPathComponent(".claude/projects")
     }
 
+    private var claudeSessionsDir: URL {
+        if let override = claudeSessionsDirOverride { return override }
+        let home: String
+        if let pw = getpwuid(getuid()) {
+            home = String(cString: pw.pointee.pw_dir)
+        } else {
+            home = NSHomeDirectory()
+        }
+        return URL(fileURLWithPath: home).appendingPathComponent(".claude/sessions")
+    }
+
     init(
         scanInterval: TimeInterval = 2.0,
         projectDirFreshness: TimeInterval = 30 * 60,
         claudeProjectsDirOverride: URL? = nil,
+        claudeSessionsDirOverride: URL? = nil,
         processProvider: @escaping @Sendable () -> [ClaudeProcessInfo] = { ProcessResolver.findClaudeProcesses() }
     ) {
         self.scanInterval = scanInterval
         self.projectDirFreshness = projectDirFreshness
         self.claudeProjectsDirOverride = claudeProjectsDirOverride
+        self.claudeSessionsDirOverride = claudeSessionsDirOverride
         self.processProvider = processProvider
     }
 
@@ -178,6 +192,7 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
                     id: sessionId,
                     projectPath: result.projectPath,
                     gitBranch: result.gitBranch,
+                    userSessionName: readUserSessionName(pid: process.pid, sessionId: sessionId),
                     model: result.model,
                     state: resolvedState,
                     lastUpdate: mtime,
@@ -226,6 +241,32 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
         }
 
         return nil
+    }
+
+    /// Read the user-set session name from Claude Code's session registry
+    /// (`~/.claude/sessions/<pid>.json`). Called on every scan tick so a
+    /// mid-session `/rename` is picked up at the next watcher refresh.
+    /// Returns nil unless the entry's sessionId matches (guards against a
+    /// stale file left behind by a dead process whose pid was reused) and the
+    /// name was set by the user (`nameSource == "user"`) - auto-derived names
+    /// like `myproject-01` are less informative than the branch/project
+    /// fallback and are ignored.
+    private func readUserSessionName(pid: Int32, sessionId: String) -> String? {
+        struct RegistryEntry: Decodable {
+            let sessionId: String?
+            let name: String?
+            let nameSource: String?
+        }
+
+        let file = claudeSessionsDir.appendingPathComponent("\(pid).json")
+        guard let data = try? Data(contentsOf: file),
+              let entry = try? JSONDecoder().decode(RegistryEntry.self, from: data),
+              entry.sessionId == sessionId,
+              entry.nameSource == "user",
+              let name = entry.name, !name.isEmpty else {
+            return nil
+        }
+        return name
     }
 
     /// Check if a session is currently compacting by looking for active `agent-acompact-*.jsonl` files.

--- a/Shared/Services/SessionMonitorService.swift
+++ b/Shared/Services/SessionMonitorService.swift
@@ -248,9 +248,12 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
     /// mid-session `/rename` is picked up at the next watcher refresh.
     /// Returns nil unless the entry's sessionId matches (guards against a
     /// stale file left behind by a dead process whose pid was reused) and the
-    /// name was set by the user (`nameSource == "user"`) - auto-derived names
-    /// like `myproject-01` are less informative than the branch/project
-    /// fallback and are ignored.
+    /// name was set by the user - auto-derived names like `myproject-01` are
+    /// less informative than the branch/project fallback and are ignored.
+    /// "User-set" means nameSource is "user" OR absent: Claude Code 2.1.202
+    /// writes `nameSource: "derived"` for auto names but drops the field
+    /// entirely after a /rename, so only an explicit derived/auto marker
+    /// disqualifies the name.
     private func readUserSessionName(pid: Int32, sessionId: String) -> String? {
         struct RegistryEntry: Decodable {
             let sessionId: String?
@@ -262,7 +265,7 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
         guard let data = try? Data(contentsOf: file),
               let entry = try? JSONDecoder().decode(RegistryEntry.self, from: data),
               entry.sessionId == sessionId,
-              entry.nameSource == "user",
+              entry.nameSource == nil || entry.nameSource == "user",
               let name = entry.name, !name.isEmpty else {
             return nil
         }

--- a/TokenEaterTests/SessionMonitorNameTests.swift
+++ b/TokenEaterTests/SessionMonitorNameTests.swift
@@ -54,10 +54,11 @@ struct SessionMonitorNameTests {
         pid: Int32 = SessionMonitorNameTests.pid,
         sessionId: String = SessionMonitorNameTests.sessionId,
         name: String,
-        nameSource: String
+        nameSource: String?
     ) throws {
+        let sourceField = nameSource.map { ",\"nameSource\":\"\($0)\"" } ?? ""
         let entry = """
-        {"pid":\(pid),"sessionId":"\(sessionId)","cwd":"\(env.projectPath)","name":"\(name)","nameSource":"\(nameSource)"}
+        {"pid":\(pid),"sessionId":"\(sessionId)","cwd":"\(env.projectPath)","name":"\(name)"\(sourceField)}
         """
         try entry.write(
             to: env.sessionsDir.appendingPathComponent("\(pid).json"),
@@ -123,6 +124,21 @@ struct SessionMonitorNameTests {
 
         #expect(sessions.count == 1)
         #expect(sessions.first?.userSessionName == "payment refactor")
+    }
+
+    @Test("a rename that omits nameSource is treated as user-set")
+    func missingNameSourceTreatedAsUserSet() throws {
+        // Observed on-disk behavior of Claude Code 2.1.202: after a live
+        // /rename the registry entry keeps `name` but drops the `nameSource`
+        // field entirely - it does NOT write `nameSource: "user"`.
+        let env = try makeEnv()
+        defer { env.cleanup() }
+        try writeRegistry(env, name: "tokeneater-monitor-name", nameSource: nil)
+
+        let sessions = scanOnce(makeService(env))
+
+        #expect(sessions.count == 1)
+        #expect(sessions.first?.userSessionName == "tokeneater-monitor-name")
     }
 
     @Test("derived (auto-generated) names are ignored")

--- a/TokenEaterTests/SessionMonitorNameTests.swift
+++ b/TokenEaterTests/SessionMonitorNameTests.swift
@@ -1,0 +1,193 @@
+import Testing
+import Foundation
+import Combine
+
+@Suite("Session name resolution from the Claude Code session registry")
+struct SessionMonitorNameTests {
+
+    // MARK: - Fixtures
+
+    private static let sessionId = "aab8ad29-0efe-4450-a838-8478e89bfec2"
+    private static let pid: Int32 = 4242
+
+    /// One valid JSONL user event - enough for JSONLParser to yield meta + state.
+    private func jsonlLine(sessionId: String, cwd: String) -> String {
+        """
+        {"type":"user","sessionId":"\(sessionId)","cwd":"\(cwd)","gitBranch":"main","timestamp":"2026-07-07T12:00:00.000Z","message":{"role":"user","content":"hi"}}
+        """
+    }
+
+    private struct Env {
+        let projectsDir: URL
+        let sessionsDir: URL
+        let projectPath: String
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: projectsDir)
+            try? FileManager.default.removeItem(at: sessionsDir)
+        }
+    }
+
+    /// Build a projects tree with a single parseable session JSONL plus an
+    /// empty sessions registry dir, both under unique temp roots.
+    private func makeEnv() throws -> Env {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("te-name-\(UUID().uuidString)")
+        let projectsDir = root.appendingPathComponent("projects")
+        let sessionsDir = root.appendingPathComponent("sessions")
+        let projectPath = root.appendingPathComponent("checkout").path
+
+        let projectDir = projectsDir.appendingPathComponent("-fake-project")
+        try fm.createDirectory(at: projectDir, withIntermediateDirectories: true)
+        try fm.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+
+        let jsonl = projectDir.appendingPathComponent("\(Self.sessionId).jsonl")
+        try jsonlLine(sessionId: Self.sessionId, cwd: projectPath)
+            .write(to: jsonl, atomically: true, encoding: .utf8)
+
+        return Env(projectsDir: projectsDir, sessionsDir: sessionsDir, projectPath: projectPath)
+    }
+
+    private func writeRegistry(
+        _ env: Env,
+        pid: Int32 = SessionMonitorNameTests.pid,
+        sessionId: String = SessionMonitorNameTests.sessionId,
+        name: String,
+        nameSource: String
+    ) throws {
+        let entry = """
+        {"pid":\(pid),"sessionId":"\(sessionId)","cwd":"\(env.projectPath)","name":"\(name)","nameSource":"\(nameSource)"}
+        """
+        try entry.write(
+            to: env.sessionsDir.appendingPathComponent("\(pid).json"),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    private func makeService(_ env: Env) -> SessionMonitorService {
+        let process = ClaudeProcessInfo(
+            pid: Self.pid,
+            parentPid: 1,
+            cwd: env.projectPath,
+            sourceKind: .terminal
+        )
+        return SessionMonitorService(
+            scanInterval: 999,
+            projectDirFreshness: 24 * 60 * 60,
+            claudeProjectsDirOverride: env.projectsDir,
+            claudeSessionsDirOverride: env.sessionsDir,
+            processProvider: { [process] }
+        )
+    }
+
+    /// Run one synchronous scan and capture the emitted sessions.
+    private func scanOnce(_ service: SessionMonitorService) -> [ClaudeSession] {
+        var captured: [ClaudeSession] = []
+        let cancellable = service.sessionsPublisher.sink { captured = $0 }
+        service.scan()
+        cancellable.cancel()
+        return captured
+    }
+
+    // MARK: - Model
+
+    @Test("displayName prefers the user-set session name over branch and project")
+    func displayNamePrefersUserName() {
+        var session = ClaudeSession(
+            id: "abc",
+            projectPath: "/Users/dev/my-project",
+            gitBranch: "feature/thing",
+            model: nil,
+            state: .idle,
+            lastUpdate: Date(),
+            startedAt: Date(),
+            processPid: 1
+        )
+        #expect(session.displayName == "feature/thing")
+
+        session.userSessionName = "payment refactor"
+        #expect(session.displayName == "payment refactor")
+    }
+
+    // MARK: - Registry reads during scan
+
+    @Test("scan picks up a user-set name from the session registry")
+    func scanPicksUpUserName() throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+        try writeRegistry(env, name: "payment refactor", nameSource: "user")
+
+        let sessions = scanOnce(makeService(env))
+
+        #expect(sessions.count == 1)
+        #expect(sessions.first?.userSessionName == "payment refactor")
+    }
+
+    @Test("derived (auto-generated) names are ignored")
+    func derivedNamesIgnored() throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+        try writeRegistry(env, name: "tokeneater-01", nameSource: "derived")
+
+        let sessions = scanOnce(makeService(env))
+
+        #expect(sessions.count == 1)
+        #expect(sessions.first?.userSessionName == nil)
+    }
+
+    @Test("a stale registry file whose sessionId does not match is ignored")
+    func staleRegistryFileIgnored() throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+        // Same pid on disk, but the file belongs to an older session (pid reuse).
+        try writeRegistry(
+            env,
+            sessionId: "00000000-dead-beef-0000-000000000000",
+            name: "old session",
+            nameSource: "user"
+        )
+
+        let sessions = scanOnce(makeService(env))
+
+        #expect(sessions.count == 1)
+        #expect(sessions.first?.userSessionName == nil)
+    }
+
+    @Test("a missing registry file leaves the name nil")
+    func missingRegistryFile() throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+
+        let sessions = scanOnce(makeService(env))
+
+        #expect(sessions.count == 1)
+        #expect(sessions.first?.userSessionName == nil)
+    }
+
+    @Test("a mid-session rename is picked up on the next scan")
+    func renamePickedUpOnNextScan() throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+        let service = makeService(env)
+
+        try writeRegistry(env, name: "first name", nameSource: "user")
+        #expect(scanOnce(service).first?.userSessionName == "first name")
+
+        try writeRegistry(env, name: "second name", nameSource: "user")
+        #expect(scanOnce(service).first?.userSessionName == "second name")
+    }
+
+    @Test("an empty name is treated as unset")
+    func emptyNameIgnored() throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+        try writeRegistry(env, name: "", nameSource: "user")
+
+        let sessions = scanOnce(makeService(env))
+
+        #expect(sessions.count == 1)
+        #expect(sessions.first?.userSessionName == nil)
+    }
+}


### PR DESCRIPTION
## Summary

The Agent Watchers overlay labels sessions with branch/project only and never picks up a session name the user set via `/rename`. This PR reads Claude Code's session registry (`~/.claude/sessions/<pid>.json`) on every watcher scan tick and surfaces the user-set name on the tile.

- `ClaudeSession` gains `userSessionName`; `displayName` becomes `userSessionName ?? visibleBranch ?? projectName`, so both watcher display modes show the name (in project+branch mode it replaces the project title, branch stays on the subtitle row).
- `SessionMonitorService.readUserSessionName(pid:sessionId:)` reads the registry entry for the matched process's pid. The name is accepted only when the entry's `sessionId` matches the JSONL-derived id (guards against stale files from PID reuse) and the name is not explicitly auto-derived.
- Because the registry is re-read on every 2-second scan, a mid-session `/rename` shows up at the next watcher refresh with no extra file watching.

**On-disk quirk found during live testing** (Claude Code 2.1.202): auto-named sessions carry `nameSource: "derived"`, but after a `/rename` the field is *dropped entirely* rather than set to `"user"`. The guard therefore treats an absent `nameSource` as user-set and only rejects explicit derived markers.

Older Claude Code versions without `~/.claude/sessions/` fall back to the existing branch/project label via the `??` chain.

## Testing

- New `SessionMonitorNameTests` suite (8 tests) covering: name pickup, derived-name filtering, absent-`nameSource` rename shape, stale-registry (sessionId mismatch) guard, missing file, empty name, mid-session rename across scans, and `displayName` precedence.
- Full suite passes: 501 tests in 54 suites.
- Verified live: installed a Release build, renamed a running session with `/rename`, and the overlay tile updated within one scan tick.