### PR TITLE
fix: keep the menu-bar popover open over a fullscreen Space

### DIFF
--- a/TokenEaterApp/App/StatusBarController.swift
+++ b/TokenEaterApp/App/StatusBarController.swift
@@ -11,6 +11,10 @@ final class StatusBarController: NSObject {
     private var localKeyMonitor: Any?
     private var appDeactivateObserver: NSObjectProtocol?
     private var spaceChangeObserver: NSObjectProtocol?
+    /// App that held focus just before the popover opened (captured before we
+    /// activate ourselves). Used to tell a real app switch from the spurious
+    /// resign the fullscreen menu-bar auto-hide causes.
+    private var popoverOriginAppPID: pid_t?
     private var cancellables = Set<AnyCancellable>()
     private var countdownCancellable: AnyCancellable?
 
@@ -519,6 +523,10 @@ final class StatusBarController: NSObject {
             dismissPopover()
         } else {
             guard let button = statusItem.button else { return }
+            // Capture the app we're opening over BEFORE we steal focus, so the
+            // resign handler can tell "focus returned here" (spurious fullscreen
+            // menu-bar hide) from "user switched to a different app".
+            popoverOriginAppPID = NSWorkspace.shared.frontmostApplication?.processIdentifier
             installPopoverContent()
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
             NSApp.activate(ignoringOtherApps: true)
@@ -711,10 +719,32 @@ final class StatusBarController: NSObject {
         // App deactivation (Cmd-Tab, clicking another app) and Space changes
         // close it too, restoring the dismissal .transient gave us for free
         // before we switched to .applicationDefined for the fullscreen fix.
+        //
+        // Fullscreen trap: over a fullscreen Space the menu bar auto-hides as
+        // soon as the cursor leaves it, and that hide resigns our app active -
+        // a spurious deactivation, not a real app switch. It fired on the first
+        // mouse move and closed the popover (confirmed via instrumentation:
+        // SHOWN -> didResignActive on cursor move). Guard on the menu bar being
+        // visible: a genuine Cmd-Tab in windowed mode keeps it visible (still
+        // dismisses), while the fullscreen auto-hide leaves it hidden (skip).
+        // A real Cmd-Tab away in fullscreen still dismisses via the Space-change
+        // observer below. Deferred one runloop so the menu bar state has
+        // settled by the time we read it.
         appDeactivateObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.didResignActiveNotification, object: nil, queue: .main
         ) { [weak self] _ in
-            self?.dismissPopover()
+            // Deferred one runloop so `frontmostApplication` reflects who is
+            // active AFTER the switch, not us mid-resign.
+            DispatchQueue.main.async {
+                guard let self else { return }
+                let nowFront = NSWorkspace.shared.frontmostApplication?.processIdentifier
+                // Focus returned to the app we opened over -> the fullscreen
+                // menu-bar auto-hide resigned us spuriously; keep the popover.
+                // A genuinely different app now front means a real switch.
+                if let nowFront, nowFront != self.popoverOriginAppPID {
+                    self.dismissPopover()
+                }
+            }
         }
         spaceChangeObserver = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.activeSpaceDidChangeNotification, object: nil, queue: .main


### PR DESCRIPTION
## Problem

Opening the menu-bar popover over a fullscreen-app Space and then moving the mouse closed it immediately. Recurring bug (third time).

## Root cause (confirmed, not guessed)

Instrumented every dismiss trigger in `StatusBarController` to a log file, reproduced twice: the culprit is the `NSApplication.didResignActiveNotification` observer. Over a fullscreen Space the menu bar auto-hides as soon as the cursor leaves it, which resigns our app active. That spurious deactivation is not a real app switch, but the observer dismissed the popover on it.

Approaches that do **not** work, for the record:
- `.transient` popover behavior self-dismisses on the first mouse move (hence `.applicationDefined`).
- `.canJoinAllSpaces` + `.fullScreenAuxiliary` let the popover join the Space but do not stop the resign dismissal.
- Guarding on `NSMenu.menuBarVisible()` fails: it returns `true` even while the fullscreen bar is auto-hiding (instrumentation showed `didResignActive-dismiss (menuBar visible)`).

## Fix

Capture `frontmostApplication` into `popoverOriginAppPID` before `NSApp.activate()` at show time. In the resign handler (deferred one runloop so frontmost reflects the post-switch app), only `dismissPopover()` when a genuinely different app is now frontmost. Focus returning to the origin app (the fullscreen auto-hide, or Cmd-Tab back to where you were) keeps the popover open.

Every other dismiss path is unchanged: click-outside (global mouse-down), Escape, `activeSpaceDidChange` (fullscreen Cmd-Tab away), and re-clicking the status item.

## Testing

Confirmed on a fullscreen Space: popover now stays on mouse move (log: `didResignActive-skip (front=<fs app> origin=<fs app>)`), and click-outside / Escape / status-item still dismiss. Instrumentation removed before commit. Debug + Release build clean (Xcode 16.4).