### PR TITLE
fix: session monitor CPU usage at idle (#255)

### DIFF
--- a/Shared/Helpers/JSONLParser.swift
+++ b/Shared/Helpers/JSONLParser.swift
@@ -102,6 +102,10 @@ enum JSONLParser {
         let lines = content.split(separator: "\n", omittingEmptySubsequences: true)
         guard !lines.isEmpty else { return nil }
 
+        // One decoder for the whole tail: allocating a JSONDecoder per line
+        // was a measurable slice of every scan tick (#255).
+        let decoder = JSONDecoder()
+
         var lastMeaningfulEvent: RawEvent?
         var latestMeta: (sessionId: String, cwd: String, gitBranch: String?)?
         var pendingPermission = false
@@ -112,7 +116,7 @@ enum JSONLParser {
 
         for line in lines.reversed() {
             guard let data = line.data(using: .utf8),
-                  let event = try? JSONDecoder().decode(RawEvent.self, from: data) else {
+                  let event = try? decoder.decode(RawEvent.self, from: data) else {
                 continue
             }
 

--- a/Shared/Helpers/ProcessResolver.swift
+++ b/Shared/Helpers/ProcessResolver.swift
@@ -25,6 +25,7 @@ enum ProcessResolver {
 
         // Build a pid → parentPid lookup for ancestor walking
         var parentLookup: [Int32: Int32] = [:]
+        parentLookup.reserveCapacity(allProcs.count)
         for proc in allProcs {
             parentLookup[proc.pid] = proc.parentPid
         }
@@ -66,10 +67,10 @@ enum ProcessResolver {
             if ret > 0 {
                 let path = String(cString: pathBuffer)
                 // IDE found → return immediately, always wins
-                if idePathPatterns.contains(where: { path.contains($0) }) {
+                if pathMatches(path, anyOf: idePatternBytes) {
                     return .ide
                 }
-                if terminalPathPatterns.contains(where: { path.contains($0) }) {
+                if pathMatches(path, anyOf: terminalPatternBytes) {
                     foundTerminal = true
                 }
             }
@@ -228,8 +229,44 @@ enum ProcessResolver {
     }
 
     /// Check if an executable path matches a known Claude Code installation.
+    /// Matches raw UTF-8 bytes rather than going through Foundation's
+    /// Unicode-aware `String.contains`: every scan tick classifies the path of
+    /// every process on the system, and the grapheme-aware search dominated
+    /// the tick's CPU (#255). The patterns are plain ASCII, and an ASCII byte
+    /// sequence can never appear inside a UTF-8 multi-byte character, so byte
+    /// matching never misses a path the Unicode-aware search matched; its one
+    /// divergence is more permissive (a combining mark directly after the
+    /// matched text no longer blocks the match).
     static func isClaudePath(_ path: String) -> Bool {
-        knownClaudePaths.contains { path.contains($0) }
+        pathMatches(path, anyOf: knownClaudePathBytes)
+    }
+
+    // MARK: - Byte-level path matching (#255)
+
+    private static let knownClaudePathBytes = knownClaudePaths.map { Array($0.utf8) }
+    private static let idePatternBytes = idePathPatterns.map { Array($0.utf8) }
+    private static let terminalPatternBytes = terminalPathPatterns.map { Array($0.utf8) }
+
+    private static func pathMatches(_ path: String, anyOf needles: [[UInt8]]) -> Bool {
+        let haystack = Array(path.utf8)
+        return needles.contains { bytesContain(haystack, $0) }
+    }
+
+    private static func bytesContain(_ haystack: [UInt8], _ needle: [UInt8]) -> Bool {
+        let m = needle.count
+        guard m > 0, haystack.count >= m else { return false }
+        let first = needle[0]
+        let limit = haystack.count - m
+        var i = 0
+        while i <= limit {
+            if haystack[i] == first {
+                var j = 1
+                while j < m, haystack[i + j] == needle[j] { j += 1 }
+                if j == m { return true }
+            }
+            i += 1
+        }
+        return false
     }
 
     /// Detect the installed Claude Code version by scanning known installation directories.
@@ -274,11 +311,37 @@ enum ProcessResolver {
             .last
     }
 
+    /// Classification verdicts memoized per executable path (#255): the set of
+    /// executable paths on a machine is small and stable, and keying by path
+    /// rather than pid makes the cache immune to pid reuse and in-place exec.
+    /// Locked because `findClaudeProcesses` runs both on the session monitor
+    /// queue (every tick) and on the overlay's click queue.
+    private static let verdictLock = NSLock()
+    private static var pathVerdicts: [String: Bool] = [:]
+
     private static func isClaudeProcess(pid: Int32) -> Bool {
         var pathBuffer = [CChar](repeating: 0, count: Int(MAXPATHLEN))
         let ret = proc_pidpath(pid, &pathBuffer, UInt32(MAXPATHLEN))
         guard ret > 0 else { return false }
-        return isClaudePath(String(cString: pathBuffer))
+        let path = String(cString: pathBuffer)
+
+        verdictLock.lock()
+        if let cached = pathVerdicts[path] {
+            verdictLock.unlock()
+            return cached
+        }
+        verdictLock.unlock()
+
+        let verdict = isClaudePath(path)
+
+        verdictLock.lock()
+        // Short-lived processes with unique paths could grow the cache without
+        // bound over long uptimes; a full reset is cheaper than an LRU and the
+        // steady-state population repays itself within one tick.
+        if pathVerdicts.count >= 2048 { pathVerdicts.removeAll(keepingCapacity: true) }
+        pathVerdicts[path] = verdict
+        verdictLock.unlock()
+        return verdict
     }
 
     private static func getProcessCwd(pid: Int32) -> String? {

--- a/Shared/Services/SessionMonitorService.swift
+++ b/Shared/Services/SessionMonitorService.swift
@@ -17,6 +17,40 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
     private let claudeSessionsDirOverride: URL?
     private let processProvider: @Sendable () -> [ClaudeProcessInfo]
 
+    // Cross-tick caches (#255). All three are touched only inside `scan()`,
+    // which runs on `queue` in production and synchronously (never
+    // concurrently) in tests, so they need no extra locking.
+
+    /// Per-project-dir file listing keyed by dir path. On APFS/HFS a dir's
+    /// mtime changes on add/remove/rename but NOT when a contained file is
+    /// appended to, so an unchanged dir mtime proves the file LIST is
+    /// unchanged and re-enumerating thousands of JSONLs every tick is pure
+    /// waste. File mtimes are deliberately NOT part of this cache: appends
+    /// move them without touching the dir, so they are re-stat'ed fresh
+    /// wherever they matter.
+    private struct DirListing {
+        let dirMtime: Date
+        let files: [(url: URL, sessionId: String)]
+    }
+    private var dirListings: [String: DirListing] = [:]
+
+    /// First-line timestamp per transcript path. Transcripts are append-only,
+    /// so a first line never changes once it exists and parses.
+    private var startedAtCache: [String: Date] = [:]
+
+    /// A file identity snapshot for cache validity: mtime plus size. Size
+    /// matters on volumes with 1-2s mtime granularity (HFS+, SMB) where two
+    /// appends can share a timestamp; an append always grows the file.
+    private struct FileStamp: Equatable {
+        let mtime: Date
+        let size: Int
+    }
+
+    /// Last tail-parse per transcript path, valid while the file's stamp is
+    /// unchanged: appends are the only mutation Claude Code performs on a
+    /// transcript.
+    private var parseCache: [String: (stamp: FileStamp, result: JSONLParseResult)] = [:]
+
     private var claudeProjectsDir: URL {
         if let override = claudeProjectsDirOverride { return override }
         let home: String
@@ -96,7 +130,10 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
         }
     }
 
-    /// Internal for perf tests. Must stay safe to call synchronously off the timer queue.
+    /// Internal for tests, which call it synchronously on a service whose
+    /// timer never runs. It mutates the cross-tick caches, so it must never
+    /// run concurrently with a live monitoring timer; production always runs
+    /// it on `queue`.
     func scan() {
         let processes = processProvider()
         guard !processes.isEmpty else {
@@ -125,36 +162,37 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
         // (`~/.claude/sessions/<pid>.json`), for the running pids only.
         let registry = readSessionRegistry(pids: Set(processes.map { $0.pid }))
 
-        // Index every transcript once (filenames + mtime, no content reads).
-        // A transcript is named "<sessionId>.jsonl", so this maps a sessionId
-        // to its file wherever it lives - which is how we resolve a `--resume`d
-        // session whose transcript sits under its ORIGINAL project dir, not the
-        // directory the process happened to be launched from (#233).
-        //
-        // Freshness note: mtime comes from each JSONL, not the dir's own mtime.
-        // On APFS/HFS a dir's mtime only changes on add/remove/rename, not when
-        // Claude appends to an existing JSONL, so dir mtime would hide every
-        // ongoing conversation. Reading cached URLResourceValues here stays
-        // cheap versus `readAndParse()` per file.
-        struct TranscriptRef { let url: URL; let mtime: Date; let dir: URL }
+        refreshDirListings(projectDirs: projectDirs, fm: fm)
+
+        // Resolve a transcript for each sessionId the registry names, and only
+        // those: the cached listings already say where a "<sessionId>.jsonl"
+        // lives, so a handful of fresh stats replaces the every-file mtime
+        // sweep the old full index paid on each tick (#255). A transcript
+        // resolves wherever it lives, which is how a `--resume`d session whose
+        // transcript sits under its ORIGINAL project dir, not the directory
+        // the process was launched from, is found (#233). When the same
+        // sessionId exists under several dirs, the newest mtime wins (dirs are
+        // walked in stable path order so equal-mtime ties cannot flap between
+        // ticks with the dictionary's hashing).
+        struct TranscriptRef { let url: URL; let stamp: FileStamp; let dir: URL }
+        var neededSids = Set<String>()
+        for proc in processes {
+            if let sid = registry[proc.pid]?.sessionId { neededSids.insert(sid) }
+        }
         var bySessionId: [String: TranscriptRef] = [:]
-        var dirFiles: [(dir: URL, files: [(url: URL, mtime: Date)])] = []
-        for dir in projectDirs where dir.hasDirectoryPath {
-            guard let urls = try? fm.contentsOfDirectory(
-                at: dir,
-                includingPropertiesForKeys: [.contentModificationDateKey],
-                options: [.skipsHiddenFiles]
-            ) else { continue }
-            var files: [(url: URL, mtime: Date)] = []
-            for url in urls where url.pathExtension == "jsonl" {
-                let mtime = (try? url.resourceValues(forKeys: [.contentModificationDateKey])
-                    .contentModificationDate) ?? .distantPast
-                files.append((url, mtime))
-                let sid = url.deletingPathExtension().lastPathComponent
-                if let existing = bySessionId[sid], existing.mtime >= mtime { continue }
-                bySessionId[sid] = TranscriptRef(url: url, mtime: mtime, dir: dir)
+        if !neededSids.isEmpty {
+            bySessionId.reserveCapacity(neededSids.count)
+            for (dirPath, listing) in dirListings.sorted(by: { $0.key < $1.key }) {
+                for entry in listing.files where neededSids.contains(entry.sessionId) {
+                    let stamp = fileStamp(atPath: entry.url.path, fm: fm)
+                    if let existing = bySessionId[entry.sessionId], existing.stamp.mtime >= stamp.mtime { continue }
+                    bySessionId[entry.sessionId] = TranscriptRef(
+                        url: entry.url,
+                        stamp: stamp,
+                        dir: URL(fileURLWithPath: dirPath, isDirectory: true)
+                    )
+                }
             }
-            if !files.isEmpty { dirFiles.append((dir, files)) }
         }
 
         var activeSessions: [ClaudeSession] = []
@@ -169,9 +207,9 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
             guard let entry = registry[proc.pid],
                   let sid = entry.sessionId,
                   let ref = bySessionId[sid],
-                  let result = readAndParse(file: ref.url) else { continue }
+                  let result = cachedReadAndParse(file: ref.url, stamp: ref.stamp) else { continue }
 
-            let startedAt = readFirstTimestamp(of: ref.url) ?? ref.mtime
+            let startedAt = cachedStartedAt(of: ref.url) ?? ref.stamp.mtime
             let resolvedState: SessionState
             if result.state == .thinking,
                let compactState = checkCompacting(sessionId: sid, projectDir: ref.dir) {
@@ -186,7 +224,7 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
                 userSessionName: userName(from: entry, sessionId: sid),
                 model: result.model,
                 state: resolvedState,
-                lastUpdate: ref.mtime,
+                lastUpdate: ref.stamp.mtime,
                 startedAt: startedAt,
                 processPid: proc.pid,
                 sourceKind: proc.sourceKind,
@@ -204,6 +242,20 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
         // over fresh dirs only.
         let remaining = processes.filter { !consumedPids.contains($0.pid) }
         if !remaining.isEmpty {
+            // The full per-file stat sweep is paid only here, when a process
+            // has no usable registry entry (older Claude Code, or a transcript
+            // the registry pass could not locate).
+            var dirFiles: [(dir: URL, files: [(url: URL, stamp: FileStamp)])] = []
+            dirFiles.reserveCapacity(dirListings.count)
+            for (dirPath, listing) in dirListings.sorted(by: { $0.key < $1.key }) where !listing.files.isEmpty {
+                var files: [(url: URL, stamp: FileStamp)] = []
+                files.reserveCapacity(listing.files.count)
+                for entry in listing.files {
+                    files.append((entry.url, fileStamp(atPath: entry.url.path, fm: fm)))
+                }
+                dirFiles.append((URL(fileURLWithPath: dirPath, isDirectory: true), files))
+            }
+
             var cwdToProcesses: [String: [ClaudeProcessInfo]] = [:]
             for proc in remaining {
                 cwdToProcesses[proc.cwd, default: []].append(proc)
@@ -218,16 +270,16 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
             let sortedDirs = dirFiles.sorted { $0.dir.lastPathComponent.count > $1.dir.lastPathComponent.count }
 
             outer: for entry in sortedDirs {
-                let sortedFiles = entry.files.sorted { $0.mtime > $1.mtime }
-                guard let newest = sortedFiles.first, newest.mtime >= freshnessCutoff else { continue }
+                let sortedFiles = entry.files.sorted { $0.stamp.mtime > $1.stamp.mtime }
+                guard let newest = sortedFiles.first, newest.stamp.mtime >= freshnessCutoff else { continue }
 
-                for (file, mtime) in sortedFiles {
+                for (file, stamp) in sortedFiles {
                     let sessionId = file.deletingPathExtension().lastPathComponent
                     if emittedSessionIds.contains(sessionId) { continue }
-                    guard let result = readAndParse(file: file) else { continue }
+                    guard let result = cachedReadAndParse(file: file, stamp: stamp) else { continue }
                     guard let process = matchProcess(projectPath: result.projectPath, in: cwdToProcesses) else { continue }
 
-                    let startedAt = readFirstTimestamp(of: file) ?? mtime
+                    let startedAt = cachedStartedAt(of: file) ?? stamp.mtime
                     let resolvedState: SessionState
                     if result.state == .thinking,
                        let compactState = checkCompacting(sessionId: sessionId, projectDir: entry.dir) {
@@ -242,7 +294,7 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
                         userSessionName: readUserSessionName(pid: process.pid, sessionId: sessionId),
                         model: result.model,
                         state: resolvedState,
-                        lastUpdate: mtime,
+                        lastUpdate: stamp.mtime,
                         startedAt: startedAt,
                         processPid: process.pid,
                         sourceKind: process.sourceKind,
@@ -271,6 +323,118 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
             return $0.id < $1.id
         }
         sessionsSubject.send(activeSessions)
+    }
+
+    /// Refresh the per-dir listing cache from a fresh top-level listing of
+    /// the projects dir. Only dirs whose mtime moved since the last tick are
+    /// re-enumerated; listings of deleted dirs are dropped, and the per-file
+    /// caches of files that left a listing are purged with them.
+    private func refreshDirListings(projectDirs: [URL], fm: FileManager) {
+        var live = Set<String>()
+        live.reserveCapacity(projectDirs.count)
+        for dir in projectDirs where dir.hasDirectoryPath {
+            let path = dir.path
+            live.insert(path)
+            let dirMtime = (try? dir.resourceValues(forKeys: [.contentModificationDateKey])
+                .contentModificationDate) ?? .distantPast
+            // Serve the cache only when the mtime is readable, matches, and is
+            // safely in the past: an unreadable mtime can hide anything, and a
+            // just-modified dir could still gain a file inside the same
+            // timestamp bucket on volumes with 1-2s mtime granularity (HFS+,
+            // SMB).
+            if dirMtime != .distantPast,
+               Date().timeIntervalSince(dirMtime) > 2,
+               let cached = dirListings[path], cached.dirMtime == dirMtime { continue }
+            // A failed enumeration must never be cached as an empty listing:
+            // recovering read permission changes ctime, not mtime, so the
+            // entry would never invalidate and the dir's sessions would stay
+            // invisible. Drop the entry and retry next tick, matching the
+            // pre-cache behavior of skipping such a dir for one tick only.
+            guard let urls = try? fm.contentsOfDirectory(
+                at: dir,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            ) else {
+                purgeFileCaches(for: dirListings.removeValue(forKey: path))
+                continue
+            }
+            var files: [(url: URL, sessionId: String)] = []
+            files.reserveCapacity(urls.count)
+            for url in urls where url.pathExtension == "jsonl" {
+                files.append((url, url.deletingPathExtension().lastPathComponent))
+            }
+            if let old = dirListings[path] {
+                let kept = Set(files.map { $0.url.path })
+                for entry in old.files where !kept.contains(entry.url.path) {
+                    parseCache.removeValue(forKey: entry.url.path)
+                    startedAtCache.removeValue(forKey: entry.url.path)
+                }
+            }
+            dirListings[path] = DirListing(dirMtime: dirMtime, files: files)
+        }
+        if dirListings.count != live.count {
+            for (path, listing) in dirListings where !live.contains(path) {
+                purgeFileCaches(for: listing)
+            }
+            dirListings = dirListings.filter { live.contains($0.key) }
+        }
+    }
+
+    /// Forget the per-file cache entries of a listing whose files left the
+    /// scan (dir deleted, or enumeration failed); a recreated file at the same
+    /// path must not inherit a dead file's parse or start timestamp.
+    private func purgeFileCaches(for listing: DirListing?) {
+        guard let listing else { return }
+        for entry in listing.files {
+            parseCache.removeValue(forKey: entry.url.path)
+            startedAtCache.removeValue(forKey: entry.url.path)
+        }
+    }
+
+    /// Fresh stat, bypassing NSURL's per-instance resource-value cache (the
+    /// listing cache reuses URL instances across ticks, whose cached values
+    /// would go stale).
+    private func fileStamp(atPath path: String, fm: FileManager) -> FileStamp {
+        guard let attrs = try? fm.attributesOfItem(atPath: path) else {
+            return FileStamp(mtime: .distantPast, size: -1)
+        }
+        return FileStamp(
+            mtime: (attrs[.modificationDate] as? Date) ?? .distantPast,
+            size: (attrs[.size] as? Int) ?? -1
+        )
+    }
+
+    /// First-line timestamp of a transcript, memoized per path: the file is
+    /// append-only, so its first line never changes. A nil parse is not
+    /// cached (the first line of a brand-new file may still be partial).
+    private func cachedStartedAt(of url: URL) -> Date? {
+        if let hit = startedAtCache[url.path] { return hit }
+        guard let ts = readFirstTimestamp(of: url) else { return nil }
+        if startedAtCache.count >= 8192 { startedAtCache.removeAll(keepingCapacity: true) }
+        startedAtCache[url.path] = ts
+        return ts
+    }
+
+    /// Tail-parse a transcript, reusing the previous tick's result while the
+    /// file's stamp (mtime + size) is unchanged: no append happened, so the
+    /// tail is identical. A failed stat (.distantPast sentinel) is never
+    /// trusted as a cache key, in either direction.
+    private func cachedReadAndParse(file: URL, stamp: FileStamp) -> JSONLParseResult? {
+        let key = file.path
+        if stamp.mtime != .distantPast,
+           let hit = parseCache[key], hit.stamp == stamp {
+            return hit.result
+        }
+        guard let result = readAndParse(file: file) else { return nil }
+        if stamp.mtime == .distantPast { return result }
+        // Real eviction happens when a file leaves its dir listing (see
+        // purgeFileCaches), so the population is bounded by the transcripts on
+        // disk; the cap is only a backstop, and it must stay above any
+        // realistic transcript count or a full fallback sweep would wipe the
+        // cache mid-scan and thrash (#255 reports ~7000 transcripts).
+        if parseCache.count >= 8192 { parseCache.removeAll(keepingCapacity: true) }
+        parseCache[key] = (stamp, result)
+        return result
     }
 
     /// Match a JSONL project path to a running Claude process.

--- a/TokenEaterTests/ProcessResolverTests.swift
+++ b/TokenEaterTests/ProcessResolverTests.swift
@@ -77,6 +77,33 @@ struct ProcessResolverTests {
         #expect(!ProcessResolver.isClaudePath(""))
     }
 
+    // MARK: - Byte-level matching (#255)
+    // The ASCII patterns must behave identically on multi-byte UTF-8 paths,
+    // including the NFD-decomposed names macOS stores on disk.
+
+    @Test("detects an install under an NFD-decomposed unicode home dir")
+    func detectsInstallUnderDecomposedUnicodeHome() {
+        // "réné" written with U+0301 combining acute accents (the on-disk form)
+        let path = "/Users/re\u{0301}ne\u{0301}/.local/share/claude/versions/2.0.10/claude"
+        #expect(ProcessResolver.isClaudePath(path))
+    }
+
+    @Test("detects an install under a multi-byte home dir")
+    func detectsInstallUnderMultibyteHome() {
+        let path = "/Users/日本語/.local/share/claude/versions/1.2.3/claude"
+        #expect(ProcessResolver.isClaudePath(path))
+    }
+
+    @Test("rejects a multi-byte path without Claude")
+    func rejectsMultibytePath() {
+        #expect(!ProcessResolver.isClaudePath("/Users/日本語/bin/node"))
+    }
+
+    @Test("rejects a near-miss package name")
+    func rejectsNearMissPackageName() {
+        #expect(!ProcessResolver.isClaudePath("/usr/lib/node_modules/@anthropic-ai/claude-codex/cli.js"))
+    }
+
     // MARK: - TTY resolution
 
     @Test("getProcessTTY returns a valid TTY for the current process")

--- a/TokenEaterTests/SessionMonitorCacheTests.swift
+++ b/TokenEaterTests/SessionMonitorCacheTests.swift
@@ -1,0 +1,237 @@
+import Testing
+import Foundation
+import Combine
+
+/// #255: the scan used to re-enumerate every project dir and re-parse every
+/// matched transcript on each tick. The fix caches dir listings (invalidated
+/// by dir mtime, which moves on add/remove/rename but not on appends), tail
+/// parses (invalidated by file mtime + size), and first-line timestamps
+/// (append-only files never change their first line). These tests pin the
+/// invalidation behavior across consecutive scans on one service instance.
+///
+/// Dir mtimes are pinned to PAST values throughout: a just-modified dir is
+/// deliberately re-enumerated for 2s regardless of the cache (coarse-mtime
+/// volumes), so only a stable past mtime proves the cache comparison itself.
+@Suite("Session monitor cross-tick caches invalidate correctly (#255)")
+struct SessionMonitorCacheTests {
+
+    private func idleLine(sessionId: String, cwd: String) -> String {
+        """
+        {"type":"assistant","sessionId":"\(sessionId)","cwd":"\(cwd)","gitBranch":"main","timestamp":"2026-09-01T12:00:00.000Z","message":{"role":"assistant","model":"claude-opus-4-7","stop_reason":"end_turn","content":[]}}
+        """
+    }
+
+    private func thinkingLine(sessionId: String, cwd: String) -> String {
+        """
+        {"type":"assistant","sessionId":"\(sessionId)","cwd":"\(cwd)","gitBranch":"main","timestamp":"2026-09-01T12:00:05.000Z","message":{"role":"assistant","model":"claude-opus-4-7","stop_reason":null,"content":[]}}
+        """
+    }
+
+    private struct Env {
+        let root: URL
+        let projectsDir: URL
+        let sessionsDir: URL
+        let projectDir: URL
+        let cwd: String
+        let sessionId: String
+
+        var transcript: URL { projectDir.appendingPathComponent("\(sessionId).jsonl") }
+
+        func cleanup() { try? FileManager.default.removeItem(at: root) }
+    }
+
+    private func makeEnv() throws -> Env {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent("te-cache-\(UUID().uuidString)")
+        let projectsDir = root.appendingPathComponent("projects")
+        let sessionsDir = root.appendingPathComponent("sessions")
+        let projectDir = projectsDir.appendingPathComponent("-checkout-x")
+        try fm.createDirectory(at: projectDir, withIntermediateDirectories: true)
+        try fm.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+
+        let env = Env(
+            root: root,
+            projectsDir: projectsDir,
+            sessionsDir: sessionsDir,
+            projectDir: projectDir,
+            cwd: root.appendingPathComponent("checkout-x").path,
+            sessionId: "cccccccc-0000-4000-8000-000000000003"
+        )
+        try idleLine(sessionId: env.sessionId, cwd: env.cwd)
+            .write(to: env.transcript, atomically: true, encoding: .utf8)
+        return env
+    }
+
+    private func makeService(_ env: Env, pid: Int32) -> SessionMonitorService {
+        let process = ClaudeProcessInfo(pid: pid, parentPid: 1, cwd: env.cwd, sourceKind: .terminal)
+        return SessionMonitorService(
+            scanInterval: 999,
+            projectDirFreshness: 24 * 60 * 60,
+            claudeProjectsDirOverride: env.projectsDir,
+            claudeSessionsDirOverride: env.sessionsDir,
+            processProvider: { [process] }
+        )
+    }
+
+    private func scanOnce(_ service: SessionMonitorService) -> [ClaudeSession] {
+        var captured: [ClaudeSession] = []
+        let cancellable = service.sessionsPublisher.sink { captured = $0 }
+        service.scan()
+        cancellable.cancel()
+        return captured
+    }
+
+    private func setMtime(_ date: Date, at url: URL) throws {
+        try FileManager.default.setAttributes([.modificationDate: date], ofItemAtPath: url.path)
+    }
+
+    private func writeRegistry(_ env: Env, pid: Int32, sessionId: String) throws {
+        try """
+        {"pid":\(pid),"sessionId":"\(sessionId)","cwd":"\(env.cwd)"}
+        """.write(to: env.sessionsDir.appendingPathComponent("\(pid).json"),
+                  atomically: true, encoding: .utf8)
+    }
+
+    private func append(_ line: String, to url: URL) throws {
+        let handle = try FileHandle(forWritingTo: url)
+        handle.seekToEndOfFile()
+        handle.write(Data(("\n" + line).utf8))
+        try handle.close()
+    }
+
+    @Test("an append is re-parsed even though the dir listing stays cached (fallback pass)")
+    func appendReparsedDespiteCachedDirListing() throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+        // A stable, past dir mtime: the cached listing stays valid across both
+        // scans, so only the file's own stamp can carry the invalidation,
+        // which is exactly the append case (appends never touch dir mtime).
+        let dirMtime = Date().addingTimeInterval(-3600)
+        try setMtime(dirMtime, at: env.projectDir)
+        let service = makeService(env, pid: 8000)
+
+        let first = scanOnce(service)
+        #expect(first.first?.state == .idle)
+
+        try append(thinkingLine(sessionId: env.sessionId, cwd: env.cwd), to: env.transcript)
+        try setMtime(Date().addingTimeInterval(5), at: env.transcript)
+        try setMtime(dirMtime, at: env.projectDir)
+
+        let second = scanOnce(service)
+        #expect(second.first?.state == .thinking)
+    }
+
+    @Test("an append is re-parsed on the registry pass too")
+    func appendReparsedOnRegistryPass() throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+        let dirMtime = Date().addingTimeInterval(-3600)
+        try setMtime(dirMtime, at: env.projectDir)
+        try writeRegistry(env, pid: 8005, sessionId: env.sessionId)
+        let service = makeService(env, pid: 8005)
+
+        let first = scanOnce(service)
+        #expect(first.first?.state == .idle)
+        #expect(first.first?.processPid == 8005)
+
+        try append(thinkingLine(sessionId: env.sessionId, cwd: env.cwd), to: env.transcript)
+        try setMtime(Date().addingTimeInterval(5), at: env.transcript)
+        try setMtime(dirMtime, at: env.projectDir)
+
+        let second = scanOnce(service)
+        #expect(second.first?.state == .thinking)
+    }
+
+    @Test("a transcript added to an already-cached dir is picked up (mtime-bump invalidation)")
+    func newTranscriptInCachedDirInvalidatesListing() throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+        try setMtime(Date().addingTimeInterval(-3600), at: env.projectDir)
+        let service = makeService(env, pid: 8004)
+
+        let first = scanOnce(service)
+        #expect(first.first?.id == env.sessionId)
+
+        // A new session starts in the SAME dir, whose listing was cached by
+        // the first scan. Creating the file bumps the dir mtime; re-pin it to
+        // a distinct PAST value so only the mtime comparison itself, not the
+        // hot-dir re-enumeration window, can refresh the listing.
+        let newSid = "ffffffff-0000-4000-8000-000000000006"
+        try idleLine(sessionId: newSid, cwd: env.cwd)
+            .write(to: env.projectDir.appendingPathComponent("\(newSid).jsonl"), atomically: true, encoding: .utf8)
+        try setMtime(Date().addingTimeInterval(-1800), at: env.projectDir)
+        try writeRegistry(env, pid: 8004, sessionId: newSid)
+
+        let second = scanOnce(service)
+        #expect(second.first?.id == newSid)
+        #expect(second.first?.transcriptPath?.hasSuffix("-checkout-x/\(newSid).jsonl") == true)
+    }
+
+    @Test("a transcript in a new project dir is picked up (listing cache miss)")
+    func newTranscriptInNewDirIsPickedUp() throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+        let service = makeService(env, pid: 8001)
+        _ = scanOnce(service)
+
+        // A second session appears in a NEW project dir after the first scan,
+        // and the registry binds the process to it (#233 resolution path).
+        let newSid = "dddddddd-0000-4000-8000-000000000004"
+        let otherDir = env.projectsDir.appendingPathComponent("-checkout-y")
+        try FileManager.default.createDirectory(at: otherDir, withIntermediateDirectories: true)
+        let otherCwd = env.root.appendingPathComponent("checkout-y").path
+        try idleLine(sessionId: newSid, cwd: otherCwd)
+            .write(to: otherDir.appendingPathComponent("\(newSid).jsonl"), atomically: true, encoding: .utf8)
+        try writeRegistry(env, pid: 8001, sessionId: newSid)
+
+        let second = scanOnce(service)
+        #expect(second.count == 1)
+        #expect(second.first?.id == newSid)
+        #expect(second.first?.transcriptPath?.hasSuffix("-checkout-y/\(newSid).jsonl") == true)
+    }
+
+    @Test("a deleted transcript drops its session on the next tick")
+    func deletedTranscriptDropsSession() throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+        let service = makeService(env, pid: 8002)
+
+        let first = scanOnce(service)
+        #expect(first.count == 1)
+
+        try FileManager.default.removeItem(at: env.transcript)
+
+        let second = scanOnce(service)
+        #expect(second.isEmpty)
+    }
+
+    @Test("a registry entry written after the first scan is honored (#233)")
+    func lateRegistryEntryHonored() throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+
+        // A second project dir holds a resumed session's transcript, present
+        // from the start; the process itself runs from checkout-x's cwd.
+        let resumedSid = "eeeeeeee-0000-4000-8000-000000000005"
+        let otherDir = env.projectsDir.appendingPathComponent("-checkout-z")
+        try FileManager.default.createDirectory(at: otherDir, withIntermediateDirectories: true)
+        let otherCwd = env.root.appendingPathComponent("checkout-z").path
+        try idleLine(sessionId: resumedSid, cwd: otherCwd)
+            .write(to: otherDir.appendingPathComponent("\(resumedSid).jsonl"), atomically: true, encoding: .utf8)
+
+        let service = makeService(env, pid: 8003)
+
+        // First scan: no registry, the cwd heuristic binds to checkout-x.
+        let first = scanOnce(service)
+        #expect(first.first?.id == env.sessionId)
+
+        // Claude Code then writes its registry entry pointing at the resumed
+        // session; the next tick must re-resolve against it, not against
+        // anything cached on the first tick.
+        try writeRegistry(env, pid: 8003, sessionId: resumedSid)
+
+        let second = scanOnce(service)
+        #expect(second.first?.id == resumedSid)
+        #expect(second.first?.transcriptPath?.hasSuffix("-checkout-z/\(resumedSid).jsonl") == true)
+    }
+}

--- a/TokenEaterTests/SessionMonitorPerfTests.swift
+++ b/TokenEaterTests/SessionMonitorPerfTests.swift
@@ -68,9 +68,13 @@ struct SessionMonitorPerfTests {
         service.scan()
         let duration = ContinuousClock.now - start
 
+        // The fixtures now parse for real, so a cold scan legitimately does
+        // 1000 full tail parses (~0.7s on a loaded CI runner); the bound only
+        // guards against pathological blowups, the warm/cold ratio test below
+        // is what pins the caches.
         #expect(
-            duration < .milliseconds(500),
-            "scan took \(duration) on 50 dirs * 20 files (1000 JSONLs); pre-fix O(N log N) stat calls can exceed this on CI"
+            duration < .milliseconds(2000),
+            "cold scan took \(duration) on 50 dirs * 20 files (1000 parsed JSONLs)"
         )
     }
 

--- a/TokenEaterTests/SessionMonitorPerfTests.swift
+++ b/TokenEaterTests/SessionMonitorPerfTests.swift
@@ -1,12 +1,16 @@
 import Testing
 import Foundation
 
-@Suite("SessionMonitorService performance")
+// .serialized: these tests assert wall-clock budgets, so they must not share
+// the process with each other while timing (other suites still run in
+// parallel, hence the generous bounds).
+@Suite("SessionMonitorService performance", .serialized)
 struct SessionMonitorPerfTests {
 
     /// Build a synthetic projects tree with `dirCount` subdirs and `filesPerDir` JSONL files each.
-    /// Files are empty placeholders - the parser will fail on them, which matches the pre-fix
-    /// behavior on JSONLs that aren't well-formed and still exercises the full walk/sort path.
+    /// Every file holds one valid assistant line whose cwd matches no process, so a scan
+    /// walks, stats, and PARSES all of them without ever emitting a session - the full
+    /// fallback-pass workload.
     private func makeSyntheticProjects(dirCount: Int, filesPerDir: Int) throws -> URL {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("te-perf-\(UUID().uuidString)")
@@ -16,17 +20,34 @@ struct SessionMonitorPerfTests {
             let dir = root.appendingPathComponent("-project-dir-\(d)")
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
             for _ in 0..<filesPerDir {
-                let file = dir.appendingPathComponent("\(UUID().uuidString).jsonl")
-                try Data().write(to: file)
+                let sid = UUID().uuidString
+                let file = dir.appendingPathComponent("\(sid).jsonl")
+                let line = """
+                {"type":"assistant","sessionId":"\(sid)","cwd":"/nonmatching/cwd","gitBranch":"main","timestamp":"2026-09-01T12:00:00.000Z","message":{"role":"assistant","model":"claude-opus-4-7","stop_reason":"end_turn","content":[]}}
+                """
+                try line.write(to: file, atomically: true, encoding: .utf8)
             }
         }
         return root
     }
 
+    /// An empty sessions dir so the scan never touches the machine's real
+    /// `~/.claude/sessions` registry inside a timed section.
+    private func makeEmptySessionsDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("te-perf-sessions-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
     @Test("scan finishes quickly on a big tree (~1000 JSONL files)")
     func scanStaysFastWithManyDirs() async throws {
         let projectsDir = try makeSyntheticProjects(dirCount: 50, filesPerDir: 20)
-        defer { try? FileManager.default.removeItem(at: projectsDir) }
+        let sessionsDir = try makeEmptySessionsDir()
+        defer {
+            try? FileManager.default.removeItem(at: projectsDir)
+            try? FileManager.default.removeItem(at: sessionsDir)
+        }
 
         // Fake a running Claude process so scan() does not bail out early, forcing the walk.
         let fakeProcess = ClaudeProcessInfo(
@@ -39,6 +60,7 @@ struct SessionMonitorPerfTests {
             scanInterval: 999,
             projectDirFreshness: 24 * 60 * 60,
             claudeProjectsDirOverride: projectsDir,
+            claudeSessionsDirOverride: sessionsDir,
             processProvider: { [fakeProcess] }
         )
 
@@ -52,10 +74,66 @@ struct SessionMonitorPerfTests {
         )
     }
 
+    @Test("a warm scan over an unchanged tree beats the cold scan (#255)")
+    func warmScanBeatsColdScan() async throws {
+        let projectsDir = try makeSyntheticProjects(dirCount: 50, filesPerDir: 20)
+        let sessionsDir = try makeEmptySessionsDir()
+        defer {
+            try? FileManager.default.removeItem(at: projectsDir)
+            try? FileManager.default.removeItem(at: sessionsDir)
+        }
+
+        // Backdate the dir mtimes so the listings qualify for the cache: a
+        // just-modified dir is deliberately re-enumerated for 2s (coarse-mtime
+        // volumes, see refreshDirListings).
+        let past = Date().addingTimeInterval(-3600)
+        for dir in try FileManager.default.contentsOfDirectory(
+            at: projectsDir, includingPropertiesForKeys: nil
+        ) where dir.hasDirectoryPath {
+            try FileManager.default.setAttributes(
+                [.modificationDate: past], ofItemAtPath: dir.path
+            )
+        }
+
+        let fakeProcess = ClaudeProcessInfo(
+            pid: 99_998,
+            parentPid: 1,
+            cwd: "/nonexistent/project/path",
+            sourceKind: .terminal
+        )
+        let service = SessionMonitorService(
+            scanInterval: 999,
+            projectDirFreshness: 24 * 60 * 60,
+            claudeProjectsDirOverride: projectsDir,
+            claudeSessionsDirOverride: sessionsDir,
+            processProvider: { [fakeProcess] }
+        )
+
+        let coldStart = ContinuousClock.now
+        service.scan() // cold: enumerates 50 dirs, parses 1000 transcripts
+        let cold = ContinuousClock.now - coldStart
+
+        let warmStart = ContinuousClock.now
+        service.scan() // warm: cached listings + parse-cache hits, stats only
+        let warm = ContinuousClock.now - warmStart
+
+        // Ratio, not an absolute bound: the warm scan skips the 1000 parses
+        // and their up-to-4 file opens each, so it must be clearly cheaper
+        // than the cold scan on any machine, however loaded.
+        #expect(
+            warm * 2 < cold,
+            "warm scan (\(warm)) is not clearly cheaper than the cold scan (\(cold)); the cross-tick caches (#255) are not engaging"
+        )
+    }
+
     @Test("stale project dirs are skipped by the freshness filter")
     func skipsStaleProjectDirs() async throws {
         let projectsDir = try makeSyntheticProjects(dirCount: 5, filesPerDir: 1)
-        defer { try? FileManager.default.removeItem(at: projectsDir) }
+        let sessionsDir = try makeEmptySessionsDir()
+        defer {
+            try? FileManager.default.removeItem(at: projectsDir)
+            try? FileManager.default.removeItem(at: sessionsDir)
+        }
 
         // Backdate 3 of the 5 dirs to simulate stale activity.
         let dirs = try FileManager.default.contentsOfDirectory(
@@ -78,6 +156,7 @@ struct SessionMonitorPerfTests {
             scanInterval: 999,
             projectDirFreshness: 30 * 60,
             claudeProjectsDirOverride: projectsDir,
+            claudeSessionsDirOverride: sessionsDir,
             processProvider: { [fakeProcess] }
         )
 


### PR DESCRIPTION
Fixes #255.

## Root cause

Every 2s scan tick paid four unbounded costs, none of which depended on anything having changed:

1. `ProcessResolver.findClaudeProcesses()` reclassified every process on the system (996 on the reporter's machine) through Foundation's Unicode-aware `String.contains`, with no memoization between ticks (`isClaudeProcess` matches the executable path from `proc_pidpath`, not the argv).
2. `scan()` re-enumerated every project dir and re-stat'ed every JSONL (~7000 for the reporter) to rebuild the transcript index from scratch.
3. Every matched transcript was tail-read (up to 4 adaptive sizes) and re-parsed each tick, with a `JSONDecoder` allocated per line and an `ISO8601DateFormatter` per `readFirstTimestamp` call.
4. Per-tick dictionaries were grown without `reserveCapacity`.

The reporter's own `sample` split the cost roughly in half between (1) and (2)+(3), which matches what we measured.

## Fix

**ProcessResolver**
- Byte-level substring matching for all three ASCII pattern lists. An ASCII needle can never match inside a UTF-8 multi-byte character, so the matcher never misses a path the old code matched (its only divergence is being more permissive when a combining mark directly follows the matched text; a differential fuzz over 200k inputs found no divergence in the other direction).
- Classification verdicts memoized per executable path behind an `NSLock` (`findClaudeProcesses` runs on both the monitor queue and the overlay click queue). Path-keyed, so pid reuse and in-place exec cannot poison it; path-only classification was already the old semantics.

**SessionMonitorService, three cross-tick caches (scan()-confined, serial queue)**
- Per-dir file listings, invalidated by dir mtime: on APFS/HFS a dir's mtime moves on add/remove/rename but not on appends, so an unchanged mtime proves the file list is unchanged. File mtimes are never cached; they are re-stat'ed fresh where they matter. A failed enumeration is never cached (it would otherwise stick forever, since regaining read permission changes ctime, not mtime), and a dir modified less than 2s ago is re-enumerated regardless, to stay safe on coarse-mtime volumes (HFS+/SMB).
- Tail parses, keyed by file mtime + size (size closes the same-second double-append window on coarse-mtime volumes). Entries are purged when a file leaves its listing.
- First-line timestamps (append-only files never change their first line).
- The registry pass now resolves only the sessionIds the registry actually names (a handful of stats instead of a full sweep); the full per-file stat sweep is paid only by the registry-less fallback pass.

**JSONLParser**: one `JSONDecoder` per tail parse instead of one per line.

## Invariants deliberately preserved

- The `--resume` resolution from #233/#242: transcripts resolve wherever they live, registry entries and `/rename` are re-read every tick, and new cache tests pin a registry entry written between ticks.
- The per-tick `sessionsSubject.send` cadence, including empty publishes: SessionStore and the overlay use it as the clock for `isStale`/`isDead` transitions. A `removeDuplicates` was considered and rejected for exactly that reason (it would freeze dead-session hiding).

## Tests

- New suite `SessionMonitorCacheTests` (6 tests) pinning each invalidation path across two scans on one service: append with the dir mtime frozen (fallback AND registry pass), a new transcript in an already-cached dir (pins the mtime comparison itself, with the hot-dir window pinned out of the way), a new dir, a deletion, a late registry entry.
- `ProcessResolverTests`: NFD-decomposed and multi-byte path cases for the byte matcher, plus a near-miss package name.
- `SessionMonitorPerfTests`: now `.serialized`, fixtures parse for real, sessions dir overridden to a temp dir, and a warm-vs-cold ratio assertion that actually pins the caches (it caught a cache-thrash bug in an earlier version of this PR, where a 512-entry wipe backstop defeated the cache on 1000-file sweeps).
- Full suite: 637 tests, 66 suites, green. Release build (Xcode 16.4 toolchain) compiles clean.

## Expected impact

Steady state with registry-backed sessions: one sysctl walk with memoized byte-match verdicts, one root listing, a few stats, zero content reads for idle sessions. The two legs the reporter measured (~28% process classification, ~34% transcript indexing/parsing) both collapse to near-zero; idle CPU should sit well under 1% of a core even with thousands of transcripts.