### PR TITLE
fix: scope updater's process-wait to the invoking user

### DIFF
--- a/Shared/Stores/UpdateStore.swift
+++ b/Shared/Stores/UpdateStore.swift
@@ -155,7 +155,10 @@ final class UpdateStore: ObservableObject {
         echo "=== TokenEater Installer ==="
         echo "Date: $(date)"
 
-        while pgrep -x "TokenEater" > /dev/null 2>&1; do sleep 0.3; done
+        # Wait only for THIS user's instance to quit. The script runs as root,
+        # so an unscoped pgrep would also match other logged-in users' instances
+        # (Fast User Switching) and stall the update until they quit too.
+        while pgrep -x -U \(getuid()) "TokenEater" > /dev/null 2>&1; do sleep 0.3; done
         echo "App quit."
 
         MOUNT=$(hdiutil attach '\(dmgSharedPath)' -nobrowse | grep '/Volumes/' | head -1 | sed 's/.*\\(\\/Volumes\\/.*\\)/\\1/')


### PR DESCRIPTION
## What

Follow-up to #219. The in-app updater's install script runs as root (via `installer.applescript`, "with administrator privileges") and waits for the app to quit with `while pgrep -x "TokenEater"`. Run as root, that pgrep matches TokenEater in every login session, not just the invoking user's.

## Why

#219 lets separate macOS users each run their own instance (Fast User Switching). With that in place, one user starting an in-app update could stall in the wait loop until every other user's instance also quit, because the root-run pgrep sees them all.

## Fix

Scope the wait to the invoking user's uid: `pgrep -x -U <uid> "TokenEater"`, where `<uid>` is `getuid()` from the app process (which runs as the invoking user). The updater now only waits for the instance it is actually replacing.

## Testing

- `TokenEaterTests`: 508 passing.
- Verified the `pgrep -x -U "$(id -u)" TokenEater` form matches the running instance on macOS 26.5. The full installer path (root + admin prompt) is not unit-testable; this is a scoping change to the wait condition only, the copy/mount/replace logic is unchanged.

Relates to #219