### PR TITLE
docs: add brew trust step for Homebrew 6 tap-trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,11 @@ Open the DMG, drag TokenEater to Applications, and launch it. The DMG is signed 
 
 ```bash
 brew tap AThevon/tokeneater
+brew trust AThevon/tokeneater
 brew install --cask tokeneater
 ```
+
+> `brew trust` is required on Homebrew 6.0+, which no longer loads a third-party tap until you trust it.
 
 ### First Setup
 


### PR DESCRIPTION
## Summary

Homebrew 6.0 introduced a tap-trust model that is on by default for non-official taps: a third-party tap (including cask taps) is not loaded until the user trusts it, so `brew install --cask tokeneater` fails right after `brew tap` with a "tap trust is required" error. Reported by a user, and observed live as tap-trust warnings during the v5.7.0 release CI.

Adds the `brew trust AThevon/tokeneater` step between the tap and the install in the README install instructions, plus a short note that it applies to Homebrew 6.0+.

Ref: https://docs.brew.sh/Tap-Trust

The homebrew-tokeneater tap README gets the same update separately.