### PR TITLE
fix: prevent onboarding keychain-read deadlock on macOS 26 (#217)

### DIFF
--- a/Shared/Services/SecurityCLIReader.swift
+++ b/Shared/Services/SecurityCLIReader.swift
@@ -38,7 +38,21 @@ final class SecurityCLIReader: SecurityCLIReaderProtocol, @unchecked Sendable {
             logger.info("security launch failed: \(error.localizedDescription, privacy: .public)")
             return nil
         }
-        task.waitUntilExit()
+        // Guard against a hung child. On macOS 26 the spawned `security` process
+        // can block indefinitely on Keychain authorization when launched by a
+        // headless (LSUIElement) GUI app, so waitUntilExit() never returns and a
+        // caller on the main thread beachballs (see #217). Wait on a background
+        // thread with a 3s timeout, then fall through to the next source.
+        let done = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            task.waitUntilExit()
+            done.signal()
+        }
+        if done.wait(timeout: .now() + 3) == .timedOut {
+            task.terminate()
+            logger.info("security read timed out after 3s; falling through to next source")
+            return nil
+        }
         guard task.terminationStatus == 0 else {
             // Common exit codes: 44 (item not found), 45 (ACL denied).
             return nil

--- a/Shared/Services/TokenProvider.swift
+++ b/Shared/Services/TokenProvider.swift
@@ -36,24 +36,28 @@ final class TokenProvider: TokenProviderProtocol, @unchecked Sendable {
 
     func hasTokenSource() -> Bool {
         if cachedToken != nil { return true }
+        if keychainReader(true) != nil { return true }
         if securityCLIReader.readToken() != nil { return true }
         if credentialsFileReader.readToken() != nil { return true }
         if configReader.readEncryptedToken() != nil { return true }
-        if keychainReader(true) != nil { return true }
         return false
     }
 
     /// Returns the current token, using the in-memory cache if available.
     /// The Keychain is only read when the cache is empty (app start, or after `invalidateToken()`).
     ///
-    /// Source priority (v5.0+):
-    /// 1. `/usr/bin/security` shell-out (primary - works for all modern Claude Code macOS users,
-    ///    no popups across app updates because `security` has a stable Apple signing identity)
-    /// 2. `.credentials.json` (legacy Claude Code fallback - still present on Linux/Windows and
-    ///    on very old macOS Claude Code installs)
-    /// 3. Claude Desktop `config.json` decryption (for users without Claude Code CLI at all)
-    /// 4. Direct `SecItemCopyMatching` (last resort - the Claude Code Keychain ACL doesn't
-    ///    whitelist us directly, but kept for defence-in-depth)
+    /// Source priority:
+    /// 1. Direct `SecItemCopyMatching` silent read - immune to the macOS 26
+    ///    `/usr/bin/security` shell-out hang (#217), and instant once the user
+    ///    has granted TokenEater access to the "Claude Code-credentials" item.
+    ///    Uses `kSecUseAuthenticationUISkip`, so it returns nil silently (never
+    ///    prompts) when access isn't granted and simply falls through.
+    /// 2. `/usr/bin/security` shell-out (primary for setups where the Keychain
+    ///    item ACL only whitelists `/usr/bin/security`; guarded by a 3s watchdog
+    ///    so a hung child can't block - see SecurityCLIReader)
+    /// 3. `.credentials.json` (legacy Claude Code fallback - still present on
+    ///    Linux/Windows and on very old macOS Claude Code installs)
+    /// 4. Claude Desktop `config.json` decryption (for users without Claude Code CLI at all)
     func currentToken() -> String? {
         if let token = cachedToken { return token }
         let token = readFromSources()
@@ -64,6 +68,16 @@ final class TokenProvider: TokenProviderProtocol, @unchecked Sendable {
     /// Reads the token from all sources in priority order, bypassing the
     /// in-memory cache. Returns the freshest token currently on the system.
     private func readFromSources() -> String? {
+        // Native silent read first: immune to the macOS 26 security shell-out
+        // hang (#217) and, once the user has granted TokenEater access to the
+        // "Claude Code-credentials" item, resolves instantly with no Process
+        // spawn. Returns nil silently when access isn't granted, so it simply
+        // falls through to the shell-out below.
+        if let token = keychainReader(true) {
+            logger.info("Token read from Keychain (silent, native)")
+            return token
+        }
+
         if let token = securityCLIReader.readToken() {
             logger.info("Token read via /usr/bin/security")
             return token
@@ -74,11 +88,6 @@ final class TokenProvider: TokenProviderProtocol, @unchecked Sendable {
         }
 
         if let token = tokenFromConfigJSON() {
-            return token
-        }
-
-        if let token = keychainReader(true) {
-            logger.info("Token read from Keychain (silent)")
             return token
         }
 

--- a/TokenEaterApp/Onboarding/OnboardingViewModel.swift
+++ b/TokenEaterApp/Onboarding/OnboardingViewModel.swift
@@ -106,12 +106,16 @@ final class OnboardingViewModel: ObservableObject {
 
     func checkClaudeCode() {
         claudeCodeStatus = .checking
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            guard let self else { return }
-            // Check if a token source EXISTS (config.json or credentials file)
-            // This doesn't require the decryption key - bootstrap happens in connect()
-            let hasSource = self.tokenProvider.hasTokenSource()
-            self.claudeCodeStatus = hasSource ? .detected : .notFound
+        // Detect a token source OFF the main thread: hasTokenSource() can shell
+        // out to /usr/bin/security, which may block for up to the reader's
+        // watchdog timeout on macOS 26 (see #217). Running it on the main thread
+        // froze onboarding and left the menu-bar item stuck.
+        let provider = tokenProvider
+        DispatchQueue.global(qos: .userInitiated).async {
+            let hasSource = provider.hasTokenSource()
+            DispatchQueue.main.async { [weak self] in
+                self?.claudeCodeStatus = hasSource ? .detected : .notFound
+            }
         }
     }
 
@@ -144,31 +148,32 @@ final class OnboardingViewModel: ObservableObject {
 
     func connect() {
         connectionStatus = .connecting
+        NSApp.activate(ignoringOtherApps: true)
 
-        // Bootstrap encryption key if needed (triggers one-time Keychain modal)
-        if !tokenProvider.isBootstrapped {
-            logger.info("Bootstrap needed - reading Claude Safe Storage from Keychain")
-            do {
-                try tokenProvider.bootstrap()
-                logger.info("Bootstrap succeeded, isBootstrapped=\(self.tokenProvider.isBootstrapped)")
-            } catch {
-                logger.error("Bootstrap failed: \(error)")
+        let provider = tokenProvider
+        Task {
+            // Resolve the token OFF the main thread - currentToken() may shell
+            // out to /usr/bin/security, which can block on macOS 26 (see #217).
+            var token = await Self.tokenOffMain(provider)
+
+            // Silent sources found nothing. This is the macOS 26 case where the
+            // security shell-out hangs and TokenEater isn't yet in the Keychain
+            // item's ACL. An interactive read surfaces the one-time "Always
+            // Allow" prompt that grants access; afterwards the silent read
+            // works. Gated on a missing token, so healthy setups never prompt.
+            if token == nil {
+                logger.info("No token via silent sources - attempting interactive Keychain grant")
+                await Self.interactiveBootstrapOffMain(provider)
+                token = await Self.tokenOffMain(provider)
+            }
+
+            guard let token else {
+                logger.error("No token after interactive bootstrap - hasTokenSource=\(provider.hasTokenSource())")
                 connectionStatus = .failed(String(localized: "onboarding.connection.failed.notoken"))
                 NSApp.activate(ignoringOtherApps: true)
                 return
             }
-        }
 
-        let token = tokenProvider.currentToken()
-        logger.info("currentToken result: \(token != nil ? "got token (\(token!.prefix(10))...)" : "nil")")
-        guard let token else {
-            logger.error("No token after bootstrap - hasTokenSource=\(self.tokenProvider.hasTokenSource()), isBootstrapped=\(self.tokenProvider.isBootstrapped)")
-            connectionStatus = .failed(String(localized: "onboarding.connection.failed.notoken"))
-            NSApp.activate(ignoringOtherApps: true)
-            return
-        }
-
-        Task {
             do {
                 let usage = try await repository.testConnection(token: token, proxyConfig: nil)
                 connectionStatus = .success(usage)
@@ -182,6 +187,36 @@ final class OnboardingViewModel: ObservableObject {
                 connectionStatus = .failed(error.localizedDescription)
             }
             NSApp.activate(ignoringOtherApps: true)
+
+            // A fresh ACL grant makes the silent detection succeed now - re-run
+            // so the Claude Code card flips from "not found" to "detected".
+            if claudeCodeStatus != .detected {
+                checkClaudeCode()
+            }
+        }
+    }
+
+    /// Reads the current token off the main thread. `currentToken()` can spawn
+    /// `/usr/bin/security`, which may block, so it must never run on the main
+    /// thread during onboarding.
+    private static func tokenOffMain(_ provider: TokenProviderProtocol) async -> String? {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: provider.currentToken())
+            }
+        }
+    }
+
+    /// Runs an interactive Keychain bootstrap off the main thread. This is the
+    /// one read allowed to surface a Keychain prompt: granting "Always Allow"
+    /// adds TokenEater to the "Claude Code-credentials" item ACL, after which
+    /// silent reads succeed (the fix for the macOS 26 shell-out hang, #217).
+    private static func interactiveBootstrapOffMain(_ provider: TokenProviderProtocol) async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                try? provider.bootstrap()
+                continuation.resume()
+            }
         }
     }
 

--- a/TokenEaterTests/TokenProviderTests.swift
+++ b/TokenEaterTests/TokenProviderTests.swift
@@ -45,8 +45,10 @@ struct TokenProviderTests {
 
     // MARK: - Tests
 
-    @Test("security CLI is the primary source")
-    func securityCLIFirst() {
+    @Test("native silent Keychain read is the primary source")
+    func keychainSilentIsPrimary() {
+        // Native SecItemCopyMatching is tried first so the macOS 26
+        // /usr/bin/security shell-out hang is bypassed once access is granted.
         let (provider, securityCLI, _, _, decryption) = makeSUT(
             securityCLIToken: "security-token",
             credentialsToken: "creds-token",
@@ -57,17 +59,34 @@ struct TokenProviderTests {
 
         let token = provider.currentToken()
 
+        #expect(token == "keychain-token")
+        #expect(securityCLI.readCallCount == 0)
+        #expect(decryption.decryptCallCount == 0)
+    }
+
+    @Test("falls back to security CLI when the silent Keychain read misses")
+    func securityCLIWhenKeychainMisses() {
+        // Mainstream path: the item ACL only whitelists /usr/bin/security, so the
+        // silent native read returns nil and the shell-out resolves the token.
+        let (provider, securityCLI, _, _, decryption) = makeSUT(
+            securityCLIToken: "security-token",
+            credentialsToken: "creds-token",
+            keychainToken: nil
+        )
+
+        let token = provider.currentToken()
+
         #expect(token == "security-token")
         #expect(securityCLI.readCallCount == 1)
         #expect(decryption.decryptCallCount == 0)
     }
 
-    @Test("falls back to credentials file when security CLI returns nil")
+    @Test("falls back to credentials file when Keychain and security CLI return nil")
     func fallbackToCredentialsFile() {
         let (provider, _, _, _, decryption) = makeSUT(
             securityCLIToken: nil,
             credentialsToken: "creds-token",
-            keychainToken: "keychain-token"
+            keychainToken: nil
         )
 
         let token = provider.currentToken()
@@ -76,8 +95,8 @@ struct TokenProviderTests {
         #expect(decryption.decryptCallCount == 0)
     }
 
-    @Test("falls back to keychain when security CLI and credentials file miss")
-    func fallbackToKeychain() {
+    @Test("reads the token from the Keychain when it is the only source")
+    func readsKeychainToken() {
         let (provider, _, _, _, decryption) = makeSUT(
             securityCLIToken: nil,
             credentialsToken: nil,
@@ -162,14 +181,13 @@ struct TokenProviderTests {
         #expect(provider.hasTokenSource() == false)
     }
 
-    @Test("config.json decryption is tried before direct Keychain")
-    func configJsonBeforeKeychain() {
+    @Test("silent Keychain read is tried before config.json decryption")
+    func keychainSilentBeforeConfigDecryption() {
         let oauthJSON: [String: Any] = [
             "claudeAiOauth": ["accessToken": "config-token"]
         ]
         let jsonData = try! JSONSerialization.data(withJSONObject: oauthJSON)
 
-        var keychainWasCalled = false
         let securityCLI = MockSecurityCLIReader()
         let credentials = MockCredentialsFileReader()
         credentials.storedToken = nil
@@ -181,10 +199,7 @@ struct TokenProviderTests {
         decryption._hasEncryptionKey = true
         decryption.decryptedData = jsonData
 
-        let keychainReader: TokenProvider.KeychainTokenReader = { _ in
-            keychainWasCalled = true
-            return "keychain-token"
-        }
+        let keychainReader: TokenProvider.KeychainTokenReader = { _ in "keychain-token" }
 
         let provider = TokenProvider(
             securityCLIReader: securityCLI,
@@ -196,8 +211,8 @@ struct TokenProviderTests {
 
         let token = provider.currentToken()
 
-        #expect(token == "config-token")
-        #expect(keychainWasCalled == false)
+        #expect(token == "keychain-token")
+        #expect(decryption.decryptCallCount == 0)
     }
 
     @Test("silent re-bootstrap recovers when decryption key is stale")


### PR DESCRIPTION
## What

Fixes the macOS 26 onboarding deadlock (#217): the app opened onboarding, beachballed forever on the "Claude Code" card, and never created the menu-bar item, so it looked installed with no icon.

## Root cause

The token read shelled out to `/usr/bin/security` on the **main thread** during onboarding (`checkClaudeCode` -> `hasTokenSource`). On macOS 26 that child can stall on keychain authorization for a headless (LSUIElement) app and never return, freezing the main run loop.

Note: contrary to the original report, the app host is **not** sandboxed (its entitlements only carry `network.client`; only the widget is sandboxed and it never reads the keychain), so the App Sandbox is not the cause. The cause is the headless spawn stalling on keychain auth.

## Changes

- **Off the main thread**: `OnboardingViewModel.checkClaudeCode()` and `connect()` resolve the token on a background queue and hop back to `@MainActor` for UI, so a slow/hung read can never freeze onboarding or the status item.
- **Watchdog**: `SecurityCLIReader` wraps `waitUntilExit()` in a 3s timeout so a hung `security` child falls through instead of blocking forever.
- **Native-first**: `readFromSources()` and `hasTokenSource()` try the silent `SecItemCopyMatching` read first (immune to the shell-out hang), falling through to `/usr/bin/security` when direct access is not granted. The silent read never prompts.
- **Interactive grant**: when all silent sources miss, Connect does a one-time interactive keychain read, surfacing the "Always Allow" prompt that adds TokenEater to the item ACL; subsequent silent reads then succeed.
- **Tests**: `TokenProviderTests` updated for the new source priority (+1 case).

## Credit

Builds on the watchdog idea from #220 by @niemst.

## Testing

- `TokenEaterTests`: 508 passing.
- Release build (Xcode 16.4): clean, no warnings on the changed files.
- Manually tested onboarding on macOS 26.5: responsive, menu-bar icon appears, Connect resolves the token.

Closes #217