### PR TITLE
fix: isolate ElectronDecryptionService tests from the real Keychain and key file

### DIFF
--- a/Shared/Services/ElectronDecryptionService.swift
+++ b/Shared/Services/ElectronDecryptionService.swift
@@ -49,20 +49,43 @@ final class ElectronDecryptionService: ElectronDecryptionServiceProtocol, @unche
 
     private var derivedKey: Data?
 
+    /// Where the AES key is cached on disk. Defaults to the live shared-container
+    /// path; injectable so tests never read, write, or delete the real file.
+    private let keyFile: URL
+
+    /// Source of the Electron safeStorage password (the "Claude Safe Storage"
+    /// Keychain item). Injectable so tests never read the real Keychain.
+    private let readPassword: @Sendable (_ silent: Bool) throws -> String
+
     // MARK: - Protocol
 
     var hasEncryptionKey: Bool { derivedKey != nil }
 
-    init() {
+    /// - Parameters:
+    ///   - keyFileURL: override the on-disk key-cache location (tests pass a temp
+    ///     path so the suite never touches the real `decryption.key`). When set,
+    ///     the one-time Keychain→file migration is skipped, since migration is a
+    ///     production concern that must never touch the real Keychain in tests.
+    ///   - passwordReader: override the Electron password source (tests inject a
+    ///     stub so `trySilentRebootstrap`/`bootstrapEncryptionKey` never read the
+    ///     real "Claude Safe Storage" Keychain item).
+    init(
+        keyFileURL: URL? = nil,
+        passwordReader: (@Sendable (_ silent: Bool) throws -> String)? = nil
+    ) {
+        self.keyFile = keyFileURL ?? Self.keyFileURL
+        self.readPassword = passwordReader ?? { try Self.readElectronPassword(silent: $0) }
+
         // Try file first (new path)
-        if let key = Self.loadKeyFromFile() {
+        if let key = Self.loadKeyFromFile(at: keyFile) {
             derivedKey = key
             return
         }
 
-        // Migrate from Keychain (old path) - one-time, silent
-        if let key = Self.loadCachedKeyFromKeychain() {
-            Self.saveKeyToFile(key)
+        // Migrate from Keychain (old path) - one-time, silent. Skipped when a
+        // custom key file is injected (tests) so init has zero real side effects.
+        if keyFileURL == nil, let key = Self.loadCachedKeyFromKeychain() {
+            Self.saveKeyToFile(key, at: keyFile)
             Self.deleteCachedKeyFromKeychain()
             derivedKey = key
             return
@@ -93,25 +116,25 @@ final class ElectronDecryptionService: ElectronDecryptionServiceProtocol, @unche
 
     func bootstrapEncryptionKey() throws {
         // Interactive Keychain read - prompts user for permission
-        let password = try Self.readElectronPassword(silent: false)
-        let key = Self.deriveKey(from: password)
-        Self.saveKeyToFile(key)
+        let key = Self.deriveKey(from: try readPassword(false))
+        Self.saveKeyToFile(key, at: keyFile)
         derivedKey = key
     }
 
     func clearCachedKey() {
         derivedKey = nil
-        Self.deleteKeyFile()
+        Self.deleteKeyFile(at: keyFile)
     }
 
     func trySilentRebootstrap() -> Bool {
-        guard let password = try? Self.readElectronPassword(silent: true) else {
+        do {
+            let key = Self.deriveKey(from: try readPassword(true))
+            Self.saveKeyToFile(key, at: keyFile)
+            derivedKey = key
+            return true
+        } catch {
             return false
         }
-        let key = Self.deriveKey(from: password)
-        Self.saveKeyToFile(key)
-        derivedKey = key
-        return true
     }
 
     // MARK: - Key Derivation (internal for testing)

--- a/TokenEaterTests/ElectronDecryptionServiceTests.swift
+++ b/TokenEaterTests/ElectronDecryptionServiceTests.swift
@@ -4,9 +4,32 @@ import Foundation
 @Suite("ElectronDecryptionService")
 struct ElectronDecryptionServiceTests {
 
+    private enum StubError: Error { case noPassword }
+
+    /// A service pointed at a throwaway temp key file (so the real
+    /// `~/Library/Application Support/com.tokeneater.shared/decryption.key` is
+    /// never read, written, or deleted) with an optional stub password source
+    /// (so the real "Claude Safe Storage" Keychain item is never read). Call
+    /// `cleanup()` via `defer` to remove the temp directory.
+    ///
+    /// Before this seam existed, constructing a bare `ElectronDecryptionService()`
+    /// and calling `clearCachedKey()` / `trySilentRebootstrap()` in tests hit the
+    /// live paths: it deleted the real cached key and, on any machine with Claude
+    /// Desktop installed, silently read the Electron safeStorage Keychain item.
+    private func makeSUT(
+        passwordReader: (@Sendable (_ silent: Bool) throws -> String)? = nil
+    ) -> (sut: ElectronDecryptionService, keyFile: URL, cleanup: () -> Void) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let keyFile = dir.appendingPathComponent("decryption.key")
+        let sut = ElectronDecryptionService(keyFileURL: keyFile, passwordReader: passwordReader)
+        return (sut, keyFile, { try? FileManager.default.removeItem(at: dir) })
+    }
+
     @Test("rejects data without v10 prefix")
     func rejectsWithoutV10Prefix() {
-        let sut = ElectronDecryptionService()
+        let (sut, _, cleanup) = makeSUT(); defer { cleanup() }
         let key = ElectronDecryptionService.deriveKey(from: "testpassword")
         sut.setDerivedKeyForTesting(key)
 
@@ -23,7 +46,7 @@ struct ElectronDecryptionServiceTests {
 
     @Test("rejects empty base64")
     func rejectsEmptyBase64() {
-        let sut = ElectronDecryptionService()
+        let (sut, _, cleanup) = makeSUT(); defer { cleanup() }
         let key = ElectronDecryptionService.deriveKey(from: "testpassword")
         sut.setDerivedKeyForTesting(key)
 
@@ -34,7 +57,7 @@ struct ElectronDecryptionServiceTests {
 
     @Test("rejects invalid base64")
     func rejectsInvalidBase64() {
-        let sut = ElectronDecryptionService()
+        let (sut, _, cleanup) = makeSUT(); defer { cleanup() }
         let key = ElectronDecryptionService.deriveKey(from: "testpassword")
         sut.setDerivedKeyForTesting(key)
 
@@ -45,14 +68,14 @@ struct ElectronDecryptionServiceTests {
 
     @Test("hasEncryptionKey is false after clearCachedKey")
     func hasEncryptionKeyFalseAfterClear() {
-        let sut = ElectronDecryptionService()
+        let (sut, _, cleanup) = makeSUT(); defer { cleanup() }
         sut.clearCachedKey()
         #expect(sut.hasEncryptionKey == false)
     }
 
     @Test("clearCachedKey removes the key")
     func clearCachedKeyRemovesKey() {
-        let sut = ElectronDecryptionService()
+        let (sut, _, cleanup) = makeSUT(); defer { cleanup() }
         let key = ElectronDecryptionService.deriveKey(from: "testpassword")
         sut.setDerivedKeyForTesting(key)
         #expect(sut.hasEncryptionKey == true)
@@ -83,7 +106,7 @@ struct ElectronDecryptionServiceTests {
 
     @Test("full encrypt-then-decrypt round trip")
     func encryptThenDecryptRoundTrip() throws {
-        let sut = ElectronDecryptionService()
+        let (sut, _, cleanup) = makeSUT(); defer { cleanup() }
         let password = "test-electron-password"
         let key = ElectronDecryptionService.deriveKey(from: password)
         sut.setDerivedKeyForTesting(key)
@@ -98,7 +121,7 @@ struct ElectronDecryptionServiceTests {
 
     @Test("round trip with empty plaintext")
     func roundTripEmptyPlaintext() throws {
-        let sut = ElectronDecryptionService()
+        let (sut, _, cleanup) = makeSUT(); defer { cleanup() }
         let key = ElectronDecryptionService.deriveKey(from: "pw")
         sut.setDerivedKeyForTesting(key)
 
@@ -110,7 +133,7 @@ struct ElectronDecryptionServiceTests {
 
     @Test("decrypt fails without encryption key set")
     func decryptFailsWithoutKey() {
-        let sut = ElectronDecryptionService()
+        let (sut, _, cleanup) = makeSUT(); defer { cleanup() }
         // v10 prefix + 16 bytes of fake ciphertext
         var data = Data([0x76, 0x31, 0x30])
         data.append(Data(repeating: 0xAA, count: 16))
@@ -162,17 +185,34 @@ struct ElectronDecryptionServiceTests {
         #expect(loaded == nil)
     }
 
-    @Test("trySilentRebootstrap returns a Bool and updates hasEncryptionKey accordingly")
-    func trySilentRebootstrapReturnsConsistentState() {
-        let sut = ElectronDecryptionService()
+    @Test("trySilentRebootstrap succeeds and caches the key when a password is available")
+    func trySilentRebootstrapSucceedsWithPassword() {
+        // Stub the password source so we never read the real Keychain, and point
+        // the cache at a temp file so we never touch the real decryption.key.
+        let (sut, keyFile, cleanup) = makeSUT(passwordReader: { _ in "electron-password" })
+        defer { cleanup() }
         sut.clearCachedKey()
         #expect(sut.hasEncryptionKey == false)
 
         let result = sut.trySilentRebootstrap()
-        // Result depends on whether "Claude Safe Storage" keychain item exists.
-        // On CI: false (no Electron keychain). On dev machine with Claude: true.
-        // Either way, hasEncryptionKey must match the return value.
-        #expect(sut.hasEncryptionKey == result)
+
+        #expect(result == true)
+        #expect(sut.hasEncryptionKey == true)
+        // The derived key was cached to the temp file, never the real one.
+        #expect(ElectronDecryptionService.loadKeyFromFile(at: keyFile) != nil)
+    }
+
+    @Test("trySilentRebootstrap fails and stays keyless when no password is available")
+    func trySilentRebootstrapFailsWithoutPassword() {
+        let (sut, keyFile, cleanup) = makeSUT(passwordReader: { _ in throw StubError.noPassword })
+        defer { cleanup() }
+        sut.clearCachedKey()
+
+        let result = sut.trySilentRebootstrap()
+
+        #expect(result == false)
+        #expect(sut.hasEncryptionKey == false)
+        #expect(ElectronDecryptionService.loadKeyFromFile(at: keyFile) == nil)
     }
 
     @Test("migrateKeyFromKeychainToFile: saves and loads correctly via file round-trip")


### PR DESCRIPTION
## Problem

`ElectronDecryptionServiceTests` constructed a bare `ElectronDecryptionService()` and called `clearCachedKey()` / `trySilentRebootstrap()`. Those hit the **live** paths:

- `clearCachedKey()` deleted the real `~/Library/Application Support/com.tokeneater.shared/decryption.key`
- `trySilentRebootstrap()`, on any machine with **Claude Desktop** installed, silently read the "Claude Safe Storage" Electron safeStorage Keychain item and wrote the real key file
- even plain construction ran the one-time Keychain to file migration against the real store

So running the test suite on a dev machine had real side effects (and the `trySilentRebootstrap` test's result depended on whether Claude Desktop was installed).

Spotted by @ahegedus while auditing a fork (documented in their fork's README, "worth reporting upstream"). Verified in our code: `clearCachedKey()` → `deleteKeyFile()` and `trySilentRebootstrap()` → `readElectronPassword(silent:)` + `saveKeyToFile()`, all against the default live paths.

## Fix

Two injection points on `ElectronDecryptionService.init`, both defaulting to the current behaviour so **production is unchanged**:

- `keyFileURL` — override the on-disk key-cache location. When set, the one-time Keychain→file migration is skipped, so init has zero real side effects.
- `passwordReader` — override the Electron password source (a `@Sendable` closure; the class is already `@unchecked Sendable`).

Tests now point at a temp key file and stub the password source. The machine-dependent "trySilentRebootstrap returns a Bool" test is split into two deterministic cases:
- password available → `true`, key cached to the temp file
- no password → `false`, stays keyless

## Testing

- 510 tests pass; the `ElectronDecryptionService` suite no longer touches the real Keychain or `decryption.key`.