### PR TITLE
refactor: extract shared composable foundations for the menu bar

### DIFF
--- a/Shared/Helpers/LossyDecodableArray.swift
+++ b/Shared/Helpers/LossyDecodableArray.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Wraps a `Decodable` so a failed decode yields `nil` instead of throwing.
+///
+/// Used to decode an array lossily: decode `[Lossy<T>]` then `compactMap`, so a
+/// single malformed element (e.g. one written by a newer app version with an
+/// unknown enum case) is dropped while every valid sibling survives, instead of
+/// the whole blob failing to decode. Shared by the composable popover and menu
+/// bar composition models.
+struct Lossy<Wrapped: Decodable>: Decodable {
+    let value: Wrapped?
+
+    init(from decoder: Decoder) throws {
+        value = try? Wrapped(from: decoder)
+    }
+}
+
+extension KeyedDecodingContainer {
+    /// Decodes an array at `key`, silently dropping elements that fail to
+    /// decode. Missing key -> empty array. Never throws.
+    func decodeLossyArray<Element: Decodable>(
+        _ type: Element.Type,
+        forKey key: Key
+    ) -> [Element] {
+        let wrapped = (try? decodeIfPresent([Lossy<Element>].self, forKey: key)) ?? []
+        return wrapped.compactMap(\.value)
+    }
+}

--- a/Shared/Models/PopoverCompositionModels.swift
+++ b/Shared/Models/PopoverCompositionModels.swift
@@ -233,17 +233,9 @@ struct PopoverComposition: Codable, Equatable {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         // Lossy element list: an element a newer version wrote with an unknown
         // kind/style is silently dropped, everything else survives.
-        let failables = (try? c.decodeIfPresent([FailableElement].self, forKey: .elements)) ?? []
-        elements = failables.compactMap { $0.value }
+        elements = c.decodeLossyArray(PopoverElement.self, forKey: .elements)
         showPlanBadge = (try? c.decodeIfPresent(Bool.self, forKey: .showPlanBadge)) ?? true
         showRefreshButton = (try? c.decodeIfPresent(Bool.self, forKey: .showRefreshButton)) ?? true
-    }
-
-    private struct FailableElement: Decodable {
-        let value: PopoverElement?
-        init(from decoder: Decoder) throws {
-            value = try? PopoverElement(from: decoder)
-        }
     }
 
     var visibleElements: [PopoverElement] { elements.filter { !$0.isHidden } }
@@ -338,19 +330,11 @@ enum PopoverBuiltinTemplate: String, CaseIterable, Identifiable {
     }
 }
 
-/// A composition the user saved under a name. Persisted as a JSON blob under
-/// the `popoverUserTemplates` UserDefaults key.
-struct PopoverUserTemplate: Codable, Equatable, Identifiable {
-    let id: UUID
-    var name: String
-    var composition: PopoverComposition
-
-    init(id: UUID = UUID(), name: String, composition: PopoverComposition) {
-        self.id = id
-        self.name = name
-        self.composition = composition
-    }
-}
+/// A popover composition the user saved under a name. Persisted as a JSON blob
+/// under the `popoverUserTemplates` UserDefaults key. Backed by the generic
+/// `UserTemplate<C>` so the menu bar editor can reuse the same container; the
+/// field layout is unchanged, so the stored blob stays compatible.
+typealias PopoverUserTemplate = UserTemplate<PopoverComposition>
 
 // MARK: - Labels (editor UI)
 

--- a/Shared/Models/UserTemplate.swift
+++ b/Shared/Models/UserTemplate.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// A user-saved composition, named and recallable. Generic over the
+/// composition type so the same container serves the composable popover
+/// (`UserTemplate<PopoverComposition>`) and, later, the composable menu bar.
+///
+/// The field layout (`id`, `name`, `composition`) is deliberately identical to
+/// the pre-generic `PopoverUserTemplate`, so the persisted
+/// `popoverUserTemplates` JSON blob decodes unchanged.
+struct UserTemplate<Composition: Codable & Equatable>: Codable, Equatable, Identifiable {
+    let id: UUID
+    var name: String
+    var composition: Composition
+
+    init(id: UUID = UUID(), name: String, composition: Composition) {
+        self.id = id
+        self.name = name
+        self.composition = composition
+    }
+}

--- a/TokenEaterApp/Popover/PopoverSectionView.swift
+++ b/TokenEaterApp/Popover/PopoverSectionView.swift
@@ -503,7 +503,7 @@ private struct ElementListEditor: View {
         // still leaks draggingID until the next drag; that limitation is
         // inherited from the pre-5.9 editor, SwiftUI offers no drag-ended
         // callback for onDrag.
-        .onDrop(of: [.text], delegate: ListGapDropDelegate(draggingID: $draggingID))
+        .onDrop(of: [.text], delegate: ReorderGapDropDelegate(draggingID: $draggingID))
     }
 
     private var elementRows: some View {
@@ -533,9 +533,9 @@ private struct ElementListEditor: View {
             }
             .onDrop(
                 of: [.text],
-                delegate: ElementDropDelegate(
+                delegate: ReorderDropDelegate(
                     item: element.id,
-                    elements: elementsBinding,
+                    items: elementsBinding,
                     draggingID: $draggingID
                 )
             )
@@ -845,51 +845,6 @@ private struct ElementRow: View {
         .help(String(localized: "popover.editor.showReset"))
     }
 }
-
-/// Container-level catch-all: ends the drag session when the drop lands in
-/// the spacing gaps between rows, clearing the lifted styling.
-private struct ListGapDropDelegate: DropDelegate {
-    @Binding var draggingID: UUID?
-
-    func performDrop(info: DropInfo) -> Bool {
-        let wasDragging = draggingID != nil
-        draggingID = nil
-        return wasDragging
-    }
-
-    func dropUpdated(info: DropInfo) -> DropProposal? {
-        DropProposal(operation: draggingID != nil ? .move : .cancel)
-    }
-}
-
-/// Drop delegate for reordering elements. Swaps the dragged element into the
-/// hovered slot on every drag tick for instant feedback.
-private struct ElementDropDelegate: DropDelegate {
-    let item: UUID
-    @Binding var elements: [PopoverElement]
-    @Binding var draggingID: UUID?
-
-    func dropEntered(info: DropInfo) {
-        guard let dragging = draggingID, dragging != item else { return }
-        guard let from = elements.firstIndex(where: { $0.id == dragging }),
-              let to = elements.firstIndex(where: { $0.id == item })
-        else { return }
-        if from != to {
-            withAnimation(.spring(response: 0.28, dampingFraction: 0.8)) {
-                elements.move(fromOffsets: IndexSet(integer: from), toOffset: to > from ? to + 1 : to)
-            }
-        }
-    }
-
-    func performDrop(info: DropInfo) -> Bool {
-        // A nil draggingID means this session wasn't started by our onDrag
-        // (external text drag) - decline instead of swallowing the drop.
-        let wasDragging = draggingID != nil
-        draggingID = nil
-        return wasDragging
-    }
-
-    func dropUpdated(info: DropInfo) -> DropProposal? {
-        DropProposal(operation: draggingID != nil ? .move : .cancel)
-    }
-}
+// Reordering drop delegates moved to `ReorderDropDelegate.swift` as generics
+// (`ReorderDropDelegate` / `ReorderGapDropDelegate`) so the menu bar editor can
+// share them.

--- a/TokenEaterApp/Popover/ReorderDropDelegate.swift
+++ b/TokenEaterApp/Popover/ReorderDropDelegate.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// Drag-to-reorder drop delegate for an `Identifiable` list, driving a live
+/// swap on every drag tick (no "release to commit" surprise). Generic so the
+/// composable popover and the composable menu bar editors share one
+/// implementation.
+///
+/// `draggingID` is the id set in the row's `.onDrag`; a nil value means the
+/// active drag wasn't started by our list (e.g. an external text drag), which
+/// both delegates decline instead of swallowing.
+struct ReorderDropDelegate<Item: Identifiable>: DropDelegate where Item.ID: Equatable {
+    let item: Item.ID
+    @Binding var items: [Item]
+    @Binding var draggingID: Item.ID?
+
+    func dropEntered(info: DropInfo) {
+        guard let dragging = draggingID, dragging != item else { return }
+        guard let from = items.firstIndex(where: { $0.id == dragging }),
+              let to = items.firstIndex(where: { $0.id == item })
+        else { return }
+        if from != to {
+            withAnimation(.spring(response: 0.28, dampingFraction: 0.8)) {
+                items.move(fromOffsets: IndexSet(integer: from), toOffset: to > from ? to + 1 : to)
+            }
+        }
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        let wasDragging = draggingID != nil
+        draggingID = nil
+        return wasDragging
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: draggingID != nil ? .move : .cancel)
+    }
+}
+
+/// Container-level catch-all: ends the drag session when the drop lands in the
+/// spacing gaps between rows (outside any row's drop target), clearing the
+/// lifted styling instead of leaving a row stuck mid-drag.
+struct ReorderGapDropDelegate<ID: Equatable>: DropDelegate {
+    @Binding var draggingID: ID?
+
+    func performDrop(info: DropInfo) -> Bool {
+        let wasDragging = draggingID != nil
+        draggingID = nil
+        return wasDragging
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: draggingID != nil ? .move : .cancel)
+    }
+}


### PR DESCRIPTION
Prep PR for the composable menu bar (step A1). Pure refactor, **no behavior change**: the popover renders and persists identically, 546 tests green, built in Release with Xcode 16.4.

Pulls three reusable pieces out of the composable-popover code so the upcoming composable menu bar shares them instead of duplicating:

- **`Lossy<Wrapped>` + `KeyedDecodingContainer.decodeLossyArray`** — the tolerant array decode that drops elements written by a newer version with unknown enum cases instead of failing the whole blob (was a private `FailableElement` inside `PopoverComposition`).
- **`UserTemplate<Composition>`** — generic named-composition container. `PopoverUserTemplate` becomes a typealias; the persisted `popoverUserTemplates` blob is unchanged (same field layout).
- **`ReorderDropDelegate<Item>` / `ReorderGapDropDelegate<ID>`** — the drag-to-reorder drop delegates generalized over `Identifiable` (were popover-private).

Deliberately left for the menu bar PR itself: the editor **view shell** and the cross-surface **metric resolver**. Those are better generalized against a second real consumer than speculatively against the working popover (avoids Release-only SwiftUI risk for zero immediate benefit), and the `RenderData` flat/memoized struct doesn't cleanly route through a resolver in isolation.

No user-facing change; nothing ships until a release is tagged.