### PR TITLE
feat: composable menu bar with templates

### DIFF
--- a/Shared/Helpers/MenuBarConfigMigrator.swift
+++ b/Shared/Helpers/MenuBarConfigMigrator.swift
@@ -9,30 +9,6 @@ import Foundation
 /// blob is absent. The legacy keys stay in UserDefaults so a downgrade restores
 /// the previous menu bar untouched.
 enum MenuBarConfigMigrator {
-    /// Account-presence snapshot from the cached usage, so a stale pin for a
-    /// metric no longer on the account doesn't produce a segment that renders
-    /// nothing (same lesson as the popover migrator).
-    struct AccountPresence {
-        var hasDesign: Bool
-        var hasFable: Bool
-        var hasExtraCredits: Bool
-
-        init(hasDesign: Bool = true, hasFable: Bool = true, hasExtraCredits: Bool = true) {
-            self.hasDesign = hasDesign
-            self.hasFable = hasFable
-            self.hasExtraCredits = hasExtraCredits
-        }
-
-        init(cachedUsage: UsageResponse?) {
-            guard let usage = cachedUsage else { self.init(); return }
-            self.init(
-                hasDesign: usage.sevenDayDesign != nil,
-                hasFable: usage.sevenDayFable != nil,
-                hasExtraCredits: usage.extraUsage?.isEnabled == true
-            )
-        }
-    }
-
     /// The fixed order the pre-5.10 renderer drew pinned metrics in. Preserving
     /// it means the migrated composition looks identical to what the user saw.
     private static let legacyOrder: [MetricID] = [
@@ -46,16 +22,18 @@ enum MenuBarConfigMigrator {
         sessionPacingDisplayMode: PacingDisplayMode,
         weeklyPacingDisplayMode: PacingDisplayMode,
         resetDisplayFormat: ResetDisplayFormat,
-        pacingShape: PacingShape,
-        presence: AccountPresence = AccountPresence()
+        pacingShape: PacingShape
     ) -> MenuBarComposition {
+        // Every pinned metric becomes a segment - including presence-gated ones
+        // (Design / Fable / Extra Credits) that happen to be absent right now.
+        // The renderer already gates presence at draw time (isSegmentAvailable),
+        // exactly like the pre-5.10 menu bar which kept the pin and re-showed it
+        // when the metric returned. Dropping it here instead would permanently
+        // lose the pin the next time the pool re-enables (e.g. Extra Credits'
+        // `isEnabled` is transient), which the old menu bar never did.
         let segments: [MenuBarSegment] = legacyOrder.compactMap { metric in
             guard pinnedMetrics.contains(metric) else { return nil }
             guard let kind = kind(for: metric) else { return nil }
-            // Drop a pinned metric the account no longer has, so migration
-            // never produces a permanently-empty segment.
-            if kind.isPresenceGated && !isAvailable(kind, presence: presence) { return nil }
-
             return MenuBarSegment(
                 kind: kind,
                 style: style(for: kind, metric: metric, menuBarStyle: menuBarStyle,
@@ -98,8 +76,13 @@ enum MenuBarConfigMigrator {
             case .badge: return .pill
             }
         case .pacing:
-            if menuBarStyle == .badge { return .pill }
             let mode = (metric == .sessionPacing) ? sessionMode : weeklyMode
+            // Old badge pacing honored the display mode: dotDelta was a
+            // glyph+delta pill, but dot / delta showed glyph-only / delta-only.
+            // The single `.pill` pacing style is glyph+delta, so only dotDelta
+            // maps to it faithfully; dot / delta keep their plain styles (losing
+            // the capsule, but preserving the content the user chose).
+            if menuBarStyle == .badge && mode == .dotDelta { return .pill }
             switch mode {
             case .dot: return .dot
             case .dotDelta: return .dotDelta
@@ -111,12 +94,4 @@ enum MenuBarConfigMigrator {
         }
     }
 
-    private static func isAvailable(_ kind: MenuBarSegmentKind, presence: AccountPresence) -> Bool {
-        switch kind {
-        case .design: return presence.hasDesign
-        case .fable: return presence.hasFable
-        case .extraCredits: return presence.hasExtraCredits
-        default: return true
-        }
-    }
 }

--- a/Shared/Helpers/MenuBarConfigMigrator.swift
+++ b/Shared/Helpers/MenuBarConfigMigrator.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// One-shot conversion of the legacy menu bar preferences (pre-5.10:
+/// `pinnedMetrics` + the single global `menuBarStyle` + the scattered per-metric
+/// display options) into an equivalent `MenuBarComposition`, so upgrading users
+/// keep the exact menu bar they had.
+///
+/// Pure function: `SettingsStore` calls it once when the new `menuBarComposition`
+/// blob is absent. The legacy keys stay in UserDefaults so a downgrade restores
+/// the previous menu bar untouched.
+enum MenuBarConfigMigrator {
+    /// Account-presence snapshot from the cached usage, so a stale pin for a
+    /// metric no longer on the account doesn't produce a segment that renders
+    /// nothing (same lesson as the popover migrator).
+    struct AccountPresence {
+        var hasDesign: Bool
+        var hasFable: Bool
+        var hasExtraCredits: Bool
+
+        init(hasDesign: Bool = true, hasFable: Bool = true, hasExtraCredits: Bool = true) {
+            self.hasDesign = hasDesign
+            self.hasFable = hasFable
+            self.hasExtraCredits = hasExtraCredits
+        }
+
+        init(cachedUsage: UsageResponse?) {
+            guard let usage = cachedUsage else { self.init(); return }
+            self.init(
+                hasDesign: usage.sevenDayDesign != nil,
+                hasFable: usage.sevenDayFable != nil,
+                hasExtraCredits: usage.extraUsage?.isEnabled == true
+            )
+        }
+    }
+
+    /// The fixed order the pre-5.10 renderer drew pinned metrics in. Preserving
+    /// it means the migrated composition looks identical to what the user saw.
+    private static let legacyOrder: [MetricID] = [
+        .serviceStatus, .sessionReset, .fiveHour, .sessionPacing,
+        .sevenDay, .weeklyPacing, .sonnet, .design, .fable, .extraCredits,
+    ]
+
+    static func migrate(
+        pinnedMetrics: Set<MetricID>,
+        menuBarStyle: MenuBarStyle,
+        sessionPacingDisplayMode: PacingDisplayMode,
+        weeklyPacingDisplayMode: PacingDisplayMode,
+        resetDisplayFormat: ResetDisplayFormat,
+        pacingShape: PacingShape,
+        presence: AccountPresence = AccountPresence()
+    ) -> MenuBarComposition {
+        let segments: [MenuBarSegment] = legacyOrder.compactMap { metric in
+            guard pinnedMetrics.contains(metric) else { return nil }
+            guard let kind = kind(for: metric) else { return nil }
+            // Drop a pinned metric the account no longer has, so migration
+            // never produces a permanently-empty segment.
+            if kind.isPresenceGated && !isAvailable(kind, presence: presence) { return nil }
+
+            return MenuBarSegment(
+                kind: kind,
+                style: style(for: kind, metric: metric, menuBarStyle: menuBarStyle,
+                             sessionMode: sessionPacingDisplayMode, weeklyMode: weeklyPacingDisplayMode),
+                options: MenuBarSegmentOptions(pacingShape: pacingShape, resetFormat: resetDisplayFormat)
+            )
+        }
+        return MenuBarComposition(segments: segments)
+    }
+
+    // MARK: - Mapping
+
+    private static func kind(for metric: MetricID) -> MenuBarSegmentKind? {
+        switch metric {
+        case .fiveHour: return .session
+        case .sevenDay: return .weekly
+        case .sonnet: return .sonnet
+        case .design: return .design
+        case .fable: return .fable
+        case .extraCredits: return .extraCredits
+        case .sessionPacing: return .sessionPacing
+        case .weeklyPacing: return .weeklyPacing
+        case .sessionReset: return .sessionReset
+        case .serviceStatus: return .serviceStatus
+        }
+    }
+
+    private static func style(
+        for kind: MenuBarSegmentKind,
+        metric: MetricID,
+        menuBarStyle: MenuBarStyle,
+        sessionMode: PacingDisplayMode,
+        weeklyMode: PacingDisplayMode
+    ) -> MenuBarSegmentStyle {
+        switch kind.family {
+        case .usage:
+            switch menuBarStyle {
+            case .classic: return .labelValue
+            case .mono: return .mono
+            case .badge: return .pill
+            }
+        case .pacing:
+            if menuBarStyle == .badge { return .pill }
+            let mode = (metric == .sessionPacing) ? sessionMode : weeklyMode
+            switch mode {
+            case .dot: return .dot
+            case .dotDelta: return .dotDelta
+            case .delta: return .delta
+            }
+        case .status:
+            if menuBarStyle == .badge { return .pill }
+            return kind == .serviceStatus ? .glyph : .text
+        }
+    }
+
+    private static func isAvailable(_ kind: MenuBarSegmentKind, presence: AccountPresence) -> Bool {
+        switch kind {
+        case .design: return presence.hasDesign
+        case .fable: return presence.hasFable
+        case .extraCredits: return presence.hasExtraCredits
+        default: return true
+        }
+    }
+}

--- a/Shared/Helpers/MenuBarRenderer.swift
+++ b/Shared/Helpers/MenuBarRenderer.swift
@@ -235,8 +235,12 @@ enum MenuBarRenderer {
         let badge = renderOutageBadgeImage(data)
         let hasMetrics = data.hasConfig && (!data.hasError || data.isAwaitingRefresh)
         guard hasMetrics else { return badge }
-        let base = drawComposition(data).image
-        return horizontallyCompose(left: badge, right: base, gap: 5)
+        let base = drawComposition(data)
+        // An empty / all-filtered composition draws the template logo, which
+        // would composite as static black next to the coloured badge. Show the
+        // badge alone in that case (an empty menu bar is a legitimate choice).
+        guard !base.hitRects.isEmpty else { return badge }
+        return horizontallyCompose(left: badge, right: base.image, gap: 5)
     }
 
     private static func renderOutageBadgeImage(_ data: RenderData) -> NSImage {

--- a/Shared/Helpers/MenuBarRenderer.swift
+++ b/Shared/Helpers/MenuBarRenderer.swift
@@ -2,8 +2,9 @@ import AppKit
 
 enum MenuBarRenderer {
     struct RenderData: Equatable {
-        let pinnedMetrics: Set<MetricID>
-        let displaySonnet: Bool
+        /// The composable menu bar: ordered segments + per-segment styles.
+        /// Drives which segments appear, in what order, and how each is drawn.
+        let composition: MenuBarComposition
         let fiveHourPct: Int
         let sevenDayPct: Int
         let sonnetPct: Int
@@ -13,13 +14,11 @@ enum MenuBarRenderer {
         let sessionPacingDelta: Int
         let sessionPacingZone: PacingZone
         let hasSessionPacing: Bool
-        let sessionPacingDisplayMode: PacingDisplayMode
-        let weeklyPacingDisplayMode: PacingDisplayMode
         let hasConfig: Bool
         let hasError: Bool
         /// Token expired/unreadable but a prior snapshot exists (#218). Keep the
-        /// last pinned metrics visible instead of collapsing to the bare logo,
-        /// so the menu bar doesn't look broken while Claude Code refreshes.
+        /// last segments visible instead of collapsing to the bare logo, so the
+        /// menu bar doesn't look broken while Claude Code refreshes.
         let isAwaitingRefresh: Bool
         let themeColors: ThemeColors
         let thresholds: UsageThresholds
@@ -33,17 +32,14 @@ enum MenuBarRenderer {
         /// True when the API returned a `five_hour` bucket at all. Independent
         /// from whether `resets_at` was populated - Anthropic can return the
         /// bucket with `utilization: 0` and no `resets_at` when you're between
-        /// two 5h windows. Used to keep session pins visible (with a placeholder
-        /// value) instead of making them disappear whenever there's a lull.
+        /// two 5h windows. Used to keep session segments visible (with a
+        /// placeholder value) instead of hiding them whenever there's a lull.
         let hasFiveHourBucket: Bool
-        let resetDisplayFormat: ResetDisplayFormat
         let resetTextColorHex: String
         let sessionPeriodColorHex: String
         let smartResetColor: Bool
         let smartColorProfile: SmartColorProfile
         let pacingMargin: Double
-        let menuBarStyle: MenuBarStyle
-        let pacingShape: PacingShape
         let designPct: Int
         let hasDesign: Bool
         let fablePct: Int
@@ -83,7 +79,27 @@ enum MenuBarRenderer {
         if !data.hasConfig || (data.hasError && !data.isAwaitingRefresh) {
             return renderLogoTemplate()
         }
-        return renderPinnedMetrics(data)
+        return drawComposition(data).image
+    }
+
+    /// Composition render that also returns each segment's hit rectangle in the
+    /// image's coordinate space. The status item ignores the rects; the editor
+    /// preview overlays invisible tap targets from them (click-to-select).
+    /// Mirrors `renderUncached`'s top-level dispatch so the preview matches the
+    /// real item, but never composes the separate outage badge (the preview is
+    /// about the composition itself).
+    static func renderWithHitRects(_ data: RenderData) -> (image: NSImage, hitRects: [SegmentHitRect]) {
+        if !data.hasConfig || (data.hasError && !data.isAwaitingRefresh) {
+            return (renderLogoTemplate(), [])
+        }
+        return drawComposition(data)
+    }
+
+    /// A rendered segment's frame in the metric image (origin bottom-left, as
+    /// AppKit NSImage). Emitted only for the editor preview.
+    struct SegmentHitRect: Equatable {
+        let id: UUID
+        let rect: CGRect
     }
 
     // MARK: - Color helpers
@@ -137,25 +153,6 @@ enum MenuBarRenderer {
             )
         }
         return themeColors.gaugeNSColor(for: Double(pct), thresholds: thresholds)
-    }
-
-    private static func resetDate(for metric: MetricID, data: RenderData) -> Date? {
-        switch metric {
-        case .fiveHour:    return data.fiveHourResetDate
-        case .sevenDay:    return data.sevenDayResetDate
-        case .sonnet:      return data.sonnetResetDate
-        case .design:      return data.designResetDate
-        case .fable:       return data.fableResetDate
-        default:           return nil
-        }
-    }
-
-    private static func windowDuration(for metric: MetricID) -> TimeInterval {
-        switch metric {
-        case .fiveHour: return 5 * 3600
-        case .sevenDay, .sonnet, .design, .fable: return 7 * 86_400
-        default: return 0
-        }
     }
 
     private static func colorForZone(_ zone: PacingZone, data: RenderData) -> NSColor {
@@ -238,12 +235,11 @@ enum MenuBarRenderer {
         let badge = renderOutageBadgeImage(data)
         let hasMetrics = data.hasConfig && (!data.hasError || data.isAwaitingRefresh)
         guard hasMetrics else { return badge }
-        let base = renderPinnedMetrics(data)
+        let base = drawComposition(data).image
         return horizontallyCompose(left: badge, right: base, gap: 5)
     }
 
     private static func renderOutageBadgeImage(_ data: RenderData) -> NSImage {
-        let height: CGFloat = 22
         let tint: NSColor = data.outageHealth == .down ? .systemRed : .systemOrange
 
         let symbolConfig = NSImage.SymbolConfiguration(pointSize: 11, weight: .bold)
@@ -265,12 +261,12 @@ enum MenuBarRenderer {
         let gap: CGFloat = 3
         let textWidth = countdown?.size().width ?? 0
         let width = glyphSize.width + (countdown != nil ? gap + textWidth : 0)
-        let img = NSImage(size: NSSize(width: ceil(width) + 2, height: height), flipped: false) { _ in
-            glyph?.draw(at: NSPoint(x: 1, y: (height - glyphSize.height) / 2),
+        let img = NSImage(size: NSSize(width: ceil(width) + 2, height: imageHeight), flipped: false) { _ in
+            glyph?.draw(at: NSPoint(x: 1, y: (imageHeight - glyphSize.height) / 2),
                         from: .zero, operation: .sourceOver, fraction: 1)
             if let countdown {
                 let ts = countdown.size()
-                countdown.draw(at: NSPoint(x: 1 + glyphSize.width + gap, y: (height - ts.height) / 2))
+                countdown.draw(at: NSPoint(x: 1 + glyphSize.width + gap, y: (imageHeight - ts.height) / 2))
             }
             return true
         }
@@ -279,12 +275,11 @@ enum MenuBarRenderer {
     }
 
     private static func horizontallyCompose(left: NSImage, right: NSImage, gap: CGFloat) -> NSImage {
-        let height: CGFloat = 22
         let width = left.size.width + gap + right.size.width
-        let img = NSImage(size: NSSize(width: ceil(width), height: height), flipped: false) { _ in
-            left.draw(at: NSPoint(x: 0, y: (height - left.size.height) / 2),
+        let img = NSImage(size: NSSize(width: ceil(width), height: imageHeight), flipped: false) { _ in
+            left.draw(at: NSPoint(x: 0, y: (imageHeight - left.size.height) / 2),
                       from: .zero, operation: .sourceOver, fraction: 1)
-            right.draw(at: NSPoint(x: left.size.width + gap, y: (height - right.size.height) / 2),
+            right.draw(at: NSPoint(x: left.size.width + gap, y: (imageHeight - right.size.height) / 2),
                        from: .zero, operation: .sourceOver, fraction: 1)
             return true
         }
@@ -292,455 +287,281 @@ enum MenuBarRenderer {
         return img
     }
 
-    // MARK: - Rendering
+    // MARK: - Composition rendering
 
-    private static func renderPinnedMetrics(_ data: RenderData) -> NSImage {
-        // Minimal uses an entirely different drawing path (pills), so hand
-        // off early instead of trying to fit it into the classic/mono
-        // NSAttributedString pipeline.
-        if data.menuBarStyle == .badge {
-            return renderBadgePills(data)
+    private static let imageHeight: CGFloat = 22
+    private static let segmentGap: CGFloat = 6
+    private static let pillHeight: CGFloat = 17
+    private static let pillPaddingH: CGFloat = 7
+    private static let pillFont = NSFont.systemFont(ofSize: 11, weight: .bold)
+
+    private struct SegmentVisual {
+        let id: UUID
+        let content: Content
+        enum Content {
+            case run(NSAttributedString)
+            case pill(text: String, tint: NSColor)
+        }
+    }
+
+    /// Draws the visible, account-available segments left to right into a single
+    /// image, mixing text runs and tinted pills, and returns per-segment hit
+    /// rects. Falls back to the app logo when nothing is drawable, so the status
+    /// item never collapses to an invisible sliver.
+    private static func drawComposition(_ data: RenderData) -> (image: NSImage, hitRects: [SegmentHitRect]) {
+        let visuals: [SegmentVisual] = data.composition.visibleSegments.compactMap { segment in
+            guard isSegmentAvailable(segment.kind, data: data) else { return nil }
+            return visual(for: segment, data: data)
+        }
+        guard !visuals.isEmpty else {
+            return (renderLogoTemplate(), [])
         }
 
-        let height: CGFloat = 22
-        let str = NSMutableAttributedString()
+        let widths = visuals.map { visualWidth($0) }
+        let total = widths.reduce(0, +) + segmentGap * CGFloat(max(visuals.count - 1, 0))
+        let imgSize = NSSize(width: ceil(total) + 2, height: imageHeight)
 
-        let sepAttrs: [NSAttributedString.Key: Any] = [
-            .font: styleFont(size: 10, weight: .regular, style: data.menuBarStyle),
-            .foregroundColor: NSColor.tertiaryLabelColor,
-        ]
-        let separator: String = {
-            switch data.menuBarStyle {
-            case .classic: return "  "
-            case .mono:    return " "
-            case .badge: return " \u{00B7} "  // middle dot with spaces
-            }
-        }()
-
-        let ordered: [MetricID] = [
-            .serviceStatus, .sessionReset, .fiveHour, .sessionPacing, .sevenDay, .weeklyPacing, .sonnet, .design, .fable, .extraCredits
-        ].filter {
-            guard data.pinnedMetrics.contains($0) else { return false }
-            // Sonnet / Design / Extra Credits visibility in the menu bar is
-            // purely driven by pinnedMetrics. Popover visibility has its own
-            // toggles.
-            if $0 == .design && !data.hasDesign { return false }
-            if $0 == .fable && !data.hasFable { return false }
-            switch $0 {
-            // Session-scoped pins stay visible as long as the API returned a
-            // five_hour bucket. Between sessions Anthropic omits resets_at, so
-            // we render a neutral placeholder rather than silently hiding a
-            // pin the user explicitly asked for.
-            case .sessionReset, .sessionPacing: return data.hasFiveHourBucket
-            case .weeklyPacing: return data.hasWeeklyPacing
-            case .design: return data.hasDesign
-            case .fable: return data.hasFable
-            case .serviceStatus: return true
-            // Extra Credits only renders when the paid pool is provisioned and
-            // enabled. Hidden otherwise so non-overage users never see "EC 0%".
-            case .extraCredits: return data.hasExtraCredits
-            default: return true
-            }
+        var rects: [SegmentHitRect] = []
+        var cursor: CGFloat = 1
+        for (i, v) in visuals.enumerated() {
+            rects.append(SegmentHitRect(id: v.id, rect: CGRect(x: cursor, y: 0, width: widths[i], height: imageHeight)))
+            cursor += widths[i] + segmentGap
         }
 
-        // If every pin got filtered out (no five-hour bucket yet, no weekly
-        // pacing, no design quota), fall back to the logo so the status item
-        // is always visible. Returning the empty-pipeline image produces a
-        // 2pt-wide icon that reads as "the menu bar item disappeared".
-        if ordered.isEmpty {
-            return renderLogoTemplate()
-        }
-        for (i, metric) in ordered.enumerated() {
-            if i > 0 {
-                str.append(NSAttributedString(string: separator, attributes: sepAttrs))
-            }
-            switch metric {
-            case .serviceStatus:
-                appendServiceStatus(to: str, data: data)
-            case .sessionReset:
-                appendSessionReset(to: str, data: data)
-            case .sessionPacing:
-                if data.hasSessionPacing {
-                    appendPacing(
-                        to: str,
-                        delta: data.sessionPacingDelta,
-                        zone: data.sessionPacingZone,
-                        mode: data.sessionPacingDisplayMode,
-                        data: data
-                    )
-                } else {
-                    appendPacingPlaceholder(
-                        to: str,
-                        mode: data.sessionPacingDisplayMode,
-                        data: data
-                    )
-                }
-            case .weeklyPacing:
-                appendPacing(
-                    to: str,
-                    delta: data.weeklyPacingDelta,
-                    zone: data.weeklyPacingZone,
-                    mode: data.weeklyPacingDisplayMode,
-                    data: data
-                )
-            case .fiveHour, .sevenDay, .sonnet, .design, .fable, .extraCredits:
-                let value: Int
-                switch metric {
-                case .fiveHour: value = data.fiveHourPct
-                case .sevenDay: value = data.sevenDayPct
-                case .sonnet: value = data.sonnetPct
-                case .design: value = data.designPct
-                case .fable: value = data.fablePct
-                case .extraCredits: value = data.extraCreditsPct
-                default: value = 0
-                }
-                appendPercentMetric(
-                    to: str,
-                    label: metric.shortLabel,
-                    value: value,
-                    resetDate: resetDate(for: metric, data: data),
-                    windowDuration: windowDuration(for: metric),
-                    data: data
-                )
-            }
-        }
-
-        let size = str.size()
-        let imgSize = NSSize(width: ceil(size.width) + 2, height: height)
         let img = NSImage(size: imgSize, flipped: false) { _ in
-            str.draw(at: NSPoint(x: 1, y: (height - size.height) / 2))
+            var x: CGFloat = 1
+            for (i, v) in visuals.enumerated() {
+                drawVisual(v, at: x, width: widths[i])
+                x += widths[i] + segmentGap
+            }
             return true
         }
         img.isTemplate = false
-        return img
+        return (img, rects)
     }
 
-    private static func appendServiceStatus(to str: NSMutableAttributedString, data: RenderData) {
-        let mono = data.menuBarMonochrome
-        let symbolName: String
-        let color: NSColor
-        switch data.outageHealth {
-        case .healthy:  symbolName = "checkmark.circle.fill";        color = mono ? .labelColor : .systemGreen
-        case .degraded: symbolName = "exclamationmark.triangle.fill"; color = mono ? .labelColor : .systemOrange
-        case .down:     symbolName = "exclamationmark.triangle.fill"; color = mono ? .labelColor : .systemRed
+    /// Presence / data gating, matching the pre-5.10 renderer: metrics the
+    /// account lacks, or session/pacing segments with no data yet, draw nothing
+    /// and the row recompacts (falling back to the logo if all are filtered).
+    private static func isSegmentAvailable(_ kind: MenuBarSegmentKind, data: RenderData) -> Bool {
+        switch kind {
+        case .design: return data.hasDesign
+        case .fable: return data.hasFable
+        case .extraCredits: return data.hasExtraCredits
+        case .sessionReset, .sessionPacing: return data.hasFiveHourBucket
+        case .weeklyPacing: return data.hasWeeklyPacing
+        default: return true
         }
+    }
+
+    private static func visual(for segment: MenuBarSegment, data: RenderData) -> SegmentVisual? {
+        let style = segment.effectiveStyle
+        let content: SegmentVisual.Content?
+        switch segment.kind.family {
+        case .usage:
+            content = usageContent(kind: segment.kind, style: style, data: data)
+        case .pacing:
+            content = pacingContent(kind: segment.kind, style: style, shape: segment.options.pacingShape, data: data)
+        case .status:
+            switch segment.kind {
+            case .sessionReset: content = resetContent(style: style, format: segment.options.resetFormat, data: data)
+            case .serviceStatus: content = statusContent(style: style, data: data)
+            default: content = nil
+            }
+        }
+        guard let content else { return nil }
+        return SegmentVisual(id: segment.id, content: content)
+    }
+
+    // MARK: - Per-family content
+
+    private static func usageContent(kind: MenuBarSegmentKind, style: MenuBarSegmentStyle, data: RenderData) -> SegmentVisual.Content {
+        let value = usageValue(kind, data: data)
+        let label = usageLabel(kind)
+        let color = colorForPct(value, resetDate: usageResetDate(kind, data: data), windowDuration: usageWindow(kind), data: data)
+
+        switch style {
+        case .labelValue:
+            let s = NSMutableAttributedString()
+            s.append(NSAttributedString(string: "\(label) ", attributes: [
+                .font: systemFont(9, .medium), .foregroundColor: periodColor(data),
+            ]))
+            s.append(NSAttributedString(string: "\(value)%", attributes: [
+                .font: systemFont(12, .bold, monoDigits: true), .foregroundColor: color,
+            ]))
+            return .run(s)
+        case .valueOnly:
+            return .run(NSAttributedString(string: "\(value)%", attributes: [
+                .font: systemFont(12, .bold, monoDigits: true), .foregroundColor: color,
+            ]))
+        case .mono:
+            let s = NSMutableAttributedString()
+            s.append(NSAttributedString(string: "\(label):", attributes: [
+                .font: monoFont(11, .regular), .foregroundColor: periodColor(data),
+            ]))
+            s.append(NSAttributedString(string: "\(value)", attributes: [
+                .font: monoFont(11, .bold), .foregroundColor: color,
+            ]))
+            return .run(s)
+        case .pill:
+            return .pill(text: "\(value)%", tint: color)
+        default:
+            return .run(NSAttributedString(string: "\(value)%", attributes: [
+                .font: systemFont(12, .bold, monoDigits: true), .foregroundColor: color,
+            ]))
+        }
+    }
+
+    private static func pacingContent(kind: MenuBarSegmentKind, style: MenuBarSegmentStyle, shape: PacingShape, data: RenderData) -> SegmentVisual.Content {
+        // weeklyPacing only renders when hasWeeklyPacing (isSegmentAvailable),
+        // so treat it as always having data here; session may show a placeholder.
+        let hasData = kind == .sessionPacing ? data.hasSessionPacing : true
+        let zone = kind == .sessionPacing ? data.sessionPacingZone : data.weeklyPacingZone
+        let delta = kind == .sessionPacing ? data.sessionPacingDelta : data.weeklyPacingDelta
+        let tint = hasData ? colorForZone(zone, data: data) : NSColor.tertiaryLabelColor
+        let sign = delta >= 0 ? "+" : ""
+        let glyph = shape.glyph
+
+        switch style {
+        case .dot:
+            return .run(NSAttributedString(string: glyph, attributes: [
+                .font: systemFont(11, .bold), .foregroundColor: tint,
+            ]))
+        case .dotDelta:
+            let s = NSMutableAttributedString()
+            s.append(NSAttributedString(string: glyph, attributes: [
+                .font: systemFont(11, .bold), .foregroundColor: tint,
+            ]))
+            s.append(NSAttributedString(string: hasData ? " \(sign)\(delta)%" : " -", attributes: [
+                .font: systemFont(10, .bold, monoDigits: true), .foregroundColor: tint,
+            ]))
+            return .run(s)
+        case .delta:
+            return .run(NSAttributedString(string: hasData ? "\(sign)\(delta)%" : "-", attributes: [
+                .font: systemFont(10, .bold, monoDigits: true), .foregroundColor: tint,
+            ]))
+        case .pill:
+            return .pill(text: hasData ? "\(glyph) \(sign)\(delta)%" : "\(glyph) -", tint: tint)
+        default:
+            return .run(NSAttributedString(string: hasData ? "\(sign)\(delta)%" : "-", attributes: [
+                .font: systemFont(10, .bold, monoDigits: true), .foregroundColor: tint,
+            ]))
+        }
+    }
+
+    private static func resetContent(style: MenuBarSegmentStyle, format: ResetDisplayFormat, data: RenderData) -> SegmentVisual.Content {
+        let resolved = resetDisplayText(format: format, data: data)
+        // Empty only when `fiveHour.resetsAt` is nil (typically between two 5h
+        // windows). Fall back to `-` so the segment stays visible.
+        let text = resolved.isEmpty ? "-" : resolved
+        let color = resetValueColor(data)
+        switch style {
+        case .pill:
+            return .pill(text: text, tint: color)
+        default:
+            return .run(NSAttributedString(string: text, attributes: [
+                .font: systemFont(12, .bold, monoDigits: true), .foregroundColor: color,
+            ]))
+        }
+    }
+
+    private static func statusContent(style: MenuBarSegmentStyle, data: RenderData) -> SegmentVisual.Content {
+        let mono = data.menuBarMonochrome
+        let color: NSColor = {
+            switch data.outageHealth {
+            case .healthy:  return mono ? .labelColor : .systemGreen
+            case .degraded: return mono ? .labelColor : .systemOrange
+            case .down:     return mono ? .labelColor : .systemRed
+            }
+        }()
+
+        if style == .pill {
+            let text: String
+            switch data.outageHealth {
+            case .healthy: text = "OK"
+            case .degraded: text = "!"
+            case .down:
+                if let secs = data.nextPollSeconds {
+                    let c = max(0, secs)
+                    text = String(format: "%d:%02d", c / 60, c % 60)
+                } else {
+                    text = "!"
+                }
+            }
+            return .pill(text: text, tint: color)
+        }
+
+        // glyph style
+        let symbolName = data.outageHealth == .healthy ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
+        let s = NSMutableAttributedString()
         let config = NSImage.SymbolConfiguration(pointSize: 11, weight: .semibold)
             .applying(NSImage.SymbolConfiguration(paletteColors: [color]))
         if let glyph = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?.withSymbolConfiguration(config) {
             let attachment = NSTextAttachment()
             attachment.image = glyph
             attachment.bounds = CGRect(x: 0, y: (11 - glyph.size.height) / 2, width: glyph.size.width, height: glyph.size.height)
-            str.append(NSAttributedString(attachment: attachment))
+            s.append(NSAttributedString(attachment: attachment))
         }
         if data.outageHealth == .down, let secs = data.nextPollSeconds {
-            let clamped = max(0, secs)
-            let text = String(format: " %d:%02d", clamped / 60, clamped % 60)
-            str.append(NSAttributedString(string: text, attributes: [
-                .font: styleFont(size: 11, weight: .semibold, style: data.menuBarStyle, monospacedDigits: true),
-                .foregroundColor: color,
+            let c = max(0, secs)
+            s.append(NSAttributedString(string: String(format: " %d:%02d", c / 60, c % 60), attributes: [
+                .font: systemFont(11, .semibold, monoDigits: true), .foregroundColor: color,
             ]))
         }
+        return .run(s)
     }
 
-    private static func appendSessionReset(to str: NSMutableAttributedString, data: RenderData) {
-        let resolvedText = resetDisplayText(data: data)
-        // Empty only when `fiveHour.resetsAt` is nil - typically between two
-        // 5h windows. Fall back to an em-less `-` placeholder so the pin
-        // stays visible and the user knows it's still active.
-        let text = resolvedText.isEmpty ? "-" : resolvedText
-        let attrs: [NSAttributedString.Key: Any] = [
-            .font: styleFont(size: 12, weight: .bold, style: data.menuBarStyle, monospacedDigits: true),
-            .foregroundColor: resetValueColor(data),
-        ]
-        str.append(NSAttributedString(string: text, attributes: attrs))
-    }
+    // MARK: - Metric value lookups
 
-    // MARK: - Badge pill rendering
-
-    /// Badge style: each metric becomes a small rounded pill with a tinted
-    /// background and colour-matched text. Drawn directly with NSBezierPath
-    /// rather than NSAttributedString so we can get real rounded corners in
-    /// the menu bar icon.
-    private struct BadgePill {
-        let text: String
-        let tint: NSColor
-    }
-
-    private static func renderBadgePills(_ data: RenderData) -> NSImage {
-        let pills = buildBadgePills(data)
-        let height: CGFloat = 22
-        let pillHeight: CGFloat = 17
-        let paddingH: CGFloat = 7
-        let gap: CGFloat = 5
-
-        let font = NSFont.systemFont(ofSize: 11, weight: .bold)
-        let textAttrs: [NSAttributedString.Key: Any] = [.font: font]
-
-        let widths: [CGFloat] = pills.map { pill in
-            ceil((pill.text as NSString).size(withAttributes: textAttrs).width) + paddingH * 2
-        }
-        let totalWidth = widths.reduce(0, +) + CGFloat(max(pills.count - 1, 0)) * gap
-        guard totalWidth > 0 else {
-            return NSImage(size: NSSize(width: 1, height: height))
-        }
-
-        let imgSize = NSSize(width: ceil(totalWidth) + 2, height: height)
-        let img = NSImage(size: imgSize, flipped: false) { _ in
-            var x: CGFloat = 1
-            for (i, pill) in pills.enumerated() {
-                let w = widths[i]
-                let pillRect = NSRect(
-                    x: x,
-                    y: (height - pillHeight) / 2,
-                    width: w,
-                    height: pillHeight
-                )
-                let path = NSBezierPath(
-                    roundedRect: pillRect,
-                    xRadius: pillHeight / 2,
-                    yRadius: pillHeight / 2
-                )
-                // Tinted fill (15% opacity) with a 1px outline of the same
-                // colour at higher opacity - keeps the pill readable on both
-                // light and dark menu bars.
-                pill.tint.withAlphaComponent(0.18).setFill()
-                path.fill()
-                pill.tint.withAlphaComponent(0.55).setStroke()
-                path.lineWidth = 0.8
-                path.stroke()
-
-                // Text centred.
-                let attrs: [NSAttributedString.Key: Any] = [
-                    .font: font,
-                    .foregroundColor: pill.tint,
-                ]
-                let textSize = (pill.text as NSString).size(withAttributes: attrs)
-                let textOrigin = NSPoint(
-                    x: x + (w - textSize.width) / 2,
-                    y: (height - textSize.height) / 2 - 0.5
-                )
-                (pill.text as NSString).draw(at: textOrigin, withAttributes: attrs)
-
-                x += w + gap
-            }
-            return true
-        }
-        img.isTemplate = false
-        return img
-    }
-
-    private static func buildBadgePills(_ data: RenderData) -> [BadgePill] {
-        let ordered: [MetricID] = [
-            .serviceStatus, .sessionReset, .fiveHour, .sessionPacing, .sevenDay, .weeklyPacing, .sonnet, .design, .fable, .extraCredits
-        ].filter {
-            guard data.pinnedMetrics.contains($0) else { return false }
-            // Sonnet / Design / Extra Credits visibility in the menu bar is
-            // purely driven by pinnedMetrics. Popover visibility has its own
-            // toggles.
-            if $0 == .design && !data.hasDesign { return false }
-            if $0 == .fable && !data.hasFable { return false }
-            switch $0 {
-            case .sessionReset, .sessionPacing: return data.hasFiveHourBucket
-            case .weeklyPacing: return data.hasWeeklyPacing
-            case .design: return data.hasDesign
-            case .fable: return data.hasFable
-            case .serviceStatus: return true
-            case .extraCredits: return data.hasExtraCredits
-            default: return true
-            }
-        }
-
-        return ordered.compactMap { metric -> BadgePill? in
-            let mono = data.menuBarMonochrome
-            switch metric {
-            case .serviceStatus:
-                switch data.outageHealth {
-                case .healthy:
-                    return BadgePill(text: "OK", tint: mono ? .labelColor : .systemGreen)
-                case .degraded:
-                    return BadgePill(text: "!", tint: mono ? .labelColor : .systemOrange)
-                case .down:
-                    let text: String
-                    if let secs = data.nextPollSeconds {
-                        let clamped = max(0, secs)
-                        text = String(format: "%d:%02d", clamped / 60, clamped % 60)
-                    } else {
-                        text = "!"
-                    }
-                    return BadgePill(text: text, tint: mono ? .labelColor : .systemRed)
-                }
-            case .sessionReset:
-                let text = resetDisplayText(data: data)
-                return BadgePill(
-                    text: text.isEmpty ? "-" : text,
-                    tint: resetValueColor(data)
-                )
-            case .fiveHour:
-                return BadgePill(
-                    text: "\(data.fiveHourPct)%",
-                    tint: colorForPct(data.fiveHourPct, resetDate: data.fiveHourResetDate, windowDuration: 5 * 3600, data: data)
-                )
-            case .sevenDay:
-                return BadgePill(
-                    text: "\(data.sevenDayPct)%",
-                    tint: colorForPct(data.sevenDayPct, resetDate: data.sevenDayResetDate, windowDuration: 7 * 86_400, data: data)
-                )
-            case .sonnet:
-                return BadgePill(
-                    text: "\(data.sonnetPct)%",
-                    tint: colorForPct(data.sonnetPct, resetDate: data.sonnetResetDate, windowDuration: 7 * 86_400, data: data)
-                )
-            case .design:
-                return BadgePill(
-                    text: "\(data.designPct)%",
-                    tint: colorForPct(data.designPct, resetDate: data.designResetDate, windowDuration: 7 * 86_400, data: data)
-                )
-            case .fable:
-                return BadgePill(
-                    text: "\(data.fablePct)%",
-                    tint: colorForPct(data.fablePct, resetDate: data.fableResetDate, windowDuration: 7 * 86_400, data: data)
-                )
-            case .extraCredits:
-                // No reset window: pass nil/0 so colorForPct falls back to the
-                // static threshold colour instead of risk-based smart colour.
-                return BadgePill(
-                    text: "\(data.extraCreditsPct)%",
-                    tint: colorForPct(data.extraCreditsPct, resetDate: nil, windowDuration: 0, data: data)
-                )
-            case .sessionPacing:
-                return pacingBadgePill(
-                    hasData: data.hasSessionPacing,
-                    zone: data.sessionPacingZone,
-                    delta: data.sessionPacingDelta,
-                    mode: data.sessionPacingDisplayMode,
-                    data: data
-                )
-            case .weeklyPacing:
-                return pacingBadgePill(
-                    hasData: true,
-                    zone: data.weeklyPacingZone,
-                    delta: data.weeklyPacingDelta,
-                    mode: data.weeklyPacingDisplayMode,
-                    data: data
-                )
-            }
+    private static func usageValue(_ kind: MenuBarSegmentKind, data: RenderData) -> Int {
+        switch kind {
+        case .session: return data.fiveHourPct
+        case .weekly: return data.sevenDayPct
+        case .sonnet: return data.sonnetPct
+        case .design: return data.designPct
+        case .fable: return data.fablePct
+        case .extraCredits: return data.extraCreditsPct
+        default: return 0
         }
     }
 
-    /// Badge pacing pill content varies with `PacingDisplayMode`:
-    /// dot-only, delta-only, or dot + delta. Also handles the placeholder
-    /// state when we don't have a pacing result yet.
-    private static func pacingBadgePill(
-        hasData: Bool,
-        zone: PacingZone,
-        delta: Int,
-        mode: PacingDisplayMode,
-        data: RenderData
-    ) -> BadgePill {
-        let tint = hasData ? colorForZone(zone, data: data) : NSColor.tertiaryLabelColor
-        let sign = delta >= 0 ? "+" : ""
-        let shape = data.pacingShape.glyph
-        let text: String = {
-            switch mode {
-            case .dot:      return shape
-            case .dotDelta: return hasData ? "\(shape) \(sign)\(delta)%" : "\(shape) -"
-            case .delta:    return hasData ? "\(sign)\(delta)%" : "-"
-            }
-        }()
-        return BadgePill(text: text, tint: tint)
-    }
-
-    // MARK: - Style-aware helpers
-
-    /// Font factory that adapts to `MenuBarStyle`:
-    /// - classic: system font
-    /// - mono: full monospaced system font
-    /// - badge: rounded design (used behind pill text)
-    /// `monospacedDigits` forces tabular-nums on the classic and minimal styles
-    /// so percentages don't jitter as they change width.
-    private static func styleFont(
-        size: CGFloat,
-        weight: NSFont.Weight,
-        style: MenuBarStyle,
-        monospacedDigits: Bool = false
-    ) -> NSFont {
-        switch style {
-        case .mono:
-            return NSFont.monospacedSystemFont(ofSize: size, weight: weight)
-        case .badge:
-            let base = NSFont.systemFont(ofSize: size, weight: weight)
-            let rounded = NSFontDescriptor(
-                fontAttributes: [.family: "SF Pro Rounded"]
-            )
-            if let custom = NSFont(descriptor: rounded, size: size) {
-                return monospacedDigits
-                    ? NSFont.monospacedDigitSystemFont(ofSize: size, weight: weight)
-                    : custom
-            }
-            return base
-        case .classic:
-            return monospacedDigits
-                ? NSFont.monospacedDigitSystemFont(ofSize: size, weight: weight)
-                : NSFont.systemFont(ofSize: size, weight: weight)
+    private static func usageLabel(_ kind: MenuBarSegmentKind) -> String {
+        switch kind {
+        case .session: return MetricID.fiveHour.shortLabel
+        case .weekly: return MetricID.sevenDay.shortLabel
+        case .sonnet: return MetricID.sonnet.shortLabel
+        case .design: return MetricID.design.shortLabel
+        case .fable: return MetricID.fable.shortLabel
+        case .extraCredits: return MetricID.extraCredits.shortLabel
+        default: return ""
         }
     }
 
-    /// Renders a `label + value%` block with style-specific layout:
-    /// - classic: "5h 26%" (label tinted tertiary, value bold colored)
-    /// - mono: "5h:26" (all mono, colon separator, no %)
-    /// - minimal: "26%" (rounded font, no label)
-    private static func appendPercentMetric(
-        to str: NSMutableAttributedString,
-        label: String,
-        value: Int,
-        resetDate: Date?,
-        windowDuration: TimeInterval,
-        data: RenderData
-    ) {
-        let valueColor = colorForPct(value, resetDate: resetDate, windowDuration: windowDuration, data: data)
-
-        switch data.menuBarStyle {
-        case .classic:
-            let labelAttrs: [NSAttributedString.Key: Any] = [
-                .font: styleFont(size: 9, weight: .medium, style: .classic),
-                .foregroundColor: periodColor(data),
-            ]
-            let valueAttrs: [NSAttributedString.Key: Any] = [
-                .font: styleFont(size: 12, weight: .bold, style: .classic, monospacedDigits: true),
-                .foregroundColor: valueColor,
-            ]
-            str.append(NSAttributedString(string: "\(label) ", attributes: labelAttrs))
-            str.append(NSAttributedString(string: "\(value)%", attributes: valueAttrs))
-
-        case .mono:
-            let labelAttrs: [NSAttributedString.Key: Any] = [
-                .font: styleFont(size: 11, weight: .regular, style: .mono),
-                .foregroundColor: periodColor(data),
-            ]
-            let valueAttrs: [NSAttributedString.Key: Any] = [
-                .font: styleFont(size: 11, weight: .bold, style: .mono),
-                .foregroundColor: valueColor,
-            ]
-            str.append(NSAttributedString(string: "\(label):", attributes: labelAttrs))
-            str.append(NSAttributedString(string: "\(value)", attributes: valueAttrs))
-
-        case .badge:
-            let valueAttrs: [NSAttributedString.Key: Any] = [
-                .font: styleFont(size: 13, weight: .bold, style: .badge, monospacedDigits: true),
-                .foregroundColor: valueColor,
-            ]
-            str.append(NSAttributedString(string: "\(value)%", attributes: valueAttrs))
+    private static func usageResetDate(_ kind: MenuBarSegmentKind, data: RenderData) -> Date? {
+        switch kind {
+        case .session: return data.fiveHourResetDate
+        case .weekly: return data.sevenDayResetDate
+        case .sonnet: return data.sonnetResetDate
+        case .design: return data.designResetDate
+        case .fable: return data.fableResetDate
+        default: return nil  // extraCredits: no reset window -> static threshold
         }
     }
 
-    private static func resetDisplayText(data: RenderData) -> String {
+    private static func usageWindow(_ kind: MenuBarSegmentKind) -> TimeInterval {
+        switch kind {
+        case .session: return 5 * 3600
+        case .weekly, .sonnet, .design, .fable: return 7 * 86_400
+        default: return 0  // extraCredits: windowless
+        }
+    }
+
+    private static func resetDisplayText(format: ResetDisplayFormat, data: RenderData) -> String {
         let relative = data.fiveHourReset
         let absolute = data.fiveHourResetAbsolute
-        switch data.resetDisplayFormat {
-        case .relative:
-            return relative
-        case .absolute:
-            return absolute
+        switch format {
+        case .relative: return relative
+        case .absolute: return absolute
         case .both:
             if relative.isEmpty { return absolute }
             if absolute.isEmpty { return relative }
@@ -748,60 +569,47 @@ enum MenuBarRenderer {
         }
     }
 
-    private static func appendPacing(
-        to str: NSMutableAttributedString,
-        delta: Int,
-        zone: PacingZone,
-        mode: PacingDisplayMode,
-        data: RenderData
-    ) {
-        let dotColor = colorForZone(zone, data: data)
-        let dotAttrs: [NSAttributedString.Key: Any] = [
-            .font: styleFont(size: 11, weight: .bold, style: data.menuBarStyle),
-            .foregroundColor: dotColor,
-        ]
-        let deltaAttrs: [NSAttributedString.Key: Any] = [
-            .font: styleFont(size: 10, weight: .bold, style: data.menuBarStyle, monospacedDigits: true),
-            .foregroundColor: dotColor,
-        ]
-        let sign = delta >= 0 ? "+" : ""
-        switch mode {
-        case .dot:
-            str.append(NSAttributedString(string: data.pacingShape.glyph, attributes: dotAttrs))
-        case .dotDelta:
-            str.append(NSAttributedString(string: data.pacingShape.glyph, attributes: dotAttrs))
-            str.append(NSAttributedString(string: " \(sign)\(delta)%", attributes: deltaAttrs))
-        case .delta:
-            str.append(NSAttributedString(string: "\(sign)\(delta)%", attributes: deltaAttrs))
+    // MARK: - Layout primitives
+
+    private static func systemFont(_ size: CGFloat, _ weight: NSFont.Weight, monoDigits: Bool = false) -> NSFont {
+        monoDigits
+            ? NSFont.monospacedDigitSystemFont(ofSize: size, weight: weight)
+            : NSFont.systemFont(ofSize: size, weight: weight)
+    }
+
+    private static func monoFont(_ size: CGFloat, _ weight: NSFont.Weight) -> NSFont {
+        NSFont.monospacedSystemFont(ofSize: size, weight: weight)
+    }
+
+    private static func visualWidth(_ v: SegmentVisual) -> CGFloat {
+        switch v.content {
+        case .run(let s):
+            return max(ceil(s.size().width), 1)
+        case .pill(let text, _):
+            let w = (text as NSString).size(withAttributes: [.font: pillFont]).width
+            return ceil(w) + pillPaddingH * 2
         }
     }
 
-    /// Neutral placeholder used when the pacing bucket exists but `resets_at`
-    /// is missing, so we can't compute a meaningful delta. Uses the system's
-    /// tertiary label colour to signal "data pending" without faking an
-    /// on-track state.
-    private static func appendPacingPlaceholder(
-        to str: NSMutableAttributedString,
-        mode: PacingDisplayMode,
-        data: RenderData
-    ) {
-        let neutralColor: NSColor = .tertiaryLabelColor
-        let dotAttrs: [NSAttributedString.Key: Any] = [
-            .font: styleFont(size: 11, weight: .bold, style: data.menuBarStyle),
-            .foregroundColor: neutralColor,
-        ]
-        let textAttrs: [NSAttributedString.Key: Any] = [
-            .font: styleFont(size: 10, weight: .bold, style: data.menuBarStyle, monospacedDigits: true),
-            .foregroundColor: neutralColor,
-        ]
-        switch mode {
-        case .dot:
-            str.append(NSAttributedString(string: data.pacingShape.glyph, attributes: dotAttrs))
-        case .dotDelta:
-            str.append(NSAttributedString(string: data.pacingShape.glyph, attributes: dotAttrs))
-            str.append(NSAttributedString(string: " -", attributes: textAttrs))
-        case .delta:
-            str.append(NSAttributedString(string: "-", attributes: textAttrs))
+    private static func drawVisual(_ v: SegmentVisual, at x: CGFloat, width: CGFloat) {
+        switch v.content {
+        case .run(let s):
+            let sz = s.size()
+            s.draw(at: NSPoint(x: x, y: (imageHeight - sz.height) / 2))
+        case .pill(let text, let tint):
+            let rect = NSRect(x: x, y: (imageHeight - pillHeight) / 2, width: width, height: pillHeight)
+            let path = NSBezierPath(roundedRect: rect, xRadius: pillHeight / 2, yRadius: pillHeight / 2)
+            tint.withAlphaComponent(0.18).setFill()
+            path.fill()
+            tint.withAlphaComponent(0.55).setStroke()
+            path.lineWidth = 0.8
+            path.stroke()
+            let attrs: [NSAttributedString.Key: Any] = [.font: pillFont, .foregroundColor: tint]
+            let ts = (text as NSString).size(withAttributes: attrs)
+            (text as NSString).draw(
+                at: NSPoint(x: x + (width - ts.width) / 2, y: (imageHeight - ts.height) / 2 - 0.5),
+                withAttributes: attrs
+            )
         }
     }
 

--- a/Shared/Models/MenuBarCompositionModels.swift
+++ b/Shared/Models/MenuBarCompositionModels.swift
@@ -1,0 +1,253 @@
+import Foundation
+
+// MARK: - Segment vocabulary
+//
+// The composable menu bar model (v5.10+). The status-bar item is an ordered
+// list of segments drawn left to right; each segment = a metric kind + a
+// visual style + options. Replaces the fixed hardcoded segment order + the
+// single global `menuBarStyle`, so segments become reorderable and each one
+// carries its own look.
+//
+// Rendered in AppKit by MenuBarRenderer (NSImage), so there is no grid / width
+// concept like the popover: a segment sizes to its content. Shares the tolerant
+// Codable helper and the `UserTemplate` container with the popover.
+
+/// What a menu bar segment shows.
+enum MenuBarSegmentKind: String, Codable, CaseIterable, Identifiable {
+    // Usage metrics (percentage)
+    case session, weekly, sonnet, design, fable, extraCredits
+    // Pacing (delta vs linear pace)
+    case sessionPacing, weeklyPacing
+    // Status / time
+    case sessionReset, serviceStatus
+
+    var id: String { rawValue }
+
+    enum Family { case usage, pacing, status }
+
+    var family: Family {
+        switch self {
+        case .session, .weekly, .sonnet, .design, .fable, .extraCredits:
+            return .usage
+        case .sessionPacing, .weeklyPacing:
+            return .pacing
+        case .sessionReset, .serviceStatus:
+            return .status
+        }
+    }
+
+    /// Styles this kind can render as. The editor filters its style menu with
+    /// this; `MenuBarCompositionModelsTests` asserts the matrix stays sane.
+    var allowedStyles: [MenuBarSegmentStyle] {
+        switch family {
+        case .usage: return [.labelValue, .valueOnly, .mono, .pill]
+        case .pacing: return [.dot, .dotDelta, .delta, .pill]
+        case .status:
+            switch self {
+            case .sessionReset: return [.text, .pill]
+            case .serviceStatus: return [.glyph, .pill]
+            default: return [.text]
+            }
+        }
+    }
+
+    /// Presence-gated kinds render nothing (and the editor greys them) when the
+    /// account lacks the metric, matching the pre-5.10 menu bar.
+    var isPresenceGated: Bool {
+        self == .design || self == .fable || self == .extraCredits
+    }
+}
+
+/// How a segment renders. Plain styles draw as an `NSAttributedString` run;
+/// `pill` draws a tinted capsule. Both are mixed freely in one status item.
+enum MenuBarSegmentStyle: String, Codable, CaseIterable, Identifiable {
+    /// "5h 62%" - short label + colored value (the classic look).
+    case labelValue
+    /// "62%" - value only, no label.
+    case valueOnly
+    /// "5h:62" - monospaced, colon separator, no percent sign.
+    case mono
+    /// Value in a tinted rounded capsule (the badge look). For pacing it shows
+    /// the shape + delta; for status the status text.
+    case pill
+    /// Pacing shape glyph only (colored by zone).
+    case dot
+    /// Pacing shape glyph + signed delta.
+    case dotDelta
+    /// Signed delta only.
+    case delta
+    /// Plain text (session reset countdown).
+    case text
+    /// Status symbol glyph (+ countdown when down).
+    case glyph
+
+    var id: String { rawValue }
+
+    var localizedLabel: String {
+        NSLocalizedString("menuBarStyle.segment.\(rawValue)", comment: "")
+    }
+}
+
+// MARK: - Options
+
+struct MenuBarSegmentOptions: Codable, Equatable {
+    /// Shape drawn for pacing dot styles.
+    var pacingShape: PacingShape
+    /// Relative / absolute / both, for the session reset segment.
+    var resetFormat: ResetDisplayFormat
+
+    init(pacingShape: PacingShape = .circle, resetFormat: ResetDisplayFormat = .relative) {
+        self.pacingShape = pacingShape
+        self.resetFormat = resetFormat
+    }
+
+    // Tolerant decoding so future option fields never break old blobs.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        pacingShape = (try? c.decodeIfPresent(PacingShape.self, forKey: .pacingShape)) ?? .circle
+        resetFormat = (try? c.decodeIfPresent(ResetDisplayFormat.self, forKey: .resetFormat)) ?? .relative
+    }
+}
+
+// MARK: - Segment
+
+struct MenuBarSegment: Codable, Equatable, Identifiable {
+    var id: UUID
+    var kind: MenuBarSegmentKind
+    var style: MenuBarSegmentStyle
+    var isHidden: Bool
+    var options: MenuBarSegmentOptions
+
+    init(
+        id: UUID = UUID(),
+        kind: MenuBarSegmentKind,
+        style: MenuBarSegmentStyle,
+        isHidden: Bool = false,
+        options: MenuBarSegmentOptions = MenuBarSegmentOptions()
+    ) {
+        self.id = id
+        self.kind = kind
+        self.style = style
+        self.isHidden = isHidden
+        self.options = options
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        // Unknown kind/style raw values (blob written by a newer app version)
+        // throw here; the composition decoder drops the segment instead of
+        // failing the whole blob.
+        kind = try c.decode(MenuBarSegmentKind.self, forKey: .kind)
+        style = try c.decode(MenuBarSegmentStyle.self, forKey: .style)
+        id = (try? c.decodeIfPresent(UUID.self, forKey: .id)) ?? UUID()
+        isHidden = (try? c.decodeIfPresent(Bool.self, forKey: .isHidden)) ?? false
+        options = (try? c.decodeIfPresent(MenuBarSegmentOptions.self, forKey: .options)) ?? MenuBarSegmentOptions()
+    }
+
+    /// Style clamped to what the kind allows - a decoded or programmatic
+    /// mismatch renders as the kind's first legal style instead of nothing.
+    var effectiveStyle: MenuBarSegmentStyle {
+        kind.allowedStyles.contains(style) ? style : (kind.allowedStyles.first ?? .text)
+    }
+}
+
+// MARK: - Composition
+
+struct MenuBarComposition: Codable, Equatable {
+    /// Ordered list; order = left-to-right render order.
+    var segments: [MenuBarSegment]
+
+    init(segments: [MenuBarSegment]) {
+        self.segments = segments
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        segments = c.decodeLossyArray(MenuBarSegment.self, forKey: .segments)
+    }
+
+    var visibleSegments: [MenuBarSegment] { segments.filter { !$0.isHidden } }
+
+    /// Validation gate used by `SettingsStore.reconcile`. Unlike the popover
+    /// (which falls back to a template when empty), an empty menu bar is a
+    /// legitimate choice - `MenuBarRenderer` already draws the app logo when
+    /// no segment is visible - so this only reports emptiness; the store keeps
+    /// the composition as-is.
+    var hasVisibleContent: Bool { !visibleSegments.isEmpty }
+
+    static let `default` = MenuBarBuiltinTemplate.classic.composition
+}
+
+// MARK: - Templates
+
+/// Built-in starting points for the menu bar look.
+enum MenuBarBuiltinTemplate: String, CaseIterable, Identifiable {
+    case classic, minimalist, pills, pacingFocus, complete
+
+    var id: String { rawValue }
+
+    var localizedName: String {
+        NSLocalizedString("menuBarTemplate.\(rawValue)", comment: "")
+    }
+
+    /// Fresh segment instances (new UUIDs) on every access, so applying a
+    /// template twice never collides ids with a live composition.
+    var composition: MenuBarComposition {
+        switch self {
+        case .classic:
+            return MenuBarComposition(segments: [
+                MenuBarSegment(kind: .session, style: .labelValue),
+                MenuBarSegment(kind: .weekly, style: .labelValue),
+            ])
+        case .minimalist:
+            return MenuBarComposition(segments: [
+                MenuBarSegment(kind: .session, style: .valueOnly),
+            ])
+        case .pills:
+            return MenuBarComposition(segments: [
+                MenuBarSegment(kind: .session, style: .pill),
+                MenuBarSegment(kind: .weekly, style: .pill),
+            ])
+        case .pacingFocus:
+            return MenuBarComposition(segments: [
+                MenuBarSegment(kind: .session, style: .labelValue),
+                MenuBarSegment(kind: .sessionPacing, style: .dotDelta),
+            ])
+        case .complete:
+            return MenuBarComposition(segments: [
+                MenuBarSegment(kind: .session, style: .labelValue),
+                MenuBarSegment(kind: .sessionReset, style: .text),
+                MenuBarSegment(kind: .weekly, style: .labelValue),
+                MenuBarSegment(kind: .sessionPacing, style: .dotDelta),
+                MenuBarSegment(kind: .weeklyPacing, style: .dotDelta),
+                MenuBarSegment(kind: .sonnet, style: .labelValue),
+            ])
+        }
+    }
+}
+
+/// A menu bar composition the user saved under a name. Persisted as a JSON
+/// blob under the `menuBarUserTemplates` UserDefaults key.
+typealias MenuBarUserTemplate = UserTemplate<MenuBarComposition>
+
+// MARK: - Labels (editor UI)
+
+extension MenuBarSegmentKind {
+    var localizedLabel: String {
+        NSLocalizedString("menuBarSegment.\(rawValue)", comment: "")
+    }
+
+    var symbolName: String {
+        switch self {
+        case .session: return "bolt.fill"
+        case .weekly: return "calendar"
+        case .sonnet: return "quote.opening"
+        case .design: return "paintbrush.pointed.fill"
+        case .fable: return "books.vertical.fill"
+        case .extraCredits: return "creditcard.fill"
+        case .sessionPacing, .weeklyPacing: return "speedometer"
+        case .sessionReset: return "clock.arrow.circlepath"
+        case .serviceStatus: return "dot.radiowaves.left.and.right"
+        }
+    }
+}

--- a/Shared/Models/MenuBarStyle.swift
+++ b/Shared/Models/MenuBarStyle.swift
@@ -1,16 +1,13 @@
 import Foundation
 
-/// Controls the typography, labels and separators of the pinned metrics
-/// rendered into the menu bar icon. Purely presentational - doesn't affect
-/// which metrics are shown (that's `pinnedMetrics`) or their values.
+/// LEGACY (pre-5.10). The single global menu bar style was replaced by the
+/// composable menu bar's per-segment styles (`MenuBarSegmentStyle`). This enum
+/// survives only as a decoding target for the stored `menuBarStyle` key that
+/// `MenuBarConfigMigrator` reads once. No UI edits it anymore.
 enum MenuBarStyle: String, Codable, CaseIterable, Identifiable {
     case classic  // SF system, short labels + space separators, weights vary
     case mono     // SF Mono, labels inline with `:` (e.g. 5h:26), tight
     case badge    // each metric in a rounded tinted pill with matching text
 
     var id: String { rawValue }
-
-    var localizedLabel: String {
-        NSLocalizedString("menuBarStyle.\(rawValue)", comment: "")
-    }
 }

--- a/Shared/Models/ResetDisplayFormat.swift
+++ b/Shared/Models/ResetDisplayFormat.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum ResetDisplayFormat: String, CaseIterable, Identifiable {
+enum ResetDisplayFormat: String, Codable, CaseIterable, Identifiable {
     case relative   // "1h 39min"
     case absolute   // "20:30" today, "Fri 08:00" other days
     case both       // "1h 39min - 20:30"

--- a/Shared/Stores/SettingsStore.swift
+++ b/Shared/Stores/SettingsStore.swift
@@ -79,6 +79,19 @@ final class SettingsStore: ObservableObject {
     @Published var popoverUserTemplates: [PopoverUserTemplate] {
         didSet { savePopoverUserTemplates() }
     }
+
+    // MARK: - Menu bar
+    /// The composable menu bar: one ordered list of segments (kind + style).
+    /// Persisted as JSON under `menuBarComposition`. The legacy `pinnedMetrics`
+    /// + `menuBarStyle` + per-metric display prefs are migrated once (see init)
+    /// and left in place so a downgrade restores the pre-5.10 menu bar.
+    @Published var menuBarComposition: MenuBarComposition {
+        didSet { saveMenuBarComposition() }
+    }
+    /// Compositions the user saved under a name from the menu bar editor.
+    @Published var menuBarUserTemplates: [MenuBarUserTemplate] {
+        didSet { saveMenuBarUserTemplates() }
+    }
     @Published var hasCompletedOnboarding: Bool {
         didSet { UserDefaults.standard.set(hasCompletedOnboarding, forKey: "hasCompletedOnboarding") }
     }
@@ -388,6 +401,34 @@ final class SettingsStore: ObservableObject {
             self.popoverUserTemplates = []
         }
 
+        // Menu bar composition. New blob, else one-shot migration of the
+        // legacy pinnedMetrics + menuBarStyle + per-metric display prefs
+        // (preserving what the user saw before 5.10), else the Classic template.
+        let hadMenuBarBlob = UserDefaults.standard.data(forKey: "menuBarComposition") != nil
+        if let data = UserDefaults.standard.data(forKey: "menuBarComposition"),
+           let decoded = try? JSONDecoder().decode(MenuBarComposition.self, from: data) {
+            self.menuBarComposition = decoded
+        } else {
+            self.menuBarComposition = MenuBarConfigMigrator.migrate(
+                pinnedMetrics: displayStore.pinnedMetrics,
+                menuBarStyle: displayStore.menuBarStyle,
+                sessionPacingDisplayMode: displayStore.sessionPacingDisplayMode,
+                weeklyPacingDisplayMode: displayStore.weeklyPacingDisplayMode,
+                resetDisplayFormat: displayStore.resetDisplayFormat,
+                pacingShape: displayStore.pacingShape,
+                presence: MenuBarConfigMigrator.AccountPresence(
+                    cachedUsage: sharedFileService.cachedUsage?.usage
+                )
+            )
+        }
+
+        if let data = UserDefaults.standard.data(forKey: "menuBarUserTemplates"),
+           let decoded = try? JSONDecoder().decode([MenuBarUserTemplate].self, from: data) {
+            self.menuBarUserTemplates = decoded
+        } else {
+            self.menuBarUserTemplates = []
+        }
+
         // The piège: a @Published child only emits the parent's objectWillChange
         // when reassigned, not when one of ITS @Published changes. Relay it so a
         // view observing `settings` re-renders on `settings.pacing.*` changes.
@@ -407,9 +448,12 @@ final class SettingsStore: ObservableObject {
         }
 
         // didSet doesn't fire during init - persist the migrated / default
-        // composition now so the one-shot migration is durable.
+        // compositions now so the one-shot migrations are durable.
         if !hadCompositionBlob {
             savePopoverComposition()
+        }
+        if !hadMenuBarBlob {
+            saveMenuBarComposition()
         }
     }
 
@@ -423,6 +467,18 @@ final class SettingsStore: ObservableObject {
     private func savePopoverUserTemplates() {
         guard let data = try? JSONEncoder().encode(popoverUserTemplates) else { return }
         UserDefaults.standard.set(data, forKey: "popoverUserTemplates")
+    }
+
+    // MARK: - Menu bar persistence
+
+    private func saveMenuBarComposition() {
+        guard let data = try? JSONEncoder().encode(menuBarComposition) else { return }
+        UserDefaults.standard.set(data, forKey: "menuBarComposition")
+    }
+
+    private func saveMenuBarUserTemplates() {
+        guard let data = try? JSONEncoder().encode(menuBarUserTemplates) else { return }
+        UserDefaults.standard.set(data, forKey: "menuBarUserTemplates")
     }
 
     /// Ensures a decoded composition still satisfies the validation rules

--- a/Shared/Stores/SettingsStore.swift
+++ b/Shared/Stores/SettingsStore.swift
@@ -415,10 +415,7 @@ final class SettingsStore: ObservableObject {
                 sessionPacingDisplayMode: displayStore.sessionPacingDisplayMode,
                 weeklyPacingDisplayMode: displayStore.weeklyPacingDisplayMode,
                 resetDisplayFormat: displayStore.resetDisplayFormat,
-                pacingShape: displayStore.pacingShape,
-                presence: MenuBarConfigMigrator.AccountPresence(
-                    cachedUsage: sharedFileService.cachedUsage?.usage
-                )
+                pacingShape: displayStore.pacingShape
             )
         }
 

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -765,9 +765,6 @@
 
 /* Menu bar style picker */
 "settings.menubar.style" = "Style";
-"menuBarStyle.classic" = "Classic";
-"menuBarStyle.mono" = "Mono";
-"menuBarStyle.badge" = "Badge";
 
 /* Pacing shape picker */
 "settings.pacing.shape" = "Pacing indicator shape";

--- a/Shared/en.lproj/Localizable.strings
+++ b/Shared/en.lproj/Localizable.strings
@@ -713,6 +713,54 @@
 "popoverTemplate.fableFirst" = "Fable First";
 "popoverTemplate.complete" = "Complete";
 
+/* Composable menu bar editor */
+"menuBar.editor.templates" = "Templates";
+"menuBar.editor.segments" = "Segments";
+"menuBar.editor.addSegment" = "Add segment";
+"menuBar.editor.family.metrics" = "Metrics";
+"menuBar.editor.family.pacing" = "Pacing";
+"menuBar.editor.family.status" = "Status";
+"menuBar.editor.unavailable" = "not available on your plan";
+"menuBar.editor.saveTemplate" = "Save as template";
+"menuBar.editor.saveTemplate.short" = "Save current";
+"menuBar.editor.saveTemplate.message" = "Saves the current menu bar layout so you can reapply it later.";
+"menuBar.editor.saveTemplate.placeholder" = "Template name";
+"menuBar.editor.save" = "Save";
+"menuBar.editor.cancel" = "Cancel";
+"menuBar.editor.deleteTemplate" = "Delete template";
+"menuBar.editor.preview" = "Preview";
+"menuBar.editor.preview.hint" = "Click a segment to select it in the list";
+"menuBar.editor.empty" = "Empty - the menu bar shows the app icon";
+"menuBar.editor.emptyList" = "No segments. Add one, or the menu bar shows just the app icon.";
+
+"menuBarSegment.session" = "Session (5h)";
+"menuBarSegment.weekly" = "Weekly";
+"menuBarSegment.sonnet" = "Sonnet";
+"menuBarSegment.design" = "Design";
+"menuBarSegment.fable" = "Fable";
+"menuBarSegment.extraCredits" = "Extra Credits";
+"menuBarSegment.sessionPacing" = "Session pacing";
+"menuBarSegment.weeklyPacing" = "Weekly pacing";
+"menuBarSegment.sessionReset" = "Session reset countdown";
+"menuBarSegment.serviceStatus" = "Service status";
+
+"menuBarStyle.segment.labelValue" = "Label + value";
+"menuBarStyle.segment.valueOnly" = "Value only";
+"menuBarStyle.segment.mono" = "Mono";
+"menuBarStyle.segment.pill" = "Pill";
+"menuBarStyle.segment.dot" = "Dot";
+"menuBarStyle.segment.dotDelta" = "Dot + delta";
+"menuBarStyle.segment.delta" = "Delta";
+"menuBarStyle.segment.text" = "Text";
+"menuBarStyle.segment.glyph" = "Glyph";
+
+"menuBarTemplate.classic" = "Classic";
+"menuBarTemplate.minimalist" = "Minimalist";
+"menuBarTemplate.pills" = "Pills";
+"menuBarTemplate.pacingFocus" = "Pacing focus";
+"menuBarTemplate.complete" = "Complete";
+
+
 "menubar.updated.never" = "never";
 
 /* Menu bar style picker */

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -713,6 +713,54 @@
 "popoverTemplate.fableFirst" = "Fable d'abord";
 "popoverTemplate.complete" = "Complet";
 
+/* Éditeur du menu bar composable */
+"menuBar.editor.templates" = "Templates";
+"menuBar.editor.segments" = "Segments";
+"menuBar.editor.addSegment" = "Ajouter un segment";
+"menuBar.editor.family.metrics" = "Métriques";
+"menuBar.editor.family.pacing" = "Pacing";
+"menuBar.editor.family.status" = "Statut";
+"menuBar.editor.unavailable" = "indisponible sur votre plan";
+"menuBar.editor.saveTemplate" = "Enregistrer comme template";
+"menuBar.editor.saveTemplate.short" = "Enregistrer";
+"menuBar.editor.saveTemplate.message" = "Enregistre la disposition actuelle du menu bar pour la réappliquer plus tard.";
+"menuBar.editor.saveTemplate.placeholder" = "Nom du template";
+"menuBar.editor.save" = "Enregistrer";
+"menuBar.editor.cancel" = "Annuler";
+"menuBar.editor.deleteTemplate" = "Supprimer le template";
+"menuBar.editor.preview" = "Aperçu";
+"menuBar.editor.preview.hint" = "Cliquez sur un segment pour le sélectionner dans la liste";
+"menuBar.editor.empty" = "Vide - le menu bar affiche l'icône de l'app";
+"menuBar.editor.emptyList" = "Aucun segment. Ajoutez-en un, sinon le menu bar affiche juste l'icône.";
+
+"menuBarSegment.session" = "Session (5h)";
+"menuBarSegment.weekly" = "Hebdomadaire";
+"menuBarSegment.sonnet" = "Sonnet";
+"menuBarSegment.design" = "Design";
+"menuBarSegment.fable" = "Fable";
+"menuBarSegment.extraCredits" = "Crédits sup.";
+"menuBarSegment.sessionPacing" = "Pacing session";
+"menuBarSegment.weeklyPacing" = "Pacing hebdo";
+"menuBarSegment.sessionReset" = "Compte à rebours session";
+"menuBarSegment.serviceStatus" = "Statut du service";
+
+"menuBarStyle.segment.labelValue" = "Label + valeur";
+"menuBarStyle.segment.valueOnly" = "Valeur seule";
+"menuBarStyle.segment.mono" = "Mono";
+"menuBarStyle.segment.pill" = "Pill";
+"menuBarStyle.segment.dot" = "Point";
+"menuBarStyle.segment.dotDelta" = "Point + delta";
+"menuBarStyle.segment.delta" = "Delta";
+"menuBarStyle.segment.text" = "Texte";
+"menuBarStyle.segment.glyph" = "Glyphe";
+
+"menuBarTemplate.classic" = "Classique";
+"menuBarTemplate.minimalist" = "Minimaliste";
+"menuBarTemplate.pills" = "Pills";
+"menuBarTemplate.pacingFocus" = "Pacing focus";
+"menuBarTemplate.complete" = "Complet";
+
+
 "menubar.updated.never" = "jamais";
 
 /* Menu bar style picker */

--- a/Shared/fr.lproj/Localizable.strings
+++ b/Shared/fr.lproj/Localizable.strings
@@ -765,9 +765,6 @@
 
 /* Menu bar style picker */
 "settings.menubar.style" = "Style";
-"menuBarStyle.classic" = "Classique";
-"menuBarStyle.mono" = "Mono";
-"menuBarStyle.badge" = "Badge";
 
 /* Pacing shape picker */
 "settings.pacing.shape" = "Forme de l'indicateur pacing";

--- a/TokenEaterApp/App/MenuBarRenderDataBuilder.swift
+++ b/TokenEaterApp/App/MenuBarRenderDataBuilder.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+@MainActor
+extension MenuBarRenderer.RenderData {
+    /// Builds render data from the live stores. Shared by the status bar
+    /// (`StatusBarController`) and the menu bar editor's live preview, so both
+    /// render the exact same pixels for the current composition.
+    static func live(
+        usage: UsageStore,
+        theme: ThemeStore,
+        settings: SettingsStore,
+        vendor: VendorStatusStore
+    ) -> MenuBarRenderer.RenderData {
+        MenuBarRenderer.RenderData(
+            composition: settings.menuBarComposition,
+            fiveHourPct: usage.fiveHourPct,
+            sevenDayPct: usage.sevenDayPct,
+            sonnetPct: usage.sonnetPct,
+            weeklyPacingDelta: Int(usage.pacingResult?.delta ?? 0),
+            weeklyPacingZone: usage.pacingResult?.zone ?? .onTrack,
+            hasWeeklyPacing: usage.pacingResult != nil,
+            sessionPacingDelta: Int(usage.fiveHourPacing?.delta ?? 0),
+            sessionPacingZone: usage.fiveHourPacing?.zone ?? .onTrack,
+            hasSessionPacing: usage.fiveHourPacing != nil,
+            hasConfig: usage.hasConfig,
+            hasError: usage.hasError,
+            isAwaitingRefresh: usage.isAwaitingRefresh,
+            themeColors: theme.current,
+            thresholds: theme.thresholds,
+            menuBarMonochrome: theme.menuBarMonochrome,
+            fiveHourReset: usage.fiveHourReset,
+            fiveHourResetAbsolute: usage.fiveHourResetAbsolute,
+            fiveHourResetDate: usage.lastUsage?.fiveHour?.resetsAtDate,
+            sevenDayResetDate: usage.lastUsage?.sevenDay?.resetsAtDate,
+            sonnetResetDate: usage.lastUsage?.sevenDaySonnet?.resetsAtDate,
+            designResetDate: usage.lastUsage?.sevenDayDesign?.resetsAtDate,
+            hasFiveHourBucket: usage.lastUsage?.fiveHour != nil,
+            resetTextColorHex: settings.resetTextColorHex,
+            sessionPeriodColorHex: settings.sessionPeriodColorHex,
+            smartResetColor: settings.smartColorEnabled,
+            smartColorProfile: settings.smartColorProfile,
+            pacingMargin: Double(settings.pacingMargin),
+            designPct: usage.designPct,
+            hasDesign: usage.hasDesign,
+            fablePct: usage.fablePct,
+            hasFable: usage.hasFable,
+            fableResetDate: usage.lastUsage?.sevenDayFable?.resetsAtDate,
+            outageActive: settings.statusShowMenuBarBadge && vendor.isDegraded,
+            outageHealth: vendor.worstHealth,
+            nextPollSeconds: vendor.nextPollDate.map { max(0, Int(ceil($0.timeIntervalSinceNow))) },
+            extraCreditsPct: usage.extraCreditsPct,
+            hasExtraCredits: usage.hasExtraCredits
+        )
+    }
+}

--- a/TokenEaterApp/App/StatusBarController.swift
+++ b/TokenEaterApp/App/StatusBarController.swift
@@ -120,7 +120,7 @@ final class StatusBarController: NSObject {
         Timer.publish(every: 60, on: .main, in: .common).autoconnect()
             .sink { [weak self] _ in
                 guard let self,
-                      self.settingsStore.pinnedMetrics.contains(.sessionReset) else { return }
+                      self.settingsStore.menuBarComposition.visibleSegments.contains(where: { $0.kind == .sessionReset }) else { return }
                 self.usageStore.refreshResetCountdown()
             }
             .store(in: &cancellables)
@@ -308,52 +308,9 @@ final class StatusBarController: NSObject {
     // MARK: - Menu Bar Icon
 
     private func updateMenuBarIcon() {
-        let image = MenuBarRenderer.render(MenuBarRenderer.RenderData(
-            pinnedMetrics: settingsStore.pinnedMetrics,
-            displaySonnet: settingsStore.displaySonnet,
-            fiveHourPct: usageStore.fiveHourPct,
-            sevenDayPct: usageStore.sevenDayPct,
-            sonnetPct: usageStore.sonnetPct,
-            weeklyPacingDelta: Int(usageStore.pacingResult?.delta ?? 0),
-            weeklyPacingZone: usageStore.pacingResult?.zone ?? .onTrack,
-            hasWeeklyPacing: usageStore.pacingResult != nil,
-            sessionPacingDelta: Int(usageStore.fiveHourPacing?.delta ?? 0),
-            sessionPacingZone: usageStore.fiveHourPacing?.zone ?? .onTrack,
-            hasSessionPacing: usageStore.fiveHourPacing != nil,
-            sessionPacingDisplayMode: settingsStore.sessionPacingDisplayMode,
-            weeklyPacingDisplayMode: settingsStore.weeklyPacingDisplayMode,
-            hasConfig: usageStore.hasConfig,
-            hasError: usageStore.hasError,
-            isAwaitingRefresh: usageStore.isAwaitingRefresh,
-            themeColors: themeStore.current,
-            thresholds: themeStore.thresholds,
-            menuBarMonochrome: themeStore.menuBarMonochrome,
-            fiveHourReset: usageStore.fiveHourReset,
-            fiveHourResetAbsolute: usageStore.fiveHourResetAbsolute,
-            fiveHourResetDate: usageStore.lastUsage?.fiveHour?.resetsAtDate,
-            sevenDayResetDate: usageStore.lastUsage?.sevenDay?.resetsAtDate,
-            sonnetResetDate: usageStore.lastUsage?.sevenDaySonnet?.resetsAtDate,
-            designResetDate: usageStore.lastUsage?.sevenDayDesign?.resetsAtDate,
-            hasFiveHourBucket: usageStore.lastUsage?.fiveHour != nil,
-            resetDisplayFormat: settingsStore.resetDisplayFormat,
-            resetTextColorHex: settingsStore.resetTextColorHex,
-            sessionPeriodColorHex: settingsStore.sessionPeriodColorHex,
-            smartResetColor: settingsStore.smartColorEnabled,
-            smartColorProfile: settingsStore.smartColorProfile,
-            pacingMargin: Double(settingsStore.pacingMargin),
-            menuBarStyle: settingsStore.menuBarStyle,
-            pacingShape: settingsStore.pacingShape,
-            designPct: usageStore.designPct,
-            hasDesign: usageStore.hasDesign,
-            fablePct: usageStore.fablePct,
-            hasFable: usageStore.hasFable,
-            fableResetDate: usageStore.lastUsage?.sevenDayFable?.resetsAtDate,
-            outageActive: settingsStore.statusShowMenuBarBadge && vendorStatusStore.isDegraded,
-            outageHealth: vendorStatusStore.worstHealth,
-            nextPollSeconds: vendorStatusStore.nextPollDate.map { max(0, Int(ceil($0.timeIntervalSinceNow))) },
-            extraCreditsPct: usageStore.extraCreditsPct,
-            hasExtraCredits: usageStore.hasExtraCredits
-        ))
+        let image = MenuBarRenderer.render(
+            .live(usage: usageStore, theme: themeStore, settings: settingsStore, vendor: vendorStatusStore)
+        )
         statusItem.button?.image = image
     }
 
@@ -361,7 +318,8 @@ final class StatusBarController: NSObject {
     /// menu-bar countdown ticks without waking the CPU every second otherwise.
     private func updateCountdownTimer() {
         let badgeCountdown = settingsStore.statusShowMenuBarBadge && vendorStatusStore.isDegraded
-        let pinCountdown = settingsStore.pinnedMetrics.contains(.serviceStatus) && vendorStatusStore.worstHealth == .down
+        let hasStatusSegment = settingsStore.menuBarComposition.visibleSegments.contains { $0.kind == .serviceStatus }
+        let pinCountdown = hasStatusSegment && vendorStatusStore.worstHealth == .down
         let active = badgeCountdown || pinCountdown
         if active, countdownCancellable == nil {
             countdownCancellable = Timer.publish(every: 1, on: .main, in: .common)

--- a/TokenEaterApp/Settings/DisplaySectionView.swift
+++ b/TokenEaterApp/Settings/DisplaySectionView.swift
@@ -5,34 +5,6 @@ struct DisplaySectionView: View {
     @EnvironmentObject private var themeStore: ThemeStore
     @EnvironmentObject private var usageStore: UsageStore
 
-    // Local @State bindings - stable across body re-evaluations.
-    // Binding to computed properties via $store.computedProp creates
-    // unstable LocationProjections that the AttributeGraph can never
-    // memoize, causing an infinite re-evaluation loop in Release builds.
-    @State private var showFiveHour: Bool
-    @State private var showSessionReset: Bool
-    @State private var showSessionPacing: Bool
-    @State private var showSevenDay: Bool
-    @State private var showWeeklyPacing: Bool
-    @State private var showSonnet: Bool
-    @State private var showDesign: Bool
-    @State private var showFable: Bool
-    @State private var showServiceStatus: Bool
-    @State private var showExtraCredits: Bool
-
-    init(initialMetrics: Set<MetricID>) {
-        _showFiveHour = State(initialValue: initialMetrics.contains(.fiveHour))
-        _showSessionReset = State(initialValue: initialMetrics.contains(.sessionReset))
-        _showSessionPacing = State(initialValue: initialMetrics.contains(.sessionPacing))
-        _showSevenDay = State(initialValue: initialMetrics.contains(.sevenDay))
-        _showWeeklyPacing = State(initialValue: initialMetrics.contains(.weeklyPacing))
-        _showSonnet = State(initialValue: initialMetrics.contains(.sonnet))
-        _showDesign = State(initialValue: initialMetrics.contains(.design))
-        _showFable = State(initialValue: initialMetrics.contains(.fable))
-        _showServiceStatus = State(initialValue: initialMetrics.contains(.serviceStatus))
-        _showExtraCredits = State(initialValue: initialMetrics.contains(.extraCredits))
-    }
-
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
             VStack(alignment: .leading, spacing: 18) {
@@ -53,8 +25,7 @@ struct DisplaySectionView: View {
                     }
                 }
 
-                chromeGroup
-                pinGroup
+                MenuBarEditorView()
                 colorsGroup
 
                 ResetSectionButton(
@@ -67,205 +38,13 @@ struct DisplaySectionView: View {
             }
             .padding(24)
         }
-        // Sync: local toggle -> store (with at-least-one guard)
-        .onChange(of: showFiveHour) { _, new in syncMetric(.fiveHour, on: new, revert: { showFiveHour = true }) }
-        .onChange(of: showSessionReset) { _, new in
-            withAnimation(.easeInOut(duration: 0.2)) {
-                syncMetric(.sessionReset, on: new, revert: { showSessionReset = true })
-            }
-        }
-        .onChange(of: showSessionPacing) { _, new in
-            withAnimation(.easeInOut(duration: 0.2)) {
-                syncMetric(.sessionPacing, on: new, revert: { showSessionPacing = true })
-            }
-        }
-        .onChange(of: showSevenDay) { _, new in syncMetric(.sevenDay, on: new, revert: { showSevenDay = true }) }
-        .onChange(of: showWeeklyPacing) { _, new in
-            withAnimation(.easeInOut(duration: 0.2)) {
-                syncMetric(.weeklyPacing, on: new, revert: { showWeeklyPacing = true })
-            }
-        }
-        .onChange(of: showSonnet) { _, new in syncMetric(.sonnet, on: new, revert: { showSonnet = true }) }
-        .onChange(of: showDesign) { _, new in syncMetric(.design, on: new, revert: { showDesign = true }) }
-        .onChange(of: showFable) { _, new in syncMetric(.fable, on: new, revert: { showFable = true }) }
-        .onChange(of: showServiceStatus) { _, new in syncMetric(.serviceStatus, on: new, revert: { showServiceStatus = true }) }
-        .onChange(of: showExtraCredits) { _, new in syncMetric(.extraCredits, on: new, revert: { showExtraCredits = true }) }
-        // Sync: store -> local toggles (external changes, e.g. pin/unpin from popover)
-        .onChange(of: settingsStore.pinnedMetrics) { _, metrics in
-            if showFiveHour != metrics.contains(.fiveHour) { showFiveHour = metrics.contains(.fiveHour) }
-            if showSessionReset != metrics.contains(.sessionReset) {
-                withAnimation(.easeInOut(duration: 0.2)) { showSessionReset = metrics.contains(.sessionReset) }
-            }
-            if showSessionPacing != metrics.contains(.sessionPacing) {
-                withAnimation(.easeInOut(duration: 0.2)) { showSessionPacing = metrics.contains(.sessionPacing) }
-            }
-            if showSevenDay != metrics.contains(.sevenDay) { showSevenDay = metrics.contains(.sevenDay) }
-            if showWeeklyPacing != metrics.contains(.weeklyPacing) {
-                withAnimation(.easeInOut(duration: 0.2)) { showWeeklyPacing = metrics.contains(.weeklyPacing) }
-            }
-            if showSonnet != metrics.contains(.sonnet) { showSonnet = metrics.contains(.sonnet) }
-            if showServiceStatus != metrics.contains(.serviceStatus) { showServiceStatus = metrics.contains(.serviceStatus) }
-            if showExtraCredits != metrics.contains(.extraCredits) { showExtraCredits = metrics.contains(.extraCredits) }
-        }
-    }
-
-    // MARK: - Chrome group
-
-    private var chromeGroup: some View {
-        groupSection(title: "settings.group.chrome", subtitle: "settings.group.chrome.hint") {
-            VStack(alignment: .leading, spacing: 12) {
-                groupLabel("settings.menubar.style")
-                HStack(spacing: 8) {
-                    ForEach(MenuBarStyle.allCases) { style in
-                        menuBarStyleButton(style)
-                    }
-                }
-
-                groupLabel("settings.pacing.shape")
-                    .padding(.top, 4)
-                HStack(spacing: 8) {
-                    ForEach(PacingShape.allCases) { shape in
-                        pacingShapeButton(shape)
-                    }
-                }
-            }
-        }
-    }
-
-    // MARK: - Pin group
-
-    private var pinGroup: some View {
-        groupSection(title: "settings.group.pin", subtitle: "settings.group.pin.hint") {
-            VStack(alignment: .leading, spacing: 10) {
-                // Lane 1 : simple metric pins, no sub-options. 2-column compact grid.
-                LazyVGrid(columns: [GridItem(.flexible(), spacing: 8), GridItem(.flexible(), spacing: 8)], spacing: 8) {
-                    MetricPinChip(
-                        label: String(localized: "metric.session"),
-                        icon: "bolt.fill",
-                        isActive: showFiveHour,
-                        accent: .orange
-                    ) { showFiveHour.toggle() }
-
-                    MetricPinChip(
-                        label: String(localized: "metric.weekly"),
-                        icon: "calendar",
-                        isActive: showSevenDay,
-                        accent: .blue
-                    ) { showSevenDay.toggle() }
-
-                    MetricPinChip(
-                        label: String(localized: "metric.sonnet"),
-                        icon: "quote.opening",
-                        isActive: showSonnet,
-                        accent: .green
-                    ) { showSonnet.toggle() }
-
-                    if usageStore.hasDesign {
-                        MetricPinChip(
-                            label: String(localized: "metric.design"),
-                            icon: "paintbrush.pointed.fill",
-                            isActive: showDesign,
-                            accent: .purple
-                        ) { showDesign.toggle() }
-                    }
-
-                    if usageStore.hasFable {
-                        MetricPinChip(
-                            label: String(localized: "metric.fable"),
-                            icon: "books.vertical.fill",
-                            isActive: showFable,
-                            accent: .pink
-                        ) { showFable.toggle() }
-                    }
-
-                    MetricPinChip(
-                        label: String(localized: "metric.serviceStatus"),
-                        icon: "dot.radiowaves.left.and.right",
-                        isActive: showServiceStatus,
-                        accent: .teal
-                    ) { showServiceStatus.toggle() }
-
-                    if usageStore.hasExtraCredits {
-                        MetricPinChip(
-                            label: String(localized: "metric.extraCredits"),
-                            icon: "creditcard.fill",
-                            isActive: showExtraCredits,
-                            accent: .yellow
-                        ) { showExtraCredits.toggle() }
-                    }
-                }
-
-                // Lane 2 : pins that carry secondary options. Full-width rows
-                // so the option picker sits comfortably to the right of the
-                // chip without overlapping the next pin.
-                expandingPinRow(
-                    label: String(localized: "metric.sessionReset"),
-                    icon: "clock.arrow.circlepath",
-                    isActive: showSessionReset,
-                    accent: .cyan,
-                    onToggle: { showSessionReset.toggle() }
-                ) {
-                    HStack(spacing: 6) {
-                        Text(String(localized: "settings.metric.format"))
-                            .font(.system(size: 10, weight: .semibold))
-                            .tracking(0.4)
-                            .foregroundStyle(.white.opacity(0.45))
-                        ResetFormatPicker(selection: $settingsStore.display.resetDisplayFormat)
-                            .labelsHidden()
-                            .frame(maxWidth: 170)
-                    }
-                }
-
-                expandingPinRow(
-                    label: String(localized: "pacing.session.label"),
-                    icon: "speedometer",
-                    isActive: showSessionPacing,
-                    accent: .pink,
-                    onToggle: { showSessionPacing.toggle() }
-                ) {
-                    PacingDisplayPicker(selection: $settingsStore.display.sessionPacingDisplayMode)
-                        .labelsHidden()
-                }
-
-                expandingPinRow(
-                    label: String(localized: "pacing.weekly.label"),
-                    icon: "speedometer",
-                    isActive: showWeeklyPacing,
-                    accent: .pink,
-                    onToggle: { showWeeklyPacing.toggle() }
-                ) {
-                    PacingDisplayPicker(selection: $settingsStore.display.weeklyPacingDisplayMode)
-                        .labelsHidden()
-                }
-            }
-        }
-    }
-
-    /// Full-width pin row with the chip on the left and its option picker on
-    /// the right. Picker is rendered as a faint inset that lights up when the
-    /// chip is active. Avoids the staircase effect we'd get if the picker
-    /// hung below in a 2-col grid.
-    @ViewBuilder
-    private func expandingPinRow<Picker: View>(
-        label: String,
-        icon: String,
-        isActive: Bool,
-        accent: Color,
-        onToggle: @escaping () -> Void,
-        @ViewBuilder picker: () -> Picker
-    ) -> some View {
-        HStack(spacing: 10) {
-            MetricPinChip(label: label, icon: icon, isActive: isActive, accent: accent, action: onToggle)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            picker()
-                .opacity(isActive ? 1 : 0.35)
-                .allowsHitTesting(isActive)
-                .layoutPriority(1)
-        }
     }
 
     // MARK: - Colors group
 
+    /// Global menu bar colour mode (monochrome vs theme palette) plus the two
+    /// hex overrides. These stay global - the composable segments carry layout,
+    /// not colour; colour still comes from the theme / smart-colour system.
     private var colorsGroup: some View {
         groupSection(title: "settings.group.colors", subtitle: "settings.group.colors.hint") {
             VStack(alignment: .leading, spacing: 12) {
@@ -341,42 +120,6 @@ struct DisplaySectionView: View {
         )
     }
 
-    private func groupLabel(_ key: String.LocalizationValue) -> some View {
-        Text(String(localized: key))
-            .font(.system(size: 10, weight: .semibold))
-            .tracking(0.6)
-            .foregroundStyle(.white.opacity(0.45))
-    }
-
-    private func pacingShapeButton(_ shape: PacingShape) -> some View {
-        let isActive = settingsStore.pacingShape == shape
-        return Button {
-            withAnimation(.easeInOut(duration: 0.12)) {
-                settingsStore.pacingShape = shape
-            }
-        } label: {
-            VStack(spacing: 6) {
-                Text(shape.glyph)
-                    .font(.system(size: 20, weight: .bold))
-                    .foregroundStyle(isActive ? .white : .white.opacity(0.55))
-                Text(shape.localizedLabel)
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(isActive ? .white.opacity(0.9) : .white.opacity(0.5))
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 10)
-            .background(
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(isActive ? Color.blue.opacity(0.2) : Color.white.opacity(0.03))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 10)
-                            .stroke(isActive ? Color.blue.opacity(0.5) : Color.white.opacity(0.06), lineWidth: 1)
-                    )
-            )
-        }
-        .buttonStyle(.plain)
-    }
-
     /// Menu-bar text color row -> empty hex falls back to a system color and
     /// shows a revert-to-default button when the user has picked a custom color.
     private func menuBarColorRow(
@@ -417,61 +160,15 @@ struct DisplaySectionView: View {
         }
     }
 
-    private func menuBarStyleButton(_ style: MenuBarStyle) -> some View {
-        let isActive = settingsStore.menuBarStyle == style
-        return Button {
-            withAnimation(.easeInOut(duration: 0.12)) {
-                settingsStore.menuBarStyle = style
-            }
-        } label: {
-            Text(style.localizedLabel)
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(isActive ? .white : .white.opacity(0.55))
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 8)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(isActive ? Color.blue.opacity(0.2) : Color.white.opacity(0.03))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 8)
-                                .stroke(isActive ? Color.blue.opacity(0.5) : Color.white.opacity(0.06), lineWidth: 1)
-                        )
-                )
-        }
-        .buttonStyle(.plain)
-    }
-
+    /// Reset the menu bar to the Classic composition and clear the colour
+    /// overrides. Monochrome lives in ThemeStore and is reset separately by
+    /// the Themes section.
     private func resetDisplayDefaults() {
-        // Pinned metrics: bring back the canonical "session + weekly + session pacing" combo.
-        settingsStore.pinnedMetrics = [.fiveHour, .sevenDay, .sessionPacing]
-        settingsStore.menuBarStyle = .classic
-        settingsStore.pacingShape = .circle
-        settingsStore.sessionPacingDisplayMode = .dotDelta
-        settingsStore.weeklyPacingDisplayMode = .dotDelta
-        settingsStore.resetDisplayFormat = .relative
+        withAnimation(.spring(response: 0.32, dampingFraction: 0.85)) {
+            settingsStore.menuBarComposition = MenuBarBuiltinTemplate.classic.composition
+        }
         settingsStore.resetTextColorHex = ""
         settingsStore.sessionPeriodColorHex = ""
-        // Local @State mirrors so the toggle UI reflects the reset immediately.
-        showFiveHour = settingsStore.pinnedMetrics.contains(.fiveHour)
-        showSessionReset = settingsStore.pinnedMetrics.contains(.sessionReset)
-        showSessionPacing = settingsStore.pinnedMetrics.contains(.sessionPacing)
-        showSevenDay = settingsStore.pinnedMetrics.contains(.sevenDay)
-        showSonnet = settingsStore.pinnedMetrics.contains(.sonnet)
-        showWeeklyPacing = settingsStore.pinnedMetrics.contains(.weeklyPacing)
-        showDesign = settingsStore.pinnedMetrics.contains(.design)
-        showFable = settingsStore.pinnedMetrics.contains(.fable)
-        showServiceStatus = settingsStore.pinnedMetrics.contains(.serviceStatus)
-        showExtraCredits = settingsStore.pinnedMetrics.contains(.extraCredits)
-    }
-
-    private func syncMetric(_ metric: MetricID, on: Bool, revert: @escaping () -> Void) {
-        if on {
-            settingsStore.pinnedMetrics.insert(metric)
-        } else if settingsStore.pinnedMetrics.count > 1 {
-            settingsStore.pinnedMetrics.remove(metric)
-        } else {
-            revert()
-        }
     }
 }
 
@@ -527,54 +224,6 @@ struct ClickChip: View {
     }
 }
 
-/// Pin chip for the "What to pin" group. Single-action click target; subsidiary
-/// option pickers live as siblings (see `expandingPinRow` in DisplaySectionView)
-/// rather than embedded children, which avoids the staircase effect a
-/// per-cell expansion would create inside a LazyVGrid.
-struct MetricPinChip: View {
-    let label: String
-    let icon: String
-    let isActive: Bool
-    let accent: Color
-    let action: () -> Void
-
-    @State private var hovering = false
-
-    var body: some View {
-        Button(action: action) {
-            HStack(spacing: 8) {
-                Image(systemName: icon)
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(isActive ? accent : .white.opacity(0.5))
-                    .frame(width: 18)
-                Text(label)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(isActive ? .white : .white.opacity(0.65))
-                Spacer(minLength: 0)
-                Image(systemName: isActive ? "checkmark" : "plus")
-                    .font(.system(size: 10, weight: .bold))
-                    .foregroundStyle(isActive ? accent : .white.opacity(0.35))
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(isActive ? accent.opacity(0.14) : Color.white.opacity(0.03))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 10)
-                            .stroke(isActive ? accent.opacity(0.5) : Color.white.opacity(0.07), lineWidth: 1)
-                    )
-            )
-            .scaleEffect(hovering ? 1.01 : 1.0)
-            .animation(.spring(response: 0.25, dampingFraction: 0.85), value: hovering)
-            .contentShape(RoundedRectangle(cornerRadius: 10))
-        }
-        .buttonStyle(.plain)
-        .onHover { hovering = $0 }
-    }
-}
-
 /// Radio-style chip for binary choices (e.g., monochrome vs custom colors).
 /// Different from ClickChip because it expects to live in a sibling pair
 /// where exactly one is active.
@@ -614,4 +263,3 @@ struct BinaryChoiceChip: View {
         .onHover { hovering = $0 }
     }
 }
-

--- a/TokenEaterApp/Settings/MenuBarEditorView.swift
+++ b/TokenEaterApp/Settings/MenuBarEditorView.swift
@@ -297,32 +297,37 @@ private struct MenuBarLivePreview: View {
                 .foregroundStyle(.white.opacity(0.4)).tracking(1)
                 .frame(maxWidth: .infinity)
 
-            ZStack(alignment: .topLeading) {
-                Image(nsImage: rendered.image)
-                    .resizable()
-                    .frame(width: w, height: h)
+            // A wide composition can overflow the pane; let it scroll
+            // horizontally instead of clipping the rightmost segment.
+            ScrollView(.horizontal, showsIndicators: false) {
+                ZStack(alignment: .topLeading) {
+                    Image(nsImage: rendered.image)
+                        .resizable()
+                        .frame(width: w, height: h)
 
-                ForEach(rendered.hitRects, id: \.id) { hit in
-                    let x = hit.rect.minX * scale
-                    let cw = hit.rect.width * scale
-                    ZStack {
-                        if selectedSegmentID == hit.id {
-                            RoundedRectangle(cornerRadius: 5)
-                                .stroke(Color.blue, lineWidth: 1.5)
-                                .background(RoundedRectangle(cornerRadius: 5).fill(Color.blue.opacity(0.12)))
+                    ForEach(rendered.hitRects, id: \.id) { hit in
+                        let x = hit.rect.minX * scale
+                        let cw = hit.rect.width * scale
+                        ZStack {
+                            if selectedSegmentID == hit.id {
+                                RoundedRectangle(cornerRadius: 5)
+                                    .stroke(Color.blue, lineWidth: 1.5)
+                                    .background(RoundedRectangle(cornerRadius: 5).fill(Color.blue.opacity(0.12)))
+                            }
+                            Color.clear.contentShape(Rectangle())
                         }
-                        Color.clear.contentShape(Rectangle())
-                    }
-                    .frame(width: cw, height: h)
-                    .offset(x: x)
-                    .onTapGesture {
-                        withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) {
-                            selectedSegmentID = (selectedSegmentID == hit.id) ? nil : hit.id
+                        .frame(width: cw, height: h)
+                        .offset(x: x)
+                        .onTapGesture {
+                            withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) {
+                                selectedSegmentID = (selectedSegmentID == hit.id) ? nil : hit.id
+                            }
                         }
                     }
                 }
+                .frame(width: w, height: h)
             }
-            .frame(width: w, height: h)
+            .frame(maxWidth: w)
             .padding(.horizontal, 14)
             .padding(.vertical, 10)
             .background(
@@ -332,7 +337,10 @@ private struct MenuBarLivePreview: View {
             )
             .environment(\.colorScheme, .dark)
 
-            Text(String(localized: rendered.hitRects.isEmpty ? "menuBar.editor.empty" : "menuBar.editor.preview.hint"))
+            // Key the hint off the composition, not the rendered hit-rects:
+            // the preview also shows the logo (no hit-rects) during an
+            // error / no-config state, where segments may still be configured.
+            Text(String(localized: settingsStore.menuBarComposition.visibleSegments.isEmpty ? "menuBar.editor.empty" : "menuBar.editor.preview.hint"))
                 .font(.system(size: 9))
                 .foregroundStyle(.white.opacity(0.3))
                 .frame(maxWidth: .infinity)

--- a/TokenEaterApp/Settings/MenuBarEditorView.swift
+++ b/TokenEaterApp/Settings/MenuBarEditorView.swift
@@ -1,0 +1,551 @@
+import SwiftUI
+
+/// Composable menu bar editor: template gallery, a reorderable segment list
+/// (the single source of edition), and a live NSImage preview whose segments
+/// are clickable (click a segment to select its row). Writes go to
+/// `settingsStore.menuBarComposition`, which both this view and the status bar
+/// observe. Unlike the popover, an empty menu bar is legitimate (the renderer
+/// draws the app icon), so there is no "can't remove the last one" guard.
+struct MenuBarEditorView: View {
+    @EnvironmentObject private var settingsStore: SettingsStore
+    @EnvironmentObject private var usageStore: UsageStore
+
+    @State private var selectedSegmentID: UUID?
+    @State private var showSaveDialog = false
+    @State private var templateName = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            MenuBarLivePreview(selectedSegmentID: $selectedSegmentID)
+
+            templatesSection
+            segmentsSection
+        }
+        .alert(String(localized: "menuBar.editor.saveTemplate"), isPresented: $showSaveDialog) {
+            TextField(String(localized: "menuBar.editor.saveTemplate.placeholder"), text: $templateName)
+            Button(String(localized: "menuBar.editor.save")) { saveCurrentAsTemplate() }
+                .disabled(templateName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            Button(String(localized: "menuBar.editor.cancel"), role: .cancel) { templateName = "" }
+        } message: {
+            Text(String(localized: "menuBar.editor.saveTemplate.message"))
+        }
+    }
+
+    // MARK: - Templates
+
+    private var templatesSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            editorLabel("menuBar.editor.templates")
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(MenuBarBuiltinTemplate.allCases) { template in
+                        MenuBarTemplateCard(name: template.localizedName, composition: template.composition) {
+                            apply(template.composition)
+                        }
+                    }
+                    ForEach(settingsStore.menuBarUserTemplates) { template in
+                        MenuBarTemplateCard(name: template.name, composition: template.composition, isUserTemplate: true) {
+                            apply(template.composition)
+                        }
+                        .contextMenu {
+                            Button(role: .destructive) {
+                                settingsStore.menuBarUserTemplates.removeAll { $0.id == template.id }
+                            } label: {
+                                Label(String(localized: "menuBar.editor.deleteTemplate"), systemImage: "trash")
+                            }
+                        }
+                    }
+                    saveTemplateCard
+                }
+                .padding(.vertical, 2)
+            }
+        }
+    }
+
+    private var saveTemplateCard: some View {
+        Button {
+            templateName = ""
+            showSaveDialog = true
+        } label: {
+            VStack(spacing: 6) {
+                Image(systemName: "plus")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.5))
+                Text(String(localized: "menuBar.editor.saveTemplate.short"))
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.5))
+                    .multilineTextAlignment(.center)
+            }
+            .frame(width: 88, height: 62)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color.white.opacity(0.02))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .strokeBorder(Color.white.opacity(0.12), style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func apply(_ composition: MenuBarComposition) {
+        withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) {
+            settingsStore.menuBarComposition = composition
+        }
+        selectedSegmentID = nil
+    }
+
+    private func saveCurrentAsTemplate() {
+        let trimmed = templateName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        var name = trimmed
+        var counter = 2
+        while settingsStore.menuBarUserTemplates.contains(where: { $0.name == name }) {
+            name = "\(trimmed) \(counter)"
+            counter += 1
+        }
+        settingsStore.menuBarUserTemplates.append(
+            MenuBarUserTemplate(name: name, composition: settingsStore.menuBarComposition)
+        )
+        templateName = ""
+    }
+
+    // MARK: - Segments
+
+    private var segmentsSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                editorLabel("menuBar.editor.segments")
+                Spacer()
+                addSegmentMenu
+            }
+            MenuBarSegmentListEditor(selectedSegmentID: $selectedSegmentID)
+        }
+    }
+
+    private var addSegmentMenu: some View {
+        Menu {
+            Section(String(localized: "menuBar.editor.family.metrics")) {
+                let metricKinds: [MenuBarSegmentKind] = [.session, .weekly, .sonnet, .design, .fable, .extraCredits]
+                ForEach(metricKinds) { addButton(for: $0) }
+            }
+            Section(String(localized: "menuBar.editor.family.pacing")) {
+                addButton(for: .sessionPacing)
+                addButton(for: .weeklyPacing)
+            }
+            Section(String(localized: "menuBar.editor.family.status")) {
+                addButton(for: .sessionReset)
+                addButton(for: .serviceStatus)
+            }
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "plus").font(.system(size: 9, weight: .bold))
+                Text(String(localized: "menuBar.editor.addSegment")).font(.system(size: 11, weight: .semibold))
+            }
+            .foregroundStyle(.white.opacity(0.85))
+            .padding(.horizontal, 10).padding(.vertical, 5)
+            .background(Capsule().fill(Color.blue.opacity(0.18)).overlay(Capsule().stroke(Color.blue.opacity(0.45), lineWidth: 1)))
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+    }
+
+    @ViewBuilder
+    private func addButton(for kind: MenuBarSegmentKind) -> some View {
+        let available = accountHasKind(kind)
+        Button {
+            addSegment(kind)
+        } label: {
+            Label(
+                available ? kind.localizedLabel
+                    : "\(kind.localizedLabel) (\(String(localized: "menuBar.editor.unavailable")))",
+                systemImage: kind.symbolName
+            )
+        }
+        .disabled(!available)
+    }
+
+    private func accountHasKind(_ kind: MenuBarSegmentKind) -> Bool {
+        switch kind {
+        case .design: return usageStore.hasDesign
+        case .fable: return usageStore.hasFable
+        case .extraCredits: return usageStore.hasExtraCredits
+        default: return true
+        }
+    }
+
+    private func addSegment(_ kind: MenuBarSegmentKind) {
+        let style = kind.allowedStyles.first ?? .text
+        let segment = MenuBarSegment(kind: kind, style: style)
+        withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) {
+            settingsStore.menuBarComposition.segments.insert(segment, at: 0)
+        }
+        selectedSegmentID = segment.id
+    }
+
+    private func editorLabel(_ key: String.LocalizationValue) -> some View {
+        Text(String(localized: key))
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(.white.opacity(0.5))
+            .textCase(.uppercase)
+            .tracking(0.8)
+    }
+}
+
+// MARK: - Template card
+
+private struct MenuBarTemplateCard: View {
+    let name: String
+    let composition: MenuBarComposition
+    var isUserTemplate: Bool = false
+    let onApply: () -> Void
+
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: onApply) {
+            VStack(spacing: 7) {
+                MenuBarTemplateSchematic(composition: composition, highlighted: hovering)
+                    .frame(height: 20)
+                HStack(spacing: 3) {
+                    if isUserTemplate {
+                        Image(systemName: "person.fill").font(.system(size: 7)).foregroundStyle(.white.opacity(0.4))
+                    }
+                    Text(name).font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(hovering ? .white : .white.opacity(0.65)).lineLimit(1)
+                }
+            }
+            .padding(8)
+            .frame(width: 88, height: 62)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(hovering ? Color.blue.opacity(0.12) : Color.white.opacity(0.03))
+                    .overlay(RoundedRectangle(cornerRadius: 12).stroke(hovering ? Color.blue.opacity(0.5) : Color.white.opacity(0.07), lineWidth: 1))
+            )
+            .scaleEffect(hovering ? 1.02 : 1.0)
+        }
+        .buttonStyle(.plain)
+        .onHover { h in withAnimation(.spring(response: 0.25, dampingFraction: 0.85)) { hovering = h } }
+    }
+}
+
+/// Horizontal strip of little chips, one per visible segment, hinting at the
+/// composition shape. Pills draw rounded, text segments squared.
+private struct MenuBarTemplateSchematic: View {
+    let composition: MenuBarComposition
+    let highlighted: Bool
+
+    var body: some View {
+        HStack(spacing: 3) {
+            ForEach(Array(composition.visibleSegments.prefix(6).enumerated()), id: \.offset) { _, segment in
+                RoundedRectangle(cornerRadius: segment.effectiveStyle == .pill ? 5 : 2)
+                    .fill(highlighted ? Color.blue.opacity(0.55) : Color.white.opacity(0.22))
+                    .frame(width: chipWidth(segment), height: 10)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func chipWidth(_ segment: MenuBarSegment) -> CGFloat {
+        switch segment.effectiveStyle {
+        case .dot, .glyph: return 8
+        case .valueOnly, .delta: return 12
+        default: return 18
+        }
+    }
+}
+
+// MARK: - Live preview (NSImage + click-to-select)
+
+private struct MenuBarLivePreview: View {
+    @EnvironmentObject private var usageStore: UsageStore
+    @EnvironmentObject private var themeStore: ThemeStore
+    @EnvironmentObject private var settingsStore: SettingsStore
+    @EnvironmentObject private var vendorStatusStore: VendorStatusStore
+
+    @Binding var selectedSegmentID: UUID?
+
+    private let scale: CGFloat = 2
+
+    var body: some View {
+        let data = MenuBarRenderer.RenderData.live(
+            usage: usageStore, theme: themeStore, settings: settingsStore, vendor: vendorStatusStore
+        )
+        let rendered = MenuBarRenderer.renderWithHitRects(data)
+        let w = rendered.image.size.width * scale
+        let h = rendered.image.size.height * scale
+
+        return VStack(spacing: 6) {
+            Text(String(localized: "menuBar.editor.preview"))
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.4)).tracking(1)
+                .frame(maxWidth: .infinity)
+
+            ZStack(alignment: .topLeading) {
+                Image(nsImage: rendered.image)
+                    .resizable()
+                    .frame(width: w, height: h)
+
+                ForEach(rendered.hitRects, id: \.id) { hit in
+                    let x = hit.rect.minX * scale
+                    let cw = hit.rect.width * scale
+                    ZStack {
+                        if selectedSegmentID == hit.id {
+                            RoundedRectangle(cornerRadius: 5)
+                                .stroke(Color.blue, lineWidth: 1.5)
+                                .background(RoundedRectangle(cornerRadius: 5).fill(Color.blue.opacity(0.12)))
+                        }
+                        Color.clear.contentShape(Rectangle())
+                    }
+                    .frame(width: cw, height: h)
+                    .offset(x: x)
+                    .onTapGesture {
+                        withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) {
+                            selectedSegmentID = (selectedSegmentID == hit.id) ? nil : hit.id
+                        }
+                    }
+                }
+            }
+            .frame(width: w, height: h)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color(nsColor: NSColor(red: 0.13, green: 0.13, blue: 0.14, alpha: 1)))
+                    .overlay(RoundedRectangle(cornerRadius: 10).stroke(.white.opacity(0.08), lineWidth: 0.5))
+            )
+            .environment(\.colorScheme, .dark)
+
+            Text(String(localized: rendered.hitRects.isEmpty ? "menuBar.editor.empty" : "menuBar.editor.preview.hint"))
+                .font(.system(size: 9))
+                .foregroundStyle(.white.opacity(0.3))
+                .frame(maxWidth: .infinity)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+// MARK: - Segment list
+
+private struct MenuBarSegmentListEditor: View {
+    @EnvironmentObject private var settingsStore: SettingsStore
+    @EnvironmentObject private var usageStore: UsageStore
+
+    @Binding var selectedSegmentID: UUID?
+    @State private var draggingID: UUID?
+
+    var body: some View {
+        VStack(spacing: 8) {
+            if settingsStore.menuBarComposition.segments.isEmpty {
+                emptyHint
+            } else {
+                segmentRows
+            }
+        }
+        .onDrop(of: [.text], delegate: ReorderGapDropDelegate(draggingID: $draggingID))
+    }
+
+    private var emptyHint: some View {
+        Text(String(localized: "menuBar.editor.emptyList"))
+            .font(.system(size: 11))
+            .foregroundStyle(.white.opacity(0.4))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 8)
+    }
+
+    private var segmentRows: some View {
+        ForEach(settingsStore.menuBarComposition.segments) { segment in
+            MenuBarSegmentRow(
+                segment: segment,
+                isSelected: selectedSegmentID == segment.id,
+                isDragging: draggingID == segment.id,
+                isAvailable: isAvailable(segment.kind),
+                onSelect: {
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) {
+                        selectedSegmentID = (selectedSegmentID == segment.id) ? nil : segment.id
+                    }
+                },
+                onToggleHidden: { mutate(segment.id) { $0.isHidden.toggle() } },
+                onDelete: { delete(segment) },
+                onStyle: { style in setStyle(style, for: segment) },
+                onShape: { shape in mutate(segment.id) { $0.options.pacingShape = shape } },
+                onFormat: { format in mutate(segment.id) { $0.options.resetFormat = format } }
+            )
+            .id(segment.id)
+            .onDrag {
+                draggingID = segment.id
+                return NSItemProvider(object: segment.id.uuidString as NSString)
+            }
+            .onDrop(of: [.text], delegate: ReorderDropDelegate(item: segment.id, items: segmentsBinding, draggingID: $draggingID))
+        }
+    }
+
+    private var segmentsBinding: Binding<[MenuBarSegment]> {
+        $settingsStore.menuBarComposition.segments
+    }
+
+    private func isAvailable(_ kind: MenuBarSegmentKind) -> Bool {
+        switch kind {
+        case .design: return usageStore.hasDesign
+        case .fable: return usageStore.hasFable
+        case .extraCredits: return usageStore.hasExtraCredits
+        default: return true
+        }
+    }
+
+    private func mutate(_ id: UUID, _ transform: (inout MenuBarSegment) -> Void) {
+        guard let idx = settingsStore.menuBarComposition.segments.firstIndex(where: { $0.id == id }) else { return }
+        withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) {
+            transform(&settingsStore.menuBarComposition.segments[idx])
+        }
+    }
+
+    private func delete(_ segment: MenuBarSegment) {
+        if selectedSegmentID == segment.id { selectedSegmentID = nil }
+        withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) {
+            settingsStore.menuBarComposition.segments.removeAll { $0.id == segment.id }
+        }
+    }
+
+    private func setStyle(_ style: MenuBarSegmentStyle, for segment: MenuBarSegment) {
+        mutate(segment.id) { $0.style = style }
+    }
+}
+
+// MARK: - Segment row
+
+private struct MenuBarSegmentRow: View {
+    let segment: MenuBarSegment
+    let isSelected: Bool
+    let isDragging: Bool
+    let isAvailable: Bool
+    let onSelect: () -> Void
+    let onToggleHidden: () -> Void
+    let onDelete: () -> Void
+    let onStyle: (MenuBarSegmentStyle) -> Void
+    let onShape: (PacingShape) -> Void
+    let onFormat: (ResetDisplayFormat) -> Void
+
+    var body: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 10) {
+                Image(systemName: "line.3.horizontal")
+                    .font(.system(size: 12, weight: .semibold)).foregroundStyle(.white.opacity(0.35)).frame(width: 14)
+                Image(systemName: segment.kind.symbolName)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(segment.isHidden ? .white.opacity(0.3) : .white.opacity(0.7)).frame(width: 16)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(segment.kind.localizedLabel)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(segment.isHidden ? .white.opacity(0.35) : .white.opacity(0.9)).lineLimit(1)
+                    if !isAvailable {
+                        Text(String(localized: "menuBar.editor.unavailable"))
+                            .font(.system(size: 9)).foregroundStyle(.orange.opacity(0.7))
+                    }
+                }
+                Spacer(minLength: 4)
+                Button(action: onToggleHidden) {
+                    Image(systemName: segment.isHidden ? "eye.slash.fill" : "eye.fill")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(segment.isHidden ? .white.opacity(0.35) : .blue)
+                        .frame(width: 20, height: 20).contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                Button(action: onDelete) {
+                    Image(systemName: "trash").font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.4)).frame(width: 20, height: 20).contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+
+            HStack(spacing: 8) {
+                if segment.kind.allowedStyles.count > 1 { styleMenu }
+                if segment.kind.family == .pacing { shapeMenu }
+                if segment.kind == .sessionReset { formatMenu }
+                Spacer(minLength: 0)
+            }
+            .padding(.leading, 24)
+        }
+        .padding(.vertical, 10).padding(.horizontal, 12)
+        .background(RoundedRectangle(cornerRadius: 10).fill(rowFill).shadow(color: isDragging ? .black.opacity(0.4) : .clear, radius: 10, y: 4))
+        .overlay(RoundedRectangle(cornerRadius: 10).stroke(rowStroke, lineWidth: 1))
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onSelect)
+        .scaleEffect(isDragging ? 1.02 : 1.0)
+        .opacity(isDragging ? 0.9 : 1.0)
+        .animation(.easeInOut(duration: 0.15), value: isDragging)
+        .animation(.easeInOut(duration: 0.15), value: isSelected)
+    }
+
+    private var rowFill: Color {
+        if isDragging { return Color.blue.opacity(0.12) }
+        if isSelected { return Color.blue.opacity(0.08) }
+        return segment.isHidden ? Color.white.opacity(0.015) : Color.white.opacity(0.04)
+    }
+
+    private var rowStroke: Color {
+        if isDragging || isSelected { return Color.blue.opacity(0.6) }
+        return segment.isHidden ? Color.white.opacity(0.04) : Color.white.opacity(0.08)
+    }
+
+    private var styleMenu: some View {
+        Menu {
+            ForEach(segment.kind.allowedStyles) { style in
+                Button {
+                    onStyle(style)
+                } label: {
+                    if style == segment.style { Label(style.localizedLabel, systemImage: "checkmark") }
+                    else { Text(style.localizedLabel) }
+                }
+            }
+        } label: {
+            pickerLabel(segment.effectiveStyle.localizedLabel)
+        }
+        .menuStyle(.borderlessButton).menuIndicator(.hidden).fixedSize()
+    }
+
+    private var shapeMenu: some View {
+        Menu {
+            ForEach(PacingShape.allCases) { shape in
+                Button {
+                    onShape(shape)
+                } label: {
+                    if shape == segment.options.pacingShape { Label("\(shape.glyph)  \(shape.localizedLabel)", systemImage: "checkmark") }
+                    else { Text("\(shape.glyph)  \(shape.localizedLabel)") }
+                }
+            }
+        } label: {
+            pickerLabel(segment.options.pacingShape.glyph)
+        }
+        .menuStyle(.borderlessButton).menuIndicator(.hidden).fixedSize()
+    }
+
+    private var formatMenu: some View {
+        Menu {
+            ForEach(ResetDisplayFormat.allCases) { format in
+                Button {
+                    onFormat(format)
+                } label: {
+                    if format == segment.options.resetFormat { Label(format.localizedLabel, systemImage: "checkmark") }
+                    else { Text(format.localizedLabel) }
+                }
+            }
+        } label: {
+            pickerLabel(segment.options.resetFormat.localizedLabel)
+        }
+        .menuStyle(.borderlessButton).menuIndicator(.hidden).fixedSize()
+    }
+
+    private func pickerLabel(_ text: String) -> some View {
+        HStack(spacing: 4) {
+            Text(text).font(.system(size: 10, weight: .semibold))
+            Image(systemName: "chevron.up.chevron.down").font(.system(size: 7, weight: .bold))
+        }
+        .foregroundStyle(.white.opacity(0.75))
+        .padding(.horizontal, 8).padding(.vertical, 4)
+        .background(Capsule().fill(Color.white.opacity(0.06)).overlay(Capsule().stroke(Color.white.opacity(0.1), lineWidth: 0.5)))
+    }
+}

--- a/TokenEaterApp/Settings/MenuBarEditorView.swift
+++ b/TokenEaterApp/Settings/MenuBarEditorView.swift
@@ -232,27 +232,41 @@ private struct MenuBarTemplateCard: View {
 }
 
 /// Horizontal strip of little chips, one per visible segment, hinting at the
-/// composition shape. Pills draw rounded, text segments squared.
+/// composition shape. Widths are proportional to each segment's relative
+/// weight and laid out against the card's actual width (GeometryReader), so a
+/// dense template like "Complete" always fits instead of spilling past the
+/// card. Pills draw rounded, text segments squared.
 private struct MenuBarTemplateSchematic: View {
     let composition: MenuBarComposition
     let highlighted: Bool
 
+    private static let spacing: CGFloat = 3
+    private static let maxChips = 8
+
     var body: some View {
-        HStack(spacing: 3) {
-            ForEach(Array(composition.visibleSegments.prefix(6).enumerated()), id: \.offset) { _, segment in
-                RoundedRectangle(cornerRadius: segment.effectiveStyle == .pill ? 5 : 2)
-                    .fill(highlighted ? Color.blue.opacity(0.55) : Color.white.opacity(0.22))
-                    .frame(width: chipWidth(segment), height: 10)
+        let segments = Array(composition.visibleSegments.prefix(Self.maxChips))
+        let weights = segments.map { weight($0) }
+        let total = max(weights.reduce(0, +), 0.001)
+
+        GeometryReader { geo in
+            let available = geo.size.width - Self.spacing * CGFloat(max(segments.count - 1, 0))
+            HStack(spacing: Self.spacing) {
+                ForEach(Array(segments.enumerated()), id: \.offset) { i, segment in
+                    RoundedRectangle(cornerRadius: segment.effectiveStyle == .pill ? 4 : 2)
+                        .fill(highlighted ? Color.blue.opacity(0.55) : Color.white.opacity(0.22))
+                        .frame(width: max(available * weights[i] / total, 2), height: 10)
+                }
             }
+            .frame(width: geo.size.width, height: geo.size.height, alignment: .center)
         }
-        .frame(maxWidth: .infinity)
     }
 
-    private func chipWidth(_ segment: MenuBarSegment) -> CGFloat {
+    /// Relative visual weight: pills / label+value read widest, dots narrowest.
+    private func weight(_ segment: MenuBarSegment) -> CGFloat {
         switch segment.effectiveStyle {
-        case .dot, .glyph: return 8
-        case .valueOnly, .delta: return 12
-        default: return 18
+        case .dot, .glyph: return 1.0
+        case .valueOnly, .delta: return 1.6
+        default: return 2.6
         }
     }
 }

--- a/TokenEaterApp/Settings/SettingsRootView.swift
+++ b/TokenEaterApp/Settings/SettingsRootView.swift
@@ -35,7 +35,7 @@ struct SettingsRootView: View {
         case .general:
             scrolling { SettingsSectionView(initialStatusInterval: settingsStore.statusPollInterval) }
         case .display:
-            scrolling { DisplaySectionView(initialMetrics: settingsStore.pinnedMetrics) }
+            scrolling { DisplaySectionView() }
         case .themes:
             scrolling { ThemesSectionView() }
         case .pacing:

--- a/TokenEaterTests/MenuBarCompositionModelsTests.swift
+++ b/TokenEaterTests/MenuBarCompositionModelsTests.swift
@@ -1,0 +1,103 @@
+import Testing
+import Foundation
+
+@Suite("MenuBarCompositionModels")
+struct MenuBarCompositionModelsTests {
+
+    @Test("every kind declares at least one style, all self-consistent")
+    func kindStyleMatrix() {
+        for kind in MenuBarSegmentKind.allCases {
+            #expect(!kind.allowedStyles.isEmpty)
+        }
+    }
+
+    @Test("effectiveStyle clamps an illegal style to the kind's first legal one")
+    func effectiveStyleClamps() {
+        // A usage kind can't render as a pacing dot.
+        let seg = MenuBarSegment(kind: .session, style: .dot)
+        #expect(seg.effectiveStyle == .labelValue)
+        let ok = MenuBarSegment(kind: .session, style: .pill)
+        #expect(ok.effectiveStyle == .pill)
+    }
+
+    @Test("composition survives an encode / decode round trip")
+    func roundTrip() throws {
+        let original = MenuBarBuiltinTemplate.complete.composition
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(MenuBarComposition.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test("unknown segment kind is dropped, valid siblings survive")
+    func unknownKindDropped() throws {
+        let json = """
+        {"segments": [
+            {"id":"\(UUID().uuidString)","kind":"session","style":"labelValue","isHidden":false,"options":{}},
+            {"id":"\(UUID().uuidString)","kind":"telepathy","style":"labelValue","isHidden":false,"options":{}}
+        ]}
+        """
+        let decoded = try JSONDecoder().decode(MenuBarComposition.self, from: Data(json.utf8))
+        #expect(decoded.segments.count == 1)
+        #expect(decoded.segments[0].kind == .session)
+    }
+
+    @Test("unknown style drops only that segment")
+    func unknownStyleDropped() throws {
+        let json = """
+        {"segments": [
+            {"kind":"session","style":"hologram"},
+            {"kind":"weekly","style":"labelValue"}
+        ]}
+        """
+        let decoded = try JSONDecoder().decode(MenuBarComposition.self, from: Data(json.utf8))
+        #expect(decoded.segments.count == 1)
+        #expect(decoded.segments[0].kind == .weekly)
+    }
+
+    @Test("missing optional fields decode to defaults")
+    func missingFieldsDefault() throws {
+        let json = """
+        {"segments": [{"kind":"sessionPacing","style":"dotDelta"}]}
+        """
+        let decoded = try JSONDecoder().decode(MenuBarComposition.self, from: Data(json.utf8))
+        let seg = try #require(decoded.segments.first)
+        #expect(seg.isHidden == false)
+        #expect(seg.options == MenuBarSegmentOptions())
+    }
+
+    @Test("hasVisibleContent reflects hidden segments")
+    func visibility() {
+        var c = MenuBarBuiltinTemplate.classic.composition
+        #expect(c.hasVisibleContent)
+        for i in c.segments.indices { c.segments[i].isHidden = true }
+        #expect(!c.hasVisibleContent)
+        #expect(c.visibleSegments.isEmpty)
+    }
+
+    @Test("every built-in template is valid: legal styles, non-empty")
+    func builtinTemplatesValid() {
+        for template in MenuBarBuiltinTemplate.allCases {
+            let c = template.composition
+            #expect(c.hasVisibleContent, "\(template.rawValue) must have visible content")
+            for seg in c.segments {
+                #expect(seg.kind.allowedStyles.contains(seg.style),
+                        "\(template.rawValue): \(seg.kind) cannot render as \(seg.style)")
+            }
+        }
+    }
+
+    @Test("templates mint fresh segment ids on every access")
+    func templatesMintFreshIDs() {
+        let a = MenuBarBuiltinTemplate.classic.composition
+        let b = MenuBarBuiltinTemplate.classic.composition
+        #expect(Set(a.segments.map(\.id)).isDisjoint(with: Set(b.segments.map(\.id))))
+    }
+
+    @Test("user template round trips through Codable")
+    func userTemplateRoundTrip() throws {
+        let t = MenuBarUserTemplate(name: "My bar", composition: MenuBarBuiltinTemplate.pills.composition)
+        let data = try JSONEncoder().encode([t])
+        let decoded = try JSONDecoder().decode([MenuBarUserTemplate].self, from: data)
+        #expect(decoded == [t])
+    }
+}

--- a/TokenEaterTests/MenuBarConfigMigratorTests.swift
+++ b/TokenEaterTests/MenuBarConfigMigratorTests.swift
@@ -10,8 +10,7 @@ struct MenuBarConfigMigratorTests {
         sessionMode: PacingDisplayMode = .dotDelta,
         weeklyMode: PacingDisplayMode = .dotDelta,
         resetFormat: ResetDisplayFormat = .relative,
-        shape: PacingShape = .circle,
-        presence: MenuBarConfigMigrator.AccountPresence = .init()
+        shape: PacingShape = .circle
     ) -> MenuBarComposition {
         MenuBarConfigMigrator.migrate(
             pinnedMetrics: pins,
@@ -19,8 +18,7 @@ struct MenuBarConfigMigratorTests {
             sessionPacingDisplayMode: sessionMode,
             weeklyPacingDisplayMode: weeklyMode,
             resetDisplayFormat: resetFormat,
-            pacingShape: shape,
-            presence: presence
+            pacingShape: shape
         )
     }
 
@@ -70,29 +68,39 @@ struct MenuBarConfigMigratorTests {
         #expect(result.segments.first { $0.kind == .sessionPacing }?.options.pacingShape == .diamond)
     }
 
-    @Test("a pinned metric absent on the account is dropped")
-    func presenceGating() {
-        let result = migrate(
-            pins: [.fiveHour, .design, .fable, .extraCredits],
-            presence: .init(hasDesign: false, hasFable: true, hasExtraCredits: false)
-        )
+    @Test("presence-gated pins are KEPT (render-time gating handles absence, so nothing is lost)")
+    func presenceGatedPinsKept() {
+        // The old menu bar kept the pin and re-showed it when the metric
+        // returned; the migrator must not drop it (extra credits' isEnabled is
+        // transient). Render-time isSegmentAvailable hides it while absent.
+        let result = migrate(pins: [.fiveHour, .design, .fable, .extraCredits])
         let kinds = result.segments.map(\.kind)
         #expect(kinds.contains(.session))
+        #expect(kinds.contains(.design))
         #expect(kinds.contains(.fable))
-        #expect(!kinds.contains(.design))
-        #expect(!kinds.contains(.extraCredits))
+        #expect(kinds.contains(.extraCredits))
     }
 
-    @Test("every migrated segment has a legal style for its kind")
+    @Test("badge pacing preserves the display mode: dotDelta -> pill, dot -> dot, delta -> delta")
+    func badgePacingHonorsMode() {
+        let dotDelta = migrate(pins: [.sessionPacing], style: .badge, sessionMode: .dotDelta)
+        #expect(dotDelta.segments.first?.style == .pill)
+        let dot = migrate(pins: [.sessionPacing], style: .badge, sessionMode: .dot)
+        #expect(dot.segments.first?.style == .dot)
+        let delta = migrate(pins: [.sessionPacing], style: .badge, sessionMode: .delta)
+        #expect(delta.segments.first?.style == .delta)
+    }
+
+    @Test("every migrated segment has a legal style for its kind, across all styles and pacing modes")
     func migratedSegmentsValid() {
+        let modes: [PacingDisplayMode] = [.dot, .dotDelta, .delta]
         for style in MenuBarStyle.allCases {
-            let result = migrate(
-                pins: Set(MetricID.allCases), style: style,
-                presence: .init(hasDesign: true, hasFable: true, hasExtraCredits: true)
-            )
-            for seg in result.segments {
-                #expect(seg.kind.allowedStyles.contains(seg.style),
-                        "\(style): \(seg.kind) got illegal \(seg.style)")
+            for mode in modes {
+                let result = migrate(pins: Set(MetricID.allCases), style: style, sessionMode: mode, weeklyMode: mode)
+                for seg in result.segments {
+                    #expect(seg.kind.allowedStyles.contains(seg.style),
+                            "\(style)/\(mode): \(seg.kind) got illegal \(seg.style)")
+                }
             }
         }
     }

--- a/TokenEaterTests/MenuBarConfigMigratorTests.swift
+++ b/TokenEaterTests/MenuBarConfigMigratorTests.swift
@@ -1,0 +1,106 @@
+import Testing
+import Foundation
+
+@Suite("MenuBarConfigMigrator")
+struct MenuBarConfigMigratorTests {
+
+    private func migrate(
+        pins: Set<MetricID>,
+        style: MenuBarStyle = .classic,
+        sessionMode: PacingDisplayMode = .dotDelta,
+        weeklyMode: PacingDisplayMode = .dotDelta,
+        resetFormat: ResetDisplayFormat = .relative,
+        shape: PacingShape = .circle,
+        presence: MenuBarConfigMigrator.AccountPresence = .init()
+    ) -> MenuBarComposition {
+        MenuBarConfigMigrator.migrate(
+            pinnedMetrics: pins,
+            menuBarStyle: style,
+            sessionPacingDisplayMode: sessionMode,
+            weeklyPacingDisplayMode: weeklyMode,
+            resetDisplayFormat: resetFormat,
+            pacingShape: shape,
+            presence: presence
+        )
+    }
+
+    @Test("default pins in classic style become label+value session then weekly")
+    func classicDefault() {
+        let result = migrate(pins: [.fiveHour, .sevenDay])
+        #expect(result.segments.map(\.kind) == [.session, .weekly])
+        #expect(result.segments.allSatisfy { $0.style == .labelValue })
+    }
+
+    @Test("order follows the legacy render order regardless of set iteration")
+    func orderPreserved() {
+        // Pins given in a jumbled set; output must be the fixed legacy order.
+        let result = migrate(pins: [.weeklyPacing, .fiveHour, .serviceStatus, .sevenDay])
+        #expect(result.segments.map(\.kind) == [.serviceStatus, .session, .weekly, .weeklyPacing])
+    }
+
+    @Test("mono style maps usage segments to the mono style")
+    func monoStyle() {
+        let result = migrate(pins: [.fiveHour], style: .mono)
+        #expect(result.segments[0].style == .mono)
+    }
+
+    @Test("badge style maps every segment to pill")
+    func badgeStyle() {
+        let result = migrate(pins: [.fiveHour, .sessionReset, .weeklyPacing, .serviceStatus], style: .badge)
+        #expect(result.segments.allSatisfy { $0.style == .pill })
+    }
+
+    @Test("pacing segments take their per-metric display mode as style")
+    func pacingModes() {
+        let result = migrate(
+            pins: [.sessionPacing, .weeklyPacing],
+            sessionMode: .dot, weeklyMode: .delta
+        )
+        #expect(result.segments.first { $0.kind == .sessionPacing }?.style == .dot)
+        #expect(result.segments.first { $0.kind == .weeklyPacing }?.style == .delta)
+    }
+
+    @Test("reset format and pacing shape are carried into options")
+    func optionsCarried() {
+        let result = migrate(
+            pins: [.sessionReset, .sessionPacing],
+            resetFormat: .both, shape: .diamond
+        )
+        #expect(result.segments.first { $0.kind == .sessionReset }?.options.resetFormat == .both)
+        #expect(result.segments.first { $0.kind == .sessionPacing }?.options.pacingShape == .diamond)
+    }
+
+    @Test("a pinned metric absent on the account is dropped")
+    func presenceGating() {
+        let result = migrate(
+            pins: [.fiveHour, .design, .fable, .extraCredits],
+            presence: .init(hasDesign: false, hasFable: true, hasExtraCredits: false)
+        )
+        let kinds = result.segments.map(\.kind)
+        #expect(kinds.contains(.session))
+        #expect(kinds.contains(.fable))
+        #expect(!kinds.contains(.design))
+        #expect(!kinds.contains(.extraCredits))
+    }
+
+    @Test("every migrated segment has a legal style for its kind")
+    func migratedSegmentsValid() {
+        for style in MenuBarStyle.allCases {
+            let result = migrate(
+                pins: Set(MetricID.allCases), style: style,
+                presence: .init(hasDesign: true, hasFable: true, hasExtraCredits: true)
+            )
+            for seg in result.segments {
+                #expect(seg.kind.allowedStyles.contains(seg.style),
+                        "\(style): \(seg.kind) got illegal \(seg.style)")
+            }
+        }
+    }
+
+    @Test("empty pins produce an empty (but valid) composition")
+    func emptyPins() {
+        let result = migrate(pins: [])
+        #expect(result.segments.isEmpty)
+        #expect(!result.hasVisibleContent)
+    }
+}

--- a/TokenEaterTests/MenuBarRendererTests.swift
+++ b/TokenEaterTests/MenuBarRendererTests.swift
@@ -85,14 +85,13 @@ struct MenuBarRendererTests {
 struct MenuBarOutageBadgeTests {
 
     static func sampleRenderData(
-        pinnedMetrics: Set<MetricID> = [.fiveHour],
+        segments: [MenuBarSegment] = [MenuBarSegment(kind: .session, style: .labelValue)],
         outageActive: Bool = false,
         outageHealth: VendorHealth = .healthy,
         nextPollSeconds: Int? = nil
     ) -> MenuBarRenderer.RenderData {
         MenuBarRenderer.RenderData(
-            pinnedMetrics: pinnedMetrics,
-            displaySonnet: false,
+            composition: MenuBarComposition(segments: segments),
             fiveHourPct: 10,
             sevenDayPct: 5,
             sonnetPct: 0,
@@ -102,8 +101,6 @@ struct MenuBarOutageBadgeTests {
             sessionPacingDelta: 0,
             sessionPacingZone: .onTrack,
             hasSessionPacing: false,
-            sessionPacingDisplayMode: .dotDelta,
-            weeklyPacingDisplayMode: .dotDelta,
             hasConfig: true,
             hasError: false,
             isAwaitingRefresh: false,
@@ -117,14 +114,11 @@ struct MenuBarOutageBadgeTests {
             sonnetResetDate: nil,
             designResetDate: nil,
             hasFiveHourBucket: true,
-            resetDisplayFormat: .relative,
             resetTextColorHex: "",
             sessionPeriodColorHex: "",
             smartResetColor: false,
             smartColorProfile: .balanced,
             pacingMargin: 10,
-            menuBarStyle: .classic,
-            pacingShape: .circle,
             designPct: 0,
             hasDesign: false,
             fablePct: 0,
@@ -156,12 +150,12 @@ struct MenuBarOutageBadgeTests {
     @Test("pinned serviceStatus with .down is non-template and wider than .healthy")
     func pinnedServiceStatusDownWiderThanHealthy() {
         let healthy = Self.sampleRenderData(
-            pinnedMetrics: [.serviceStatus],
+            segments: [MenuBarSegment(kind: .serviceStatus, style: .glyph)],
             outageHealth: .healthy,
             nextPollSeconds: nil
         )
         let down = Self.sampleRenderData(
-            pinnedMetrics: [.serviceStatus],
+            segments: [MenuBarSegment(kind: .serviceStatus, style: .glyph)],
             outageHealth: .down,
             nextPollSeconds: 125
         )
@@ -283,30 +277,24 @@ struct MenuBarExtraCreditsRenderTests {
 
     /// Full RenderData with neutral defaults; tests override only what matters.
     private func data(
-        pinned: Set<MetricID> = [.extraCredits],
+        segments: [MenuBarSegment] = [MenuBarSegment(kind: .extraCredits, style: .labelValue)],
         hasExtraCredits: Bool = true,
-        extraCreditsPct: Int = 67,
-        style: MenuBarStyle = .classic
+        extraCreditsPct: Int = 67
     ) -> MenuBarRenderer.RenderData {
         MenuBarRenderer.RenderData(
-            pinnedMetrics: pinned,
-            displaySonnet: false,
+            composition: MenuBarComposition(segments: segments),
             fiveHourPct: 0, sevenDayPct: 0, sonnetPct: 0,
             weeklyPacingDelta: 0, weeklyPacingZone: .onTrack, hasWeeklyPacing: false,
             sessionPacingDelta: 0, sessionPacingZone: .onTrack, hasSessionPacing: false,
-            sessionPacingDisplayMode: .dotDelta, weeklyPacingDisplayMode: .dotDelta,
             hasConfig: true, hasError: false, isAwaitingRefresh: false,
             themeColors: .default, thresholds: .default,
             menuBarMonochrome: false,
             fiveHourReset: "", fiveHourResetAbsolute: "",
             fiveHourResetDate: nil, sevenDayResetDate: nil, sonnetResetDate: nil, designResetDate: nil,
             hasFiveHourBucket: false,
-            resetDisplayFormat: .relative,
             resetTextColorHex: "", sessionPeriodColorHex: "",
             smartResetColor: false, smartColorProfile: .balanced,
             pacingMargin: 10,
-            menuBarStyle: style,
-            pacingShape: .circle,
             designPct: 0, hasDesign: false,
             fablePct: 0, hasFable: false, fableResetDate: nil,
             outageActive: false, outageHealth: .healthy, nextPollSeconds: nil,
@@ -314,26 +302,28 @@ struct MenuBarExtraCreditsRenderTests {
         )
     }
 
-    @Test("EC pinned + pool enabled renders a value (non-template image)")
+    @Test("EC segment + pool enabled renders a value (non-template image)")
     func renderedWhenEnabled() {
         let image = MenuBarRenderer.renderUncached(data(hasExtraCredits: true))
-        // The pinned-metrics path produces a non-template text image; the
-        // logo fallback is a template. So a non-template image proves EC drew.
+        // The composition path produces a non-template text image; the logo
+        // fallback is a template. So a non-template image proves EC drew.
         #expect(image.isTemplate == false)
         #expect(image.size.width > 0)
     }
 
-    @Test("EC pinned but pool disabled falls back to the logo (template image)")
+    @Test("EC segment but pool disabled falls back to the logo (template image)")
     func logoFallbackWhenDisabled() {
-        // Only EC is pinned and it's filtered out → ordered list is empty →
-        // the renderer returns the template logo instead of a 0-width sliver.
+        // Only EC is in the composition and it's filtered out → no visible
+        // segment → the renderer returns the template logo, not a 0-width sliver.
         let image = MenuBarRenderer.renderUncached(data(hasExtraCredits: false))
         #expect(image.isTemplate == true)
     }
 
-    @Test("EC renders in badge style too")
-    func renderedInBadgeStyle() {
-        let image = MenuBarRenderer.renderUncached(data(hasExtraCredits: true, style: .badge))
+    @Test("EC renders in pill style too")
+    func renderedInPillStyle() {
+        let image = MenuBarRenderer.renderUncached(
+            data(segments: [MenuBarSegment(kind: .extraCredits, style: .pill)], hasExtraCredits: true)
+        )
         #expect(image.isTemplate == false)
         #expect(image.size.width > 0)
     }


### PR DESCRIPTION
Composable menu bar, the sibling of the composable popover (#230), built on the shared foundations extracted in #231.

## What

The status-bar item stops being a fixed, hardcoded-order list styled by a single global `menuBarStyle`. It becomes an **ordered list of segments**, each with its own **style**, reorderable and composable like the popover.

- **Segments**: session / weekly / Sonnet / Design / Fable / extra credits (usage), session & weekly pacing, session reset countdown, service status.
- **Per-segment styles**: usage -> `label+value` / `value only` / `mono` / `pill`; pacing -> `dot` / `dot+delta` / `delta` / `pill`; reset -> `text` / `pill`; status -> `glyph` / `pill`. The old global classic/mono/badge look is now a per-segment choice, and looks can be **mixed** in one bar.
- **Colours stay global** via the existing theme / smart-colour system (monochrome, hex overrides live in the Display colour group). Segments carry layout, not colour.

## Highlights

- **Renderer surgery** (`MenuBarRenderer`): one unified drawing loop composes text runs and tinted pills left to right into a single `NSImage` (the old text and pill paths were mutually-exclusive whole-icon modes), and emits per-segment hit rects.
- **Editor** (replaces the Display pin grid + style/shape controls): template gallery (Classic / Minimalist / Pills / Pacing focus / Complete + user-saved), reorderable segment list, per-segment style + pacing-shape + reset-format pickers, add menu grouped by family with account-presence gating.
- **Live preview with click-to-select**: renders the real `MenuBarRenderer` NSImage at 2x and overlays invisible tap targets from the hit rects, so clicking a segment selects its row (the AppKit equivalent of the popover's click-to-select).
- **Silent migration**: `pinnedMetrics` + `menuBarStyle` + the per-metric display prefs -> composition, preserving the legacy render order and presence-gating stale pins from the cached usage. Legacy keys stay in UserDefaults for downgrade.
- An empty menu bar is legitimate (the renderer already draws the app icon), so there is no "can't remove the last one" guard.

## Shared with the popover (from #231)

`Lossy` tolerant Codable, `UserTemplate<C>`, and the `ReorderDropDelegate` / `ReorderGapDropDelegate` are reused. The editor **view** is a dedicated, menu-bar-specific implementation rather than a forced generalization of the popover's SwiftUI hierarchy - the two surfaces render very differently (AppKit NSImage vs SwiftUI grid), and generalizing the working popover editor speculatively would risk Release-only bugs for no immediate gain.

## Tests

New Swift Testing coverage: composition model (style/kind matrix, tolerant decode, templates), migrator (legacy order, style mapping, presence gating, per-metric pacing modes), renderer reworked onto the composition API. Full suite: 565 green. Built + validated in Release with Xcode 16.4.

Nothing ships until a release is tagged.