### PR TITLE
fix: give the menu bar status item a stable autosaveName (macOS 26 missing icon)

### DIFF
--- a/TokenEaterApp/App/StatusBarController.swift
+++ b/TokenEaterApp/App/StatusBarController.swift
@@ -39,6 +39,16 @@ final class StatusBarController: NSObject {
         self.vendorStatusStore = vendorStatusStore
         self.tokenFileMonitor = tokenFileMonitor
         self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        // Track the item under a stable, app-specific identity rather than the
+        // generic "Item-0" the system assigns by default. On macOS 26 the OS
+        // (Control Center) manages menu-bar-item visibility, and a corrupted
+        // managed state for "Item-0" left the NSStatusItem existing (its
+        // visibility prefs still flipped) but with no menu bar window ever
+        // created, so the icon never appeared and no defaults edit recovered it
+        // (#236). A distinct autosaveName gives the item a fresh tracking
+        // identity, sidestepping the stuck "Item-0" state, and persists its
+        // position properly going forward.
+        self.statusItem.autosaveName = "TokenEaterStatusItem"
         self.statusItem.isVisible = settingsStore.showMenuBar
 
         super.init()


### PR DESCRIPTION
## Problem (#236)

On macOS 26.5.2 the status item can stop appearing entirely. The app runs normally (dashboard, Connected, live data), `showMenuBar = 1`, metrics pinned, but no status item is ever created. Verified by the reporter via `CGWindowListCopyWindowInfo`: TokenEater owns no menu bar window, only its dashboard window. Not a notch/width issue, not #217 (no keychain hang), `StatusBarController` alive.

Telling clue: toggling "Show in menu bar" writes `NSStatusItem VisibleCC Item-0` 0 then 1, so the `NSStatusItem` object exists and its Control-Center-managed visibility flips, yet no window is created, and no defaults edit (position, Visible, VisibleCC) recovers it. A different `LSUIElement` app registers fine against the same Control Center, so the failure is specific to us.

## Cause

We created the status item with `statusItem(withLength:)` and never set an `autosaveName`, so the OS tracked it under the generic `Item-0` identity. On macOS 26 the OS (Control Center) manages menu-bar-item visibility; the managed state for `Item-0` got stuck, leaving the item without a menu bar window and unrecoverable from the app side.

## Fix

Set an explicit `statusItem.autosaveName = "TokenEaterStatusItem"`, giving the item a fresh, app-specific tracking identity instead of the corrupted `Item-0`. This is also just correct practice (stable position persistence).

One-time effect on upgrade: the item resets to the default (rightmost) menu bar position under the new name; users who had dragged it can move it back once.

## Caveat

I could not reproduce this locally (it needs the specific macOS 26 stuck state), so this is a candidate fix that the reporter should confirm. Build clean (Release, Xcode 16.4).