### PR TITLE
feat: detect Claude Code sessions run from the VSCode-family extension

### DIFF
--- a/Shared/Helpers/ProcessResolver.swift
+++ b/Shared/Helpers/ProcessResolver.swift
@@ -239,11 +239,17 @@ enum ProcessResolver {
     /// divergence is more permissive (a combining mark directly after the
     /// matched text no longer blocks the match).
     static func isClaudePath(_ path: String) -> Bool {
-        pathMatches(path, anyOf: knownClaudePathBytes)
+        // The npm package and the legacy extension layout embed a vendored
+        // ripgrep under .../claude-code/vendor/ripgrep/<arch>/rg. Those spawn
+        // as short-lived child processes whose path contains a Claude pattern,
+        // and must never classify as Claude sessions (#260).
+        if pathMatches(path, anyOf: excludedPathBytes) { return false }
+        return pathMatches(path, anyOf: knownClaudePathBytes)
     }
 
     // MARK: - Byte-level path matching (#255)
 
+    private static let excludedPathBytes = ["/vendor/ripgrep/"].map { Array($0.utf8) }
     private static let knownClaudePathBytes = knownClaudePaths.map { Array($0.utf8) }
     private static let idePatternBytes = idePathPatterns.map { Array($0.utf8) }
     private static let terminalPatternBytes = terminalPathPatterns.map { Array($0.utf8) }

--- a/Shared/Helpers/ProcessResolver.swift
+++ b/Shared/Helpers/ProcessResolver.swift
@@ -16,6 +16,7 @@ enum ProcessResolver {
         "/Caskroom/claude-code/",                        // Homebrew Cask stable (arm64 + x86_64)
         "/Caskroom/claude-code@latest/",                 // Homebrew Cask @latest channel
         "/Library/Application Support/Claude/claude-code/", // Claude Desktop embedded CLI
+        "/extensions/anthropic.claude-code-",               // VSCode/Cursor/Windsurf extension embedded binary (#260)
     ]
 
     /// Find all running Claude Code CLI processes with their working directories.

--- a/Shared/Services/SessionMonitorService.swift
+++ b/Shared/Services/SessionMonitorService.swift
@@ -273,7 +273,13 @@ final class SessionMonitorService: SessionMonitorServiceProtocol, @unchecked Sen
                 let sortedFiles = entry.files.sorted { $0.stamp.mtime > $1.stamp.mtime }
                 guard let newest = sortedFiles.first, newest.stamp.mtime >= freshnessCutoff else { continue }
 
-                for (file, stamp) in sortedFiles {
+                // Per-file gate on top of the per-dir one: a short-lived
+                // helper process (e.g. the VSCode extension's bundled CLI
+                // doing title generation, #260) shares the live session's cwd
+                // but has no registry entry, and without this gate it would
+                // bind to whatever OLD transcript sits in the same dir and
+                // flash a ghost watcher.
+                for (file, stamp) in sortedFiles where stamp.mtime >= freshnessCutoff {
                     let sessionId = file.deletingPathExtension().lastPathComponent
                     if emittedSessionIds.contains(sessionId) { continue }
                     guard let result = cachedReadAndParse(file: file, stamp: stamp) else { continue }

--- a/TokenEaterTests/ProcessResolverTests.swift
+++ b/TokenEaterTests/ProcessResolverTests.swift
@@ -87,6 +87,14 @@ struct ProcessResolverTests {
         #expect(!ProcessResolver.isClaudePath(path))
     }
 
+    @Test("rejects the vendored ripgrep bundled inside Claude Code installs")
+    func rejectsVendoredRipgrep() {
+        let legacyExtension = "/Users/simon/.vscode/extensions/anthropic.claude-code-2.0.3/resources/claude-code/vendor/ripgrep/arm64-darwin/rg"
+        let npmInstall = "/usr/local/lib/node_modules/@anthropic-ai/claude-code/vendor/ripgrep/arm64-darwin/rg"
+        #expect(!ProcessResolver.isClaudePath(legacyExtension))
+        #expect(!ProcessResolver.isClaudePath(npmInstall))
+    }
+
     // MARK: - Non-Claude paths
 
     @Test("rejects unrelated process")

--- a/TokenEaterTests/ProcessResolverTests.swift
+++ b/TokenEaterTests/ProcessResolverTests.swift
@@ -64,6 +64,29 @@ struct ProcessResolverTests {
         #expect(ProcessResolver.isClaudePath(path))
     }
 
+    // MARK: - Editor extension embedded binary (#260)
+    // The VSCode-family Claude Code extensions spawn their own bundled CLI from
+    // <editor dir>/extensions/anthropic.claude-code-<version>/resources/...,
+    // never the user's installed CLI, so the extension dir is its own pattern.
+
+    @Test("detects the VSCode extension embedded binary")
+    func detectsVSCodeExtensionBinary() {
+        let path = "/Users/simon/.vscode/extensions/anthropic.claude-code-2.1.63-darwin-arm64/resources/native-binary/claude"
+        #expect(ProcessResolver.isClaudePath(path))
+    }
+
+    @Test("detects the Cursor extension embedded binary")
+    func detectsCursorExtensionBinary() {
+        let path = "/Users/simon/.cursor/extensions/anthropic.claude-code-2.1.68-darwin-arm64/resources/native-binaries/darwin-arm64/claude"
+        #expect(ProcessResolver.isClaudePath(path))
+    }
+
+    @Test("rejects another publisher's claude-named extension")
+    func rejectsOtherPublisherExtension() {
+        let path = "/Users/simon/.vscode/extensions/someone.claude-helper-1.0.0/bin/claude"
+        #expect(!ProcessResolver.isClaudePath(path))
+    }
+
     // MARK: - Non-Claude paths
 
     @Test("rejects unrelated process")

--- a/TokenEaterTests/SessionMonitorCacheTests.swift
+++ b/TokenEaterTests/SessionMonitorCacheTests.swift
@@ -205,6 +205,36 @@ struct SessionMonitorCacheTests {
         #expect(second.isEmpty)
     }
 
+    @Test("a stale transcript is never bound to a second process (per-file freshness gate)")
+    func staleTranscriptNotBoundToSecondProcess() throws {
+        let env = try makeEnv()
+        defer { env.cleanup() }
+
+        // A second, STALE transcript in the same project dir (backdated past
+        // the freshness window), plus a second cwd-matched process with no
+        // registry entry, like a short-lived helper spawn from the VSCode
+        // extension (#260): the helper must not resurrect the stale session
+        // as a ghost watcher.
+        let staleSid = "abababab-0000-4000-8000-000000000007"
+        let staleFile = env.projectDir.appendingPathComponent("\(staleSid).jsonl")
+        try idleLine(sessionId: staleSid, cwd: env.cwd)
+            .write(to: staleFile, atomically: true, encoding: .utf8)
+        try setMtime(Date().addingTimeInterval(-2 * 3600), at: staleFile)
+
+        let p1 = ClaudeProcessInfo(pid: 8100, parentPid: 1, cwd: env.cwd, sourceKind: .terminal)
+        let p2 = ClaudeProcessInfo(pid: 8101, parentPid: 1, cwd: env.cwd, sourceKind: .terminal)
+        let service = SessionMonitorService(
+            scanInterval: 999,
+            projectDirFreshness: 30 * 60,
+            claudeProjectsDirOverride: env.projectsDir,
+            claudeSessionsDirOverride: env.sessionsDir,
+            processProvider: { [p1, p2] }
+        )
+
+        let sessions = scanOnce(service)
+        #expect(sessions.map(\.id) == [env.sessionId])
+    }
+
     @Test("a registry entry written after the first scan is honored (#233)")
     func lateRegistryEntryHonored() throws {
         let env = try makeEnv()


### PR DESCRIPTION
Fixes #260 (and its self-closed twin #258).

## Why no watcher appeared

The extension never uses the installed CLI: it spawns its own bundled binary from `<editor>/extensions/anthropic.claude-code-<version>/resources/native-binary(-ies)/claude` (verified locally on both VSCode and Cursor installs), a path no existing `knownClaudePaths` pattern matched. `isClaudeProcess` therefore rejected the process and the scan emitted nothing, JSONL or not.

## Changes

- One pattern, `/extensions/anthropic.claude-code-`, covers VSCode, Insiders, VSCodium, Cursor and Windsurf. The IDE badge already resolves through the extension host ancestor chain, and teleport falls back to activating the editor app (no TTY to focus).
- Hardening from the adversarial review of the pattern's blast radius:
  - the vendored ripgrep bundled inside Claude Code installs (`.../vendor/ripgrep/<arch>/rg`, present in both the legacy extension layout and the npm package, so this also fixes a latent exposure of the npm pattern) is excluded from classification;
  - the fallback pass now applies the freshness window per file, not only to a dir's newest transcript, so a short-lived helper spawn (title generation, `--no-session-persistence`) can no longer bind to an old transcript and flash a ghost watcher.

## Known limits

- Extension 2.0.x ran `cli.js` through node and stays undetectable by executable path.
- A helper spawn can still briefly bind to another sub-30min transcript in the same project; transient by construction (1-2 ticks), called out for manual validation.

## Tests

642 tests green, including: extension paths for VSCode and Cursor, another-publisher rejection, vendored-ripgrep rejection, and a scan-level test proving a stale transcript is never bound to a second cwd-matched process.

Manual validation before the next release: run one session in the VSCode extension and one in Cursor, check watcher presence, IDE badge, live states, teleport, and absence of ghost flashes.