### PR TITLE
fix: prevent keychain-read deadlock on macOS 26 (#217)

### DIFF
--- a/Shared/Services/SecurityCLIReader.swift
+++ b/Shared/Services/SecurityCLIReader.swift
@@ -38,7 +38,19 @@ final class SecurityCLIReader: SecurityCLIReaderProtocol, @unchecked Sendable {
             logger.info("security launch failed: \(error.localizedDescription, privacy: .public)")
             return nil
         }
-        task.waitUntilExit()
+        // Guard against Process hanging: on macOS 26 the App Sandbox blocks
+        // launching /usr/bin/security and waitUntilExit() never returns,
+        // deadlocking the caller (see #217). Time out and fall through.
+        let done = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            task.waitUntilExit()
+            done.signal()
+        }
+        if done.wait(timeout: .now() + 3) == .timedOut {
+            task.terminate()
+            logger.info("security read timed out after 3s; falling through to next source")
+            return nil
+        }
         guard task.terminationStatus == 0 else {
             // Common exit codes: 44 (item not found), 45 (ACL denied).
             return nil

--- a/Shared/Services/TokenProvider.swift
+++ b/Shared/Services/TokenProvider.swift
@@ -46,14 +46,14 @@ final class TokenProvider: TokenProviderProtocol, @unchecked Sendable {
     /// Returns the current token, using the in-memory cache if available.
     /// The Keychain is only read when the cache is empty (app start, or after `invalidateToken()`).
     ///
-    /// Source priority (v5.0+):
-    /// 1. `/usr/bin/security` shell-out (primary - works for all modern Claude Code macOS users,
-    ///    no popups across app updates because `security` has a stable Apple signing identity)
-    /// 2. `.credentials.json` (legacy Claude Code fallback - still present on Linux/Windows and
+    /// Source priority:
+    /// 1. Direct `SecItemCopyMatching` (primary - sandbox-safe, works on macOS 26 where
+    ///    Process-spawning `/usr/bin/security` is blocked by the App Sandbox)
+    /// 2. `/usr/bin/security` shell-out (fallback - for setups where the Keychain ACL only
+    ///    whitelists `/usr/bin/security` and the app is desandboxed)
+    /// 3. `.credentials.json` (legacy Claude Code fallback - still present on Linux/Windows and
     ///    on very old macOS Claude Code installs)
-    /// 3. Claude Desktop `config.json` decryption (for users without Claude Code CLI at all)
-    /// 4. Direct `SecItemCopyMatching` (last resort - the Claude Code Keychain ACL doesn't
-    ///    whitelist us directly, but kept for defence-in-depth)
+    /// 4. Claude Desktop `config.json` decryption (for users without Claude Code CLI at all)
     func currentToken() -> String? {
         if let token = cachedToken { return token }
         let token = readFromSources()
@@ -64,6 +64,15 @@ final class TokenProvider: TokenProviderProtocol, @unchecked Sendable {
     /// Reads the token from all sources in priority order, bypassing the
     /// in-memory cache. Returns the freshest token currently on the system.
     private func readFromSources() -> String? {
+        // Native SecItemCopyMatching first: it works inside the App Sandbox on
+        // macOS 26, where Process.run("/usr/bin/security") is blocked and hangs
+        // (see #217). Silent read succeeds once the user has granted access to
+        // the "Claude Code-credentials" item.
+        if let token = keychainReader(true) {
+            logger.info("Token read from Keychain (silent, native)")
+            return token
+        }
+
         if let token = securityCLIReader.readToken() {
             logger.info("Token read via /usr/bin/security")
             return token
@@ -74,11 +83,6 @@ final class TokenProvider: TokenProviderProtocol, @unchecked Sendable {
         }
 
         if let token = tokenFromConfigJSON() {
-            return token
-        }
-
-        if let token = keychainReader(true) {
-            logger.info("Token read from Keychain (silent)")
             return token
         }
 


### PR DESCRIPTION
## What this PR does

Fixes the macOS 26 hang where TokenEater shows no menu-bar icon / blank UI and never reads the Claude Code token. Adds a 3s watchdog around the `/usr/bin/security` `Process`, and tries the sandbox-safe native `SecItemCopyMatching` path first.

## Why

`SecurityCLIReader.readToken()` launches `/usr/bin/security … -w` and calls `waitUntilExit()` synchronously (its own comment notes the app must be desandboxed for this to work). Under the macOS 26 App Sandbox the launch is blocked and `waitUntilExit()` never returns, so token resolution — run on the main thread during onboarding — deadlocks the UI thread and the status item is never created. The resolver never falls through to the working native reader.

Closes #217

## How to test

1. On macOS 26, run a build with this change.
2. Ensure Claude Code has credentials in the Keychain item `Claude Code-credentials` (default on modern Claude Code).
3. Launch TokenEater — the menu-bar icon should appear immediately and usage should populate (previously the icon never appeared / stayed blank).
4. If prompted for Keychain access, click "Always Allow".

## Screenshots / recordings

N/A — no UI changes; the fix is in the token-read services.

## Checklist

- [ ] Tests pass locally — no Xcode build env on my side, so `xcodebuild … TokenEaterTests` was not run. Only `swiftc -parse` on the two changed files (exit 0). Relying on CI.
- [ ] If you changed SwiftUI or the widget, you tested it manually in a Release build — N/A, changes are in `Shared/Services/` only; no SwiftUI/widget touched.
- [x] Branch is rebased on the latest `main` — branch was created off `upstream/main`.

Follow-up (not in this PR): treat HTTP 429 from `/api/oauth/usage` as "retry later" rather than an expired token (relates to #218 and anthropics/claude-code#31637).
