### PR TITLE
fix: make the Studio add-element pill legible

### DIFF
--- a/Shared/Components/AddElementMenuButton.swift
+++ b/Shared/Components/AddElementMenuButton.swift
@@ -20,11 +20,13 @@ import SwiftUI
 /// `.buttonStyle(.bordered)` specifically to avoid it. This view keeps the
 /// custom capsule, so it takes the modifiers-on-`Menu` route instead.
 ///
-/// Solid accent fill with inverted (near-black) text, so the label stays
-/// legible on the editor's darkest surfaces - a translucent accent fill left
-/// the text sitting on effectively raw background and was unreadable. The
-/// hover lift and `.easeOut(0.12)` timing match `DSMenu`, the sibling
-/// component in this folder.
+/// Styling follows the module-accent rule from `DesignTokens` and
+/// `docs/design/MASTER.md`: an accent used as fill stays at or below 0.15 and is
+/// "never loud". Legibility comes from the label being accent-coloured rather
+/// than white, which is what makes a translucent fill work here - the same
+/// combination the segment dropzone in `MenuBarEditorView` already uses (fill
+/// 0.10-0.16, border 0.55, accent text). The hover lift and `.easeOut(0.12)`
+/// timing match `DSMenu`, the sibling component in this folder.
 struct AddElementMenuButton<MenuContent: View>: View {
     let title: String
     @ViewBuilder var menuContent: () -> MenuContent
@@ -41,8 +43,7 @@ struct AddElementMenuButton<MenuContent: View>: View {
                 Text(title)
                     .font(.system(size: 11, weight: .bold))
             }
-            // Inverted: dark text on the light violet fill.
-            .foregroundStyle(DS.Palette.bgElevated)
+            .foregroundStyle(DS.Palette.accentStudio)
         }
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
@@ -51,8 +52,12 @@ struct AddElementMenuButton<MenuContent: View>: View {
         .padding(.vertical, 6)
         .background(
             Capsule()
-                .fill(DS.Palette.accentStudio)
-                .overlay(Capsule().fill(.white.opacity(isHovering ? 0.18 : 0)))
+                .fill(DS.Palette.accentStudio.opacity(isHovering ? 0.22 : 0.15))
+                .overlay(
+                    Capsule().strokeBorder(
+                        DS.Palette.accentStudio.opacity(0.55), lineWidth: 1
+                    )
+                )
         )
         .onHover { isHovering = $0 }
         .animation(.easeOut(duration: 0.12), value: isHovering)

--- a/Shared/Components/AddElementMenuButton.swift
+++ b/Shared/Components/AddElementMenuButton.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// Compact violet "+ <title>" menu trigger used by the Studio composable
+/// editors (popover composer, menu bar composer) to add a new element or
+/// segment to a composition.
+///
+/// IMPORTANT: both the capsule `.background` AND the `.padding` are applied to
+/// the `Menu` itself, never inside the `label:` closure. Verified empirically
+/// (isolated SwiftUI harness, Xcode 26.6 / Swift 6.3.3): under
+/// `.menuStyle(.borderlessButton)` AppKit re-renders the label through its own
+/// button cell, which paints the text but silently drops both a `.background()`
+/// and a `.padding()` applied inside that closure. A background there renders
+/// as no capsule at all, and padding there leaves the text flush against the
+/// capsule edge once the background is moved out on its own. Label internals
+/// make no difference: per-child vs container-level `.foregroundStyle`,
+/// `.contentShape`, and hover state were each tested and ruled out.
+///
+/// `EditorPickerLabel` in `MenuBarEditorView.swift` documents the same root
+/// cause independently; its call sites use `.menuStyle(.button)` +
+/// `.buttonStyle(.bordered)` specifically to avoid it. This view keeps the
+/// custom capsule, so it takes the modifiers-on-`Menu` route instead.
+///
+/// Solid accent fill with inverted (near-black) text, so the label stays
+/// legible on the editor's darkest surfaces - a translucent accent fill left
+/// the text sitting on effectively raw background and was unreadable. The
+/// hover lift and `.easeOut(0.12)` timing match `DSMenu`, the sibling
+/// component in this folder.
+struct AddElementMenuButton<MenuContent: View>: View {
+    let title: String
+    @ViewBuilder var menuContent: () -> MenuContent
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Menu {
+            menuContent()
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "plus")
+                    .font(.system(size: 9, weight: .bold))
+                Text(title)
+                    .font(.system(size: 11, weight: .bold))
+            }
+            // Inverted: dark text on the light violet fill.
+            .foregroundStyle(DS.Palette.bgElevated)
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(
+            Capsule()
+                .fill(DS.Palette.accentStudio)
+                .overlay(Capsule().fill(.white.opacity(isHovering ? 0.18 : 0)))
+        )
+        .onHover { isHovering = $0 }
+        .animation(.easeOut(duration: 0.12), value: isHovering)
+    }
+}

--- a/TokenEaterApp/Popover/PopoverSectionView.swift
+++ b/TokenEaterApp/Popover/PopoverSectionView.swift
@@ -250,7 +250,7 @@ struct PopoverSectionView: View {
     }
 
     private var addElementMenu: some View {
-        Menu {
+        AddElementMenuButton(title: String(localized: "popover.editor.addElement")) {
             Section(String(localized: "popover.editor.family.metrics")) {
                 let metricKinds: [PopoverElementKind] = [.session, .weekly, .sonnet, .fable, .extraCredits]
                 ForEach(metricKinds) { kind in
@@ -270,25 +270,7 @@ struct PopoverSectionView: View {
                 addButton(for: .openButton)
                 addButton(for: .quitButton)
             }
-        } label: {
-            HStack(spacing: 5) {
-                Image(systemName: "plus")
-                    .font(.system(size: 9, weight: .bold))
-                Text(String(localized: "popover.editor.addElement"))
-                    .font(.system(size: 11, weight: .semibold))
-            }
-            .foregroundStyle(.white.opacity(0.85))
-            .padding(.horizontal, 10)
-            .padding(.vertical, 5)
-            .background(
-                Capsule()
-                    .fill(Color.blue.opacity(0.18))
-                    .overlay(Capsule().stroke(Color.blue.opacity(0.45), lineWidth: 1))
-            )
         }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .fixedSize()
     }
 
     @ViewBuilder

--- a/TokenEaterApp/Popover/PopoverSectionView.swift
+++ b/TokenEaterApp/Popover/PopoverSectionView.swift
@@ -44,10 +44,18 @@ struct PopoverSectionView: View {
 
             // Middle: the element list (scrolls). Auto-scrolls to the row
             // that matches a preview tap.
+            //
+            // The header stays outside the ScrollView on purpose: it carries
+            // this column's primary action ("add element"), and scrolling a
+            // long composition used to push both the label and that button out
+            // of sight. Only the list moves.
             ScrollViewReader { proxy in
-                ScrollView(.vertical, showsIndicators: true) {
-                    elementsSection
-                        .padding(.bottom, 8)
+                VStack(alignment: .leading, spacing: 10) {
+                    elementsHeader
+                    ScrollView(.vertical, showsIndicators: true) {
+                        elementsList
+                            .padding(.bottom, 8)
+                    }
                 }
                 .onChange(of: selectedElementID) { _, id in
                     guard let id else { return }
@@ -237,16 +245,25 @@ struct PopoverSectionView: View {
 
     // MARK: - Elements
 
+    /// Assembled form, used by the narrow layout where a single ScrollView
+    /// wraps the whole page and a pinned header would make no sense.
     private var elementsSection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            HStack {
-                editorSectionLabel("popover.editor.elements")
-                Spacer()
-                addElementMenu
-            }
-
-            ElementListEditor(selectedElementID: $selectedElementID)
+            elementsHeader
+            elementsList
         }
+    }
+
+    private var elementsHeader: some View {
+        HStack {
+            editorSectionLabel("popover.editor.elements")
+            Spacer()
+            addElementMenu
+        }
+    }
+
+    private var elementsList: some View {
+        ElementListEditor(selectedElementID: $selectedElementID)
     }
 
     private var addElementMenu: some View {

--- a/TokenEaterApp/Studio/MenuBarEditorView.swift
+++ b/TokenEaterApp/Studio/MenuBarEditorView.swift
@@ -52,10 +52,16 @@ struct MenuBarEditorView<PreviewHeader: View, PreviewFooter: View>: View {
             // Left: template rail (scrolls independently).
             templatesRail
 
-            // Middle: the segment list, the only column that scrolls.
-            ScrollView(.vertical, showsIndicators: true) {
-                segmentsSection
-                    .padding(.bottom, 8)
+            // Middle: the segment list, the only column that scrolls. The
+            // header sits outside the ScrollView because it carries this
+            // column's primary action ("add segment"), which used to scroll
+            // away with the list.
+            VStack(alignment: .leading, spacing: 10) {
+                segmentsHeader
+                ScrollView(.vertical, showsIndicators: true) {
+                    segmentsList
+                        .padding(.bottom, 8)
+                }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
@@ -197,13 +203,21 @@ struct MenuBarEditorView<PreviewHeader: View, PreviewFooter: View>: View {
 
     private var segmentsSection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            HStack {
-                editorLabel("menuBar.editor.segments")
-                Spacer()
-                addSegmentMenu
-            }
-            MenuBarSegmentListEditor(selectedSegmentID: $selectedSegmentID)
+            segmentsHeader
+            segmentsList
         }
+    }
+
+    private var segmentsHeader: some View {
+        HStack {
+            editorLabel("menuBar.editor.segments")
+            Spacer()
+            addSegmentMenu
+        }
+    }
+
+    private var segmentsList: some View {
+        MenuBarSegmentListEditor(selectedSegmentID: $selectedSegmentID)
     }
 
     private var addSegmentMenu: some View {

--- a/TokenEaterApp/Studio/MenuBarEditorView.swift
+++ b/TokenEaterApp/Studio/MenuBarEditorView.swift
@@ -207,7 +207,7 @@ struct MenuBarEditorView<PreviewHeader: View, PreviewFooter: View>: View {
     }
 
     private var addSegmentMenu: some View {
-        Menu {
+        AddElementMenuButton(title: String(localized: "menuBar.editor.addSegment")) {
             Section(String(localized: "menuBar.editor.family.metrics")) {
                 let metricKinds: [MenuBarSegmentKind] = [.session, .weekly, .sonnet, .fable, .extraCredits]
                 ForEach(metricKinds) { addButton(for: $0) }
@@ -221,18 +221,7 @@ struct MenuBarEditorView<PreviewHeader: View, PreviewFooter: View>: View {
                 addButton(for: .sessionReset)
                 addButton(for: .serviceStatus)
             }
-        } label: {
-            HStack(spacing: 5) {
-                Image(systemName: "plus").font(.system(size: 9, weight: .bold))
-                Text(String(localized: "menuBar.editor.addSegment")).font(.system(size: 11, weight: .semibold))
-            }
-            .foregroundStyle(.white.opacity(0.85))
-            .padding(.horizontal, 10).padding(.vertical, 5)
-            .background(Capsule().fill(Color.blue.opacity(0.18)).overlay(Capsule().stroke(Color.blue.opacity(0.45), lineWidth: 1)))
         }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .fixedSize()
     }
 
     @ViewBuilder


### PR DESCRIPTION
## What this PR does


Makes the "Add element" / "Add segment" trigger in the Studio composable editors actually visible. No capsule rendered behind it at all, which left dim text sitting on the editor's dark background at almost no contrast. The result was effectively invisible: the only way to add an element to a composition was easy to miss entirely, and read as a label rather than a button.

## Screenshots / recordings
**Before**
<img width="388" height="70" alt="Screenshot 2026-08-24 at 3 26 56 PM" src="https://github.com/user-attachments/assets/a6596806-17fc-4f69-b283-8a5bc00565d6" />

**After**
<img width="397" height="98" alt="Screenshot 2026-08-24 at 3 25 41 PM" src="https://github.com/user-attachments/assets/ccffcd71-6b43-4b71-a346-254e9de97d94" />

## Why


Under `.menuStyle(.borderlessButton)`, AppKit re-renders the `Menu`'s label through its own button cell. That cell paints the text but silently drops both a `.background()` and a `.padding()` applied inside the `label:` closure. Both editors did exactly that, so the capsule never appeared.

`EditorPickerLabel` in `MenuBarEditorView.swift` already documents this same behaviour, and its call sites use `.menuStyle(.button)` + `.buttonStyle(.bordered)` specifically to avoid it. This view keeps the custom capsule, so it moves the two modifiers onto the `Menu` instead.

I verified the cause in an isolated SwiftUI harness rather than guessing. Starting from the broken construction, none of these made the background paint: per-child instead of container-level `.foregroundStyle`, adding `.contentShape(Capsule())`, reproducing another component's exact label construction, or raising the fill and stroke opacity. Moving the modifiers onto the `Menu` was the only thing that worked.

On the styling: the first attempt kept a translucent accent fill and just strengthened the border, which did not help, because the problem was text contrast rather than edge definition. A translucent fill leaves the label sitting on effectively raw background. Solid `accentStudio` with inverted near-black text fixes the legibility properly. The hover state and its `.easeOut(0.12)` timing match `DSMenu`, the sibling component in the same folder.

Both editors had byte-identical copies of this button, so they now share one component in `Shared/Components/` and cannot drift apart again.

## How to test


1. Open TokenEater, then **Studio → Popover**. Widen the window past 780pt to get the three-column layout.
2. Look at the top-right of the ELEMENTS column. "Add element" should be a filled violet pill with clear padding, not bare text.
3. Hover it. The fill should lift slightly.
4. Click it and confirm the menu still opens with the same Metrics / Pacing / Utilities sections in the same order, and that adding an element still works.
5. Repeat on **Studio → Menu bar** for the equivalent "Add segment" control.

## Checklist


- [x] Tests pass locally
- [x] If you changed SwiftUI or the widget, you tested it manually in a Release build
- [x] Branch is rebased on the latest `main`

---

Tested on macOS 26.x with Xcode 26.6 / Swift 6.3.3. Full suite green (624 tests, 65 suites) and the Release build is clean apart from the two warnings already present on `main`. Built unsigned with `CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO`, since I do not have your team ID.

No changes to menu contents, ordering, section grouping, or the `accountHasKind` availability logic.

One thing worth flagging: `DSMenu` has the same bug. Its capsule and hover state use the same label-scoped construction and never paint either, which defeats the purpose its own doc comment describes. I left it alone to keep this PR focused and will open a separate issue. Note that whoever fixes it will need to move the `.padding()` along with the `.background()`, since both are dropped.
