### PR TITLE
fix: allow separate macOS users to each run their own instance

### DIFF
--- a/TokenEaterApp/App/TokenEaterApp.swift
+++ b/TokenEaterApp/App/TokenEaterApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 import Combine
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
@@ -98,6 +99,18 @@ struct TokenEaterApp: App {
     private let vendorStatusStore: VendorStatusStore
 
     init() {
+        // NSRunningApplication only enumerates the current login session, so this
+        // refuses a second launch by the same user without blocking a separate
+        // macOS user's own instance (e.g. under Fast User Switching).
+        if let bundleID = Bundle.main.bundleIdentifier {
+            let currentPID = ProcessInfo.processInfo.processIdentifier
+            if let existing = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
+                .first(where: { $0.processIdentifier != currentPID }) {
+                existing.activate()
+                exit(0)
+            }
+        }
+
         // Migrate v4.x sandbox-container UserDefaults into the real path BEFORE
         // any store is constructed - store inits read UserDefaults.standard, so
         // missing this step would make every upgrading user land on onboarding.

--- a/TokenEaterApp/Info.plist
+++ b/TokenEaterApp/Info.plist
@@ -33,8 +33,6 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
-	<key>LSMultipleInstancesProhibited</key>
-	<true/>
 	<key>LSUIElement</key>
 	<true/>
 </dict>

--- a/project.yml
+++ b/project.yml
@@ -38,7 +38,6 @@ targets:
         LSApplicationCategoryType: public.app-category.utilities
         CFBundleDisplayName: TokenEater
         LSUIElement: true
-        LSMultipleInstancesProhibited: true
         CFBundleURLTypes:
           - CFBundleURLName: com.tokeneater.app
             CFBundleURLSchemes:


### PR DESCRIPTION
## Summary
- `LSMultipleInstancesProhibited` in `project.yml`/`Info.plist` blocks launching the app under a second logged-in macOS user (e.g. via Fast User Switching), not just a duplicate launch by the same user. macOS shows "You can't open the application ... because someone else is using it" even when the other session belongs to an entirely different account.
- Replaced the plist-level prohibition with an app-level guard in `TokenEaterApp.init()` using `NSRunningApplication.runningApplications(withBundleIdentifier:)`, which only enumerates the *current login session*. This still redirects (activates the existing instance and exits) a duplicate launch by the same user, but no longer blocks a separate user's independent instance.

## Test plan
- [x] Clean build against `main` (ad-hoc signed, Debug config) succeeds
- [x] Log in as two separate macOS users (e.g. via Fast User Switching), launch the app in each session, confirm both run and update independently (no "someone else is using it" dialog)
- [x] Launch the app twice as the *same* user, confirm the second launch activates the existing instance instead of spawning a duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)