### PR TITLE
refactor(security): make the fixed-IV AES encrypt path private

### DIFF
--- a/Shared/Services/ElectronDecryptionService.swift
+++ b/Shared/Services/ElectronDecryptionService.swift
@@ -189,7 +189,18 @@ final class ElectronDecryptionService: ElectronDecryptionServiceProtocol, @unche
         return Data(outBuffer.prefix(outLength))
     }
 
-    static func aesEncrypt(plaintext: Data, key: Data) throws -> Data {
+    /// Electron compatibility only. Do not call this for anything else.
+    ///
+    /// This encrypts under the fixed IV above, which Electron's `safeStorage`
+    /// format requires and which is harmless for the decrypt path we actually
+    /// need. Encrypting with it is not: a constant IV means identical plaintext
+    /// prefixes produce identical ciphertext blocks, so an observer learns which
+    /// values repeat without ever holding the key. Its only caller is the debug
+    /// round-trip test helper below, and it stays private so no future feature
+    /// can reach for it by accident. Anything that genuinely needs to encrypt
+    /// should use AES.GCM or ChaChaPoly from CryptoKit, with a fresh random
+    /// nonce per message.
+    private static func aesEncrypt(plaintext: Data, key: Data) throws -> Data {
         var outLength = 0
         var outBuffer = [UInt8](repeating: 0, count: plaintext.count + kCCBlockSizeAES128)
 


### PR DESCRIPTION
`ElectronDecryptionService` encrypts under a constant IV, which the Electron
`safeStorage` format requires. That is fine for the decrypt path we actually need
it for. Encrypting under a constant IV is not: identical plaintext prefixes yield
identical ciphertext blocks, so an observer learns which values repeat without
ever holding the key.

Nothing outside the `#if DEBUG` round-trip test helper calls it today, so this is
latent rather than exploitable and does not warrant an advisory. Closing it off
keeps a future feature from reaching for a convenient-looking encrypt function
and introducing a real weakness. Anything that genuinely needs to encrypt should
use `AES.GCM` or `ChaChaPoly` with a fresh random nonce per message.

Reported privately by [Mike Graff](https://github.com/michaelgraff) (Dolby
Laboratories) alongside GHSA-jxvp-49pc-jjg9, which was the more serious of the
two and shipped in 5.12.1.

626 tests pass, Release build OK.
