### PR TITLE
fix: recognise the Claude 5 generation in History (Opus 5, Sonnet 5)

### DIFF
--- a/Shared/Models/UsageHistoryModels.swift
+++ b/Shared/Models/UsageHistoryModels.swift
@@ -42,9 +42,11 @@ enum HistoryRange: String, CaseIterable, Codable, Sendable {
 /// collapse all minor versions, anything unrecognised lands in `.other`.
 enum ModelKind: String, CaseIterable, Codable, Hashable, Sendable {
     case fable
+    case opus5
     case opus48
     case opus47
     case opus46
+    case sonnet5
     case sonnet
     case haiku
     case other
@@ -54,17 +56,22 @@ enum ModelKind: String, CaseIterable, Codable, Hashable, Sendable {
         if lower.contains("fable") {
             // Fable 5 (and any future Fable minor) maps to the Fable family.
             self = .fable
-        } else if lower.contains("opus-4-8") || lower.contains("opus-4.8") {
-            self = .opus48
+        } else if lower.contains("opus-5") || lower.contains("opus-4-8") || lower.contains("opus-4.8") {
+            // The Claude 5 generation drops the minor suffix ("claude-opus-5"),
+            // so a plain "opus-5" check is enough and cannot collide with the
+            // 4.x checks below ("opus-4-5" does not contain "opus-5") (#259).
+            self = lower.contains("opus-5") ? .opus5 : .opus48
         } else if lower.contains("opus-4-7") || lower.contains("opus-4.7") {
             self = .opus47
         } else if lower.contains("opus-4-6") || lower.contains("opus-4.6") {
             self = .opus46
         } else if lower.contains("opus") {
             // Bare "opus" alias and any unversioned Opus string map to the
-            // current shipping version. Future minor versions need their own
+            // current shipping version. Future versions need their own
             // explicit case above to get a distinct label and color.
-            self = .opus48
+            self = .opus5
+        } else if lower.contains("sonnet-5") {
+            self = .sonnet5
         } else if lower.contains("sonnet") {
             self = .sonnet
         } else if lower.contains("haiku") {
@@ -76,26 +83,29 @@ enum ModelKind: String, CaseIterable, Codable, Hashable, Sendable {
 
     var displayName: String {
         switch self {
-        case .fable:  return "Fable 5"
-        case .opus48: return "Opus 4.8"
-        case .opus47: return "Opus 4.7"
-        case .opus46: return "Opus 4.6"
-        case .sonnet: return "Sonnet"
-        case .haiku:  return "Haiku"
-        case .other:  return "Other"
+        case .fable:   return "Fable 5"
+        case .opus5:   return "Opus 5"
+        case .opus48:  return "Opus 4.8"
+        case .opus47:  return "Opus 4.7"
+        case .opus46:  return "Opus 4.6"
+        case .sonnet5: return "Sonnet 5"
+        case .sonnet:  return "Sonnet"
+        case .haiku:   return "Haiku"
+        case .other:   return "Other"
         }
     }
 
-    /// Family used by the filter chips. Opus 4.8, 4.7 and 4.6 fold into `.opus`
-    /// since users typically think "Opus" not "Opus 4.8 vs 4.7 vs 4.6". Fable is
-    /// its own family (no minor-version split yet).
+    /// Family used by the filter chips. Opus 5, 4.8, 4.7 and 4.6 fold into
+    /// `.opus` since users typically think "Opus" not "Opus 5 vs 4.8"; Sonnet 5
+    /// folds into `.sonnet` the same way. Fable is its own family (no
+    /// minor-version split yet).
     var family: ModelFamily {
         switch self {
-        case .fable:                    return .fable
-        case .opus48, .opus47, .opus46: return .opus
-        case .sonnet:                   return .sonnet
-        case .haiku:                    return .haiku
-        case .other:                    return .other
+        case .fable:                            return .fable
+        case .opus5, .opus48, .opus47, .opus46: return .opus
+        case .sonnet5, .sonnet:                 return .sonnet
+        case .haiku:                            return .haiku
+        case .other:                            return .other
         }
     }
 
@@ -104,7 +114,7 @@ enum ModelKind: String, CaseIterable, Codable, Hashable, Sendable {
     /// `stackOrderContainsEveryCase` test guards completeness (the array is not
     /// compiler-checked for missing cases).
     static var stackOrder: [ModelKind] {
-        [.haiku, .opus46, .opus47, .opus48, .fable, .sonnet, .other]
+        [.haiku, .opus46, .opus47, .opus48, .opus5, .fable, .sonnet, .sonnet5, .other]
     }
 }
 
@@ -313,6 +323,9 @@ struct HistoryCache: Codable, Sendable {
     /// v2: bumped so existing caches that bucketed `claude-fable-5` under
     /// `.other` (before Fable had its own `ModelKind`) are discarded and
     /// re-scanned, reclassifying Fable history immediately on update (#199).
-    static let currentVersion = 2
+    /// v3: same story for the Claude 5 generation: caches that bucketed
+    /// `claude-opus-5` under `.opus48` and `claude-sonnet-5` under `.sonnet`
+    /// must be re-scanned to pick up the new cases (#259, #261).
+    static let currentVersion = 3
     static let empty = HistoryCache(version: currentVersion, entries: [:])
 }

--- a/Shared/Models/UsageHistoryModels.swift
+++ b/Shared/Models/UsageHistoryModels.swift
@@ -65,6 +65,10 @@ enum ModelKind: String, CaseIterable, Codable, Hashable, Sendable {
             self = .opus47
         } else if lower.contains("opus-4-6") || lower.contains("opus-4.6") {
             self = .opus46
+        } else if lower.contains("opus-4") {
+            // A 4.x minor without an explicit case above stays in its own
+            // generation instead of inflating the Opus 5 bucket.
+            self = .opus48
         } else if lower.contains("opus") {
             // Bare "opus" alias and any unversioned Opus string map to the
             // current shipping version. Future versions need their own
@@ -325,7 +329,14 @@ struct HistoryCache: Codable, Sendable {
     /// re-scanned, reclassifying Fable history immediately on update (#199).
     /// v3: same story for the Claude 5 generation: caches that bucketed
     /// `claude-opus-5` under `.opus48` and `claude-sonnet-5` under `.sonnet`
-    /// must be re-scanned to pick up the new cases (#259, #261).
+    /// must be re-scanned to pick up the new cases (#259, #261). Side effect,
+    /// accepted: legacy rows whose JSONL says just "opus" relabel from
+    /// Opus 4.8 to Opus 5 in the re-scan (the bare alias carries no era, and
+    /// the fallback tracks the current shipping version by design).
     static let currentVersion = 3
     static let empty = HistoryCache(version: currentVersion, entries: [:])
+
+    /// True when this cache was written by the current schema. The loader
+    /// discards anything else so stale classifications are re-scanned.
+    var isCurrentVersion: Bool { version == Self.currentVersion }
 }

--- a/Shared/Services/SessionHistoryService.swift
+++ b/Shared/Services/SessionHistoryService.swift
@@ -294,7 +294,7 @@ final class SessionHistoryService: SessionHistoryServiceProtocol {
     private static func loadCache() -> HistoryCache {
         guard let data = try? Data(contentsOf: cacheURL),
               let cache = try? JSONDecoder().decode(HistoryCache.self, from: data),
-              cache.version == HistoryCache.currentVersion
+              cache.isCurrentVersion
         else {
             return .empty
         }

--- a/TokenEaterApp/Windows/History/HistoryView.swift
+++ b/TokenEaterApp/Windows/History/HistoryView.swift
@@ -1275,13 +1275,15 @@ struct HistoryView: View {
     /// better readability for back-to-back stacked segments.
     private func gradient(for kind: ModelKind) -> Color {
         switch kind {
-        case .fable:  return Color(hex: "#E86FC4")
-        case .opus48: return Color(hex: "#F2B968")
-        case .opus47: return Color(hex: "#E8A24A")
-        case .opus46: return Color(hex: "#C2792B")
-        case .sonnet: return Color(hex: "#5BC489")
-        case .haiku:  return Color(hex: "#4FB7B0")
-        case .other:  return Color(hex: "#9B8BD9")
+        case .fable:   return Color(hex: "#E86FC4")
+        case .opus5:   return Color(hex: "#EF8E52")
+        case .opus48:  return Color(hex: "#F2B968")
+        case .opus47:  return Color(hex: "#E8A24A")
+        case .opus46:  return Color(hex: "#C2792B")
+        case .sonnet5: return Color(hex: "#8CCF5F")
+        case .sonnet:  return Color(hex: "#5BC489")
+        case .haiku:   return Color(hex: "#4FB7B0")
+        case .other:   return Color(hex: "#9B8BD9")
         }
     }
 

--- a/TokenEaterTests/HistoryCacheTests.swift
+++ b/TokenEaterTests/HistoryCacheTests.swift
@@ -1,0 +1,20 @@
+import Testing
+import Foundation
+
+@Suite("HistoryCache versioning")
+struct HistoryCacheTests {
+
+    /// Every schema bump (#199, #259/#261) relies on version-mismatched caches
+    /// being rejected so already-parsed history is re-scanned and
+    /// reclassified; the loader's discard path was previously untested.
+    @Test func outdatedCacheIsRejected() throws {
+        let v2JSON = Data(#"{"version":2,"entries":{}}"#.utf8)
+        let decoded = try JSONDecoder().decode(HistoryCache.self, from: v2JSON)
+        #expect(!decoded.isCurrentVersion)
+    }
+
+    @Test func emptyCacheIsCurrent() {
+        #expect(HistoryCache.empty.isCurrentVersion)
+        #expect(HistoryCache.currentVersion == 3)
+    }
+}

--- a/TokenEaterTests/ModelKindTests.swift
+++ b/TokenEaterTests/ModelKindTests.swift
@@ -31,6 +31,12 @@ struct ModelKindTests {
         #expect(ModelKind(rawModel: "opus-4.6") == .opus46)
     }
 
+    /// A 4.x minor without its own case stays in the 4.x generation instead of
+    /// being absorbed by the bare-opus fallback into the Opus 5 bucket.
+    @Test func unknownOpus4MinorStaysInGeneration4() {
+        #expect(ModelKind(rawModel: "claude-opus-4-5") == .opus48)
+    }
+
     /// The bare "opus" alias appears in JSONL for the default model and must not
     /// fall through to `.other`; it maps to the current shipping Opus version.
     @Test func bareOpusAliasMapsToCurrentVersion() {
@@ -91,5 +97,6 @@ struct ModelKindTests {
 
     @Test func stackOrderContainsEveryCase() {
         #expect(Set(ModelKind.stackOrder) == Set(ModelKind.allCases))
+        #expect(ModelKind.stackOrder.count == ModelKind.allCases.count)
     }
 }

--- a/TokenEaterTests/ModelKindTests.swift
+++ b/TokenEaterTests/ModelKindTests.swift
@@ -6,6 +6,15 @@ struct ModelKindTests {
 
     // MARK: - Opus version mapping
 
+    /// Claude 5 generation IDs carry no minor suffix ("claude-opus-5") and must
+    /// not be absorbed by the bare-opus fallback into a 4.x label (#259).
+    @Test func opus5IsRecognised() {
+        #expect(ModelKind(rawModel: "claude-opus-5") == .opus5)
+        #expect(ModelKind(rawModel: "claude-opus-5[1m]") == .opus5)
+        #expect(ModelKind(rawModel: "opus-5") == .opus5)
+        #expect(ModelKind.opus5.displayName == "Opus 5")
+    }
+
     @Test func opus48IsRecognised() {
         #expect(ModelKind(rawModel: "claude-opus-4-8") == .opus48)
         #expect(ModelKind(rawModel: "claude-opus-4-8[1m]") == .opus48)
@@ -25,7 +34,7 @@ struct ModelKindTests {
     /// The bare "opus" alias appears in JSONL for the default model and must not
     /// fall through to `.other`; it maps to the current shipping Opus version.
     @Test func bareOpusAliasMapsToCurrentVersion() {
-        #expect(ModelKind(rawModel: "opus") == .opus48)
+        #expect(ModelKind(rawModel: "opus") == .opus5)
     }
 
     // MARK: - Fable
@@ -47,8 +56,18 @@ struct ModelKindTests {
 
     // MARK: - Other families
 
+    /// Sonnet 5 gets a versioned label instead of collapsing into the generic
+    /// legacy "Sonnet" bucket (#261).
+    @Test func sonnet5IsRecognised() {
+        #expect(ModelKind(rawModel: "claude-sonnet-5") == .sonnet5)
+        #expect(ModelKind(rawModel: "claude-sonnet-5[1m]") == .sonnet5)
+        #expect(ModelKind.sonnet5.displayName == "Sonnet 5")
+        #expect(ModelKind.sonnet5.family == .sonnet)
+    }
+
     @Test func sonnetAndHaiku() {
         #expect(ModelKind(rawModel: "claude-sonnet-4-6") == .sonnet)
+        #expect(ModelKind(rawModel: "claude-sonnet-4-5-20250929") == .sonnet)
         #expect(ModelKind(rawModel: "claude-haiku-4-5") == .haiku)
     }
 
@@ -60,6 +79,7 @@ struct ModelKindTests {
     // MARK: - Family folding
 
     @Test func everyOpusVersionFoldsIntoOpusFamily() {
+        #expect(ModelKind.opus5.family == .opus)
         #expect(ModelKind.opus48.family == .opus)
         #expect(ModelKind.opus47.family == .opus)
         #expect(ModelKind.opus46.family == .opus)


### PR DESCRIPTION
Fixes #259 and #261. Third iteration of the unknown-model-ID pattern (#188 fixed by #189, #199 fixed by #201): the Claude 5 generation drops the minor version suffix, so `claude-opus-5` was absorbed by the bare-opus fallback and labeled Opus 4.8, and `claude-sonnet-5` collapsed into the unversioned legacy Sonnet bucket.

## Changes

- `ModelKind`: new `opus5` and `sonnet5` cases, matched before the 4.x checks and the generic buckets (`opus-4-5`/`sonnet-4-5` cannot collide with the `opus-5`/`sonnet-5` substrings, pinned by tests). An unrecognised 4.x minor now stays labeled Opus 4.8 instead of falling into the Opus 5 bucket. The bare `opus` alias maps to Opus 5, the current shipping version, as its comment always promised.
- History chart: distinct colors for both new cases (hue-checked against their stack neighbors); family chips untouched (Opus 5 folds into Opus, Sonnet 5 into Sonnet), so filters, Monitoring tiles and `topActiveModelName` pick the fix up automatically.
- `HistoryCache` schema bumped to v3 so already-parsed history is re-scanned and reclassified on first open, same mechanism as the Fable bump (#199). The discard path is now expressed as `HistoryCache.isCurrentVersion` and pinned by a new test suite.

## Accepted side effect

Legacy rows whose JSONL says just `opus` relabel from Opus 4.8 to Opus 5 in the re-scan: the bare alias carries no era information, and the fallback tracks the current shipping version by design. Called out in the v3 comment.

## Tests

642 tests, 67 suites green, including new pins: `opus5IsRecognised`, `sonnet5IsRecognised`, `unknownOpus4MinorStaysInGeneration4`, the retargeted bare-alias test, the sonnet-4-5 non-collision guard, and the previously untested cache-version discard.