### PR TITLE
docs: restructure the README as a storefront

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,10 @@ TokenEater is a native macOS menu bar app, plus WidgetKit widgets and a floating
 
 It complements the other docs and deliberately does not duplicate them:
 
-- [`README.md`](README.md) - what the app does (full feature list), the security and privacy model, the public API shape.
+- [`README.md`](README.md) - what the app does (full feature list), the security and privacy model, the two API calls.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) - contribution workflow, commit conventions, how to get help, the external-contributor signing caveat.
 - [`SETUP.md`](SETUP.md) - building from source as an end user.
+- [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) - common fixes and the canonical clean-reset script.
 - [`docs/design/MASTER.md`](docs/design/MASTER.md) and [`docs/design/COLORING.md`](docs/design/COLORING.md) - the window design system and the Smart Color risk model.
 
 Current version: 5.13.0 (`MARKETING_VERSION` in `project.yml`).
@@ -222,7 +223,7 @@ gh workflow run test-build.yml -f branch=<branch>
 gh run download <run-id> -n TokenEater-test -D /tmp/tokeneater-test/
 ```
 
-Installing that DMG cleanly requires a heavier reset than the local nuke (it also wipes `UserDefaults` and sandbox containers). See the clean-reset block in [`SETUP.md`](SETUP.md) / [`README.md`](README.md).
+Installing that DMG cleanly requires a heavier reset than the local nuke (it also wipes `UserDefaults` and sandbox containers). See the clean-reset block in [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md).
 
 ## Signing, notarization, and release
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,15 @@
 
 <p align="center">
   <strong>Monitor your Claude AI usage limits directly from your macOS desktop.</strong>
-  <br>
-  <a href="https://tokeneater.vercel.app">Website</a> · <a href="https://tokeneater.vercel.app/en/docs">Docs</a> · <a href="https://github.com/AThevon/TokenEater/releases/latest">Download</a>
+</p>
+
+<p align="center">
+  <a href="https://tokeneater.vercel.app">Website</a> ·
+  <a href="#install">Install</a> ·
+  <a href="#what-you-get">Features</a> ·
+  <a href="#privacy-two-read-only-calls">Privacy</a> ·
+  <a href="https://tokeneater.vercel.app/en/docs">Docs</a> ·
+  <a href="https://github.com/AThevon/TokenEater/releases">Releases</a>
 </p>
 
 <p align="center">
@@ -15,6 +22,7 @@
   <img src="https://img.shields.io/badge/Swift-5.9-F05138?logo=swift&logoColor=white" alt="Swift 5.9">
   <img src="https://img.shields.io/badge/WidgetKit-native-007AFF?logo=apple&logoColor=white" alt="WidgetKit">
   <img src="https://img.shields.io/badge/Claude-Pro%20%2F%20Max%20%2F%20Team-D97706" alt="Claude Pro / Max / Team">
+  <img src="https://img.shields.io/github/downloads/AThevon/TokenEater/total?color=F97316" alt="Downloads">
   <img src="https://img.shields.io/badge/license-MIT-green" alt="MIT License">
   <img src="https://img.shields.io/github/v/release/AThevon/TokenEater?color=F97316" alt="Release">
   <a href="https://buymeacoffee.com/athevon"><img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buymeacoffee&logoColor=black" alt="Buy Me a Coffee"></a>
@@ -24,21 +32,34 @@
 
 > **Requires a Claude Pro, Max, or Team plan.** The free plan does not expose usage data.
 
-## What is TokenEater?
+<!--
+Screenshots slot. Four shots, ~200px wide each, dropped into docs/assets/readme/:
+  popover.png    (menu bar + popover dashboard)
+  monitoring.png (main window, Monitoring space)
+  watchers.png   (Agent Watchers overlay over a desktop)
+  widgets.png    (desktop widgets)
+Then wire them here as a centered row:
+<p align="center">
+  <img src="docs/assets/readme/popover.png" width="200" alt="...">
+  ...
+</p>
+-->
 
-A native macOS menu bar app + desktop widgets + floating overlay that tracks your Claude AI usage in real-time.
+## What you get
 
-- **Menu bar** — Live percentages, color-coded thresholds, and a fully composable popover dashboard: build it element by element (rings, chips, arcs, pacing bars... at full, half, or third width), start from built-in templates (Classic / Compact / Focus / Minimalist and more), and save your own.
-- **Dashboard** — Three-space layout (Monitoring / History / Settings) with flippable tiles surfacing 7d sparklines, peak day, and a pacing-vs-equilibrium graph.
-- **History** — Tokens-over-time browser sourced from Claude Code's local JSONL logs, with four stats tabs: Tokens (stacked chart by model family), Projects (ranked breakdown with share bars), Sessions (session counts over time), and Cache (hit-rate curve). Filter by model family, switch range (24h / 7d / 30d / 90d), hover for per-bucket details.
-- **Widgets** — Native WidgetKit widgets (usage gauges, progress bars, pacing) with reactive refresh.
-- **Agent Watchers** — Floating overlay showing active Claude Code sessions with dock-like hover effect. Click to jump to the right terminal (Terminal.app, iTerm2, tmux, Kitty, WezTerm), right-click for quick actions (open project in Finder, copy path or session id, reveal transcript, hide). Frost or Neon style, with per-session context fraction.
-- **Smart Color** — Risk-aware coloring that combines absolute usage, projection rate, and pacing into a continuous risk score with early-window confidence damping. Three temperaments (Confident / Balanced / Suspicious) to dial sensitivity to your appetite for risk.
-- **Smart pacing** — Are you burning through tokens or cruising? Four zones: chill, on track, warning, hot.
-- **Themes** — 4 presets + full custom colors. Configurable warning/critical thresholds.
-- **Notifications** — Granular per-surface (5h / 7d / Sonnet / Design) and per-event toggles (escalation, recovery, pacing, scheduled reset reminders, extra credits, token expiry).
+A native menu bar app, desktop widgets, and a floating overlay that track your Claude usage in real time.
 
-See all features in detail on the [website](https://tokeneater.vercel.app).
+- **Menu bar.** Live percentages with color-coded thresholds, and a popover dashboard you compose element by element (rings, chips, arcs, pacing bars at full, half, or third width), start from built-in templates, and save as your own.
+- **Dashboard.** A three-space window (Monitoring / History / Settings) with flippable tiles, 7-day sparklines, peak day, and a pacing-vs-equilibrium graph.
+- **History.** Tokens over time from Claude Code's local logs: a stacked chart by model, project ranking, session counts, and cache hit rate, filterable by model family across 24h to 90d ranges.
+- **Widgets.** Native WidgetKit gauges, progress bars, and pacing, refreshed reactively.
+- **Agent Watchers.** A floating overlay of your live Claude Code sessions, terminals and VSCode-family extensions alike. Click a session to jump to its terminal or editor (Terminal, iTerm2, tmux, Kitty, WezTerm), right-click for quick actions.
+- **Smart Color.** Blends how much you have used with how fast you are burning, so the color warns you before the number does. Three temperaments set how cautious it is.
+- **Smart pacing.** Are you burning through tokens or cruising? Four zones: chill, on track, warning, hot.
+- **Themes.** Four presets plus full custom colors, a glow or flat look, and configurable warning thresholds.
+- **Notifications.** Per-surface and per-event toggles: escalation, recovery, pacing, scheduled reset reminders, extra credits, token expiry.
+
+Everything in detail on the [website](https://tokeneater.vercel.app).
 
 ## Install
 
@@ -58,146 +79,79 @@ brew install --cask tokeneater
 
 > `brew trust` is required on Homebrew 6.0+, which no longer loads a third-party tap until you trust it.
 
-### First Setup
+### First setup
 
-**Prerequisites:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated (`claude` then `/login`). Requires a **Pro, Max, or Team plan**.
+**Prerequisites:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated (`claude` then `/login`), on a **Pro, Max, or Team plan**.
 
-1. Open TokenEater — a guided setup walks you through connecting your account
-2. Right-click on desktop > **Edit Widgets** > search "TokenEater"
+1. Open TokenEater: a guided setup walks you through connecting your account
+2. Right-click on the desktop > **Edit Widgets** > search "TokenEater"
 
 ## Update
 
-TokenEater checks for updates automatically. When a new version is available, a modal lets you download and install it in-app — macOS will ask for your admin password to replace the app in `/Applications`.
+TokenEater checks for updates automatically. When a new version is available, a modal lets you download and install it in-app; macOS will ask for your admin password to replace the app in `/Applications`.
 
 If you installed via Homebrew: `brew update && brew upgrade --cask tokeneater`
 
 ## Uninstall
 
 Delete `TokenEater.app` from Applications, then optionally clean up shared data:
+
 ```bash
 rm -rf /Applications/TokenEater.app
 rm -rf ~/Library/Application\ Support/com.tokeneater.shared
 ```
 
-If installed via Homebrew: `brew uninstall --cask tokeneater`
+If you installed via Homebrew: `brew uninstall --cask tokeneater`. For a complete wipe, caches and widget state included, use the clean reset in the [troubleshooting guide](docs/TROUBLESHOOTING.md).
 
-## Build from source
+## Build it yourself
 
 ```bash
-# Requirements: macOS 14+, Xcode 16.4+, XcodeGen (brew install xcodegen)
-
 git clone https://github.com/AThevon/TokenEater.git
 cd TokenEater
-xcodegen generate
-plutil -insert NSExtension -json '{"NSExtensionPointIdentifier":"com.apple.widgetkit-extension"}' \
-  TokenEaterWidget/Info.plist 2>/dev/null || true
-xcodebuild -project TokenEater.xcodeproj -scheme TokenEaterApp \
-  -configuration Release -derivedDataPath build build
-cp -R "build/Build/Products/Release/TokenEater.app" /Applications/
+./build.sh
 ```
 
-## Architecture
+The script checks Xcode, installs XcodeGen if needed, and assembles the app. Local builds are not notarized, so Gatekeeper blocks the first launch (right-click > Open, or System Settings > Privacy & Security > Open Anyway). The step-by-step walkthrough is in [`SETUP.md`](SETUP.md).
 
-```
-TokenEaterApp/           App host (settings, OAuth, menu bar, overlay)
-TokenEaterWidget/        Widget Extension (WidgetKit, reactive refresh)
-Shared/                  Shared code (services, stores, models, pacing)
-  ├── Models/            Pure Codable structs
-  ├── Services/          Protocol-based I/O (API, TokenProvider, SharedFile, Notification, SessionMonitor, SessionHistory)
-  ├── Repositories/      Orchestration (UsageRepository)
-  ├── Stores/            ObservableObject state containers (Usage, Theme, Settings, History, MonitoringInsights, Session, Update)
-  └── Helpers/           Pure functions (PacingCalculator, MenuBarRenderer, JSONLParser, SmartColor)
-```
+## Privacy: two read-only calls
 
-The app reads Claude Code's OAuth token silently from the macOS Keychain (`kSecUseAuthenticationUISkip`), calls the Anthropic usage API, and writes results to a shared JSON file. A `TokenFileMonitor` watches the credential files with a `DispatchSource` filesystem watcher and triggers immediate refresh. The widget reads the shared file — it never touches the network or Keychain. The Agent Watchers overlay scans running Claude Code processes every 2s using macOS system APIs and tail-reads their JSONL logs.
+TokenEater reads the **OAuth access token** Claude Code already keeps in your macOS Keychain, the same token Claude Code itself uses. At first launch, macOS asks you to allow that access: click **Always Allow** once. The prompt is standard macOS behavior for any app reading a keychain item it did not create, and since the read goes through Apple's own `security` tool, whose signature never changes, the prompt does not come back on updates.
 
-## How it works
+Everything the app does with the token:
 
-```
-GET https://api.anthropic.com/api/oauth/usage
-Authorization: Bearer <token>
-anthropic-beta: oauth-2025-04-20
-```
+- `GET api.anthropic.com/api/oauth/usage`, your current usage stats
+- `GET api.anthropic.com/api/oauth/profile`, your plan info
 
-Returns `utilization` (0–100) and `resets_at` for each limit bucket.
+Both are read-only. The app cannot send messages, read conversations, or modify your account. The token never leaves your machine except for those two calls, the widget reads a local JSON file with no network or keychain access at all, and the History tab and Agent Watchers read Claude Code's local session logs without anything leaving your Mac.
 
-## Security & Privacy
+Anthropic does not offer a third-party OAuth flow or scoped tokens yet, so reading the existing token is the only way an app like this can exist. If scoped tokens become available, TokenEater will adopt them immediately. The relevant code is short and auditable: keychain access in [`SecurityCLIReader.swift`](Shared/Services/SecurityCLIReader.swift) and [`TokenProvider.swift`](Shared/Services/TokenProvider.swift), the two API calls in [`APIClient.swift`](Shared/Services/APIClient.swift).
 
-TokenEater reads an **OAuth access token** from the Claude Code keychain entry - the same standard token that Claude Code itself uses. At first launch, macOS will prompt you to allow this access; this is normal macOS behavior for any app reading a keychain item it didn't create.
-
-**What the app does with the token:**
-- Calls `GET /api/oauth/usage` (your current usage stats)
-- Calls `GET /api/oauth/profile` (your plan info)
-
-**What the app cannot do:** send messages, read conversations, modify your account, or access anything beyond read-only usage data.
-
-The token never leaves your machine except for these two API calls to `api.anthropic.com`. The widget reads a local JSON file and has no network or keychain access at all.
-
-Anthropic does not currently offer a third-party OAuth flow or scoped API tokens - reading the existing token from the keychain is the only option. If scoped tokens become available, TokenEater will adopt them immediately. The entire codebase is open source and auditable: keychain access is in [`SecurityCLIReader.swift`](Shared/Services/SecurityCLIReader.swift) (primary) and [`TokenProvider.swift`](Shared/Services/TokenProvider.swift) (Security-framework fallback), API calls in [`APIClient.swift`](Shared/Services/APIClient.swift).
-
-## Troubleshooting
-
-### Common issues
+## If something breaks
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| "Rate limited" or "API unavailable" | Your OAuth token has hit its per-token request limit | Run `claude /login` in your terminal for a fresh token - TokenEater detects the change and recovers automatically within seconds |
-| Keychain popup asking to access "Claude Code-credentials" | First run on a new install needs to authorize `/usr/bin/security` to read your Claude Code token | Click **Always Allow** once - it sticks across future app updates |
-| Widget stuck / not updating | macOS caches widget extensions aggressively | Remove the widget, run a clean reset, re-add the widget |
+| "Rate limited" or "API unavailable" | Your OAuth token has hit its per-token request limit | Run `claude /login` for a fresh token; TokenEater detects the change and recovers within seconds |
+| Keychain popup on first run | A new install needs authorization to read your Claude Code token | Click **Always Allow** once; it sticks across updates |
+| Widget stuck or not updating | macOS caches widget extensions aggressively | Remove the widget, run the clean reset, re-add the widget |
 
-### Clean reset
+Anything deeper, including the full clean reset that wipes caches, preferences, and widget state, lives in the [troubleshooting guide](docs/TROUBLESHOOTING.md).
 
-If something is broken and you want to start fresh, run this in your terminal. It kills all related processes, wipes caches, preferences, and containers, then removes the app:
+## Documentation
 
-```bash
-# 1. Kill processes
-killall TokenEater NotificationCenter chronod cfprefsd 2>/dev/null; sleep 1
-
-# 2. Wipe preferences
-defaults delete com.tokeneater.app 2>/dev/null
-defaults delete com.claudeusagewidget.app 2>/dev/null
-rm -f ~/Library/Preferences/com.tokeneater.app.plist
-rm -f ~/Library/Preferences/com.claudeusagewidget.app.plist
-
-# 3. Wipe sandbox containers
-for c in com.tokeneater.app com.tokeneater.app.widget com.claudeusagewidget.app com.claudeusagewidget.app.widget; do
-    d="$HOME/Library/Containers/$c/Data"
-    [ -d "$d" ] && rm -rf "$d/Library/Preferences/"* "$d/Library/Caches/"* "$d/Library/Application Support/"* "$d/tmp/"* 2>/dev/null
-done
-
-# 4. Wipe shared data and caches
-rm -rf ~/Library/Application\ Support/com.tokeneater.shared
-rm -rf ~/Library/Application\ Support/com.claudeusagewidget.shared
-rm -rf ~/Library/Caches/com.tokeneater.app
-rm -rf ~/Library/Group\ Containers/group.com.claudeusagewidget.shared
-
-# 5. Wipe WidgetKit caches (critical - macOS keeps old widget binaries here)
-TMPBASE=$(getconf DARWIN_USER_TEMP_DIR)
-CACHEBASE=$(getconf DARWIN_USER_CACHE_DIR)
-rm -rf "${TMPBASE}com.apple.chrono" "${CACHEBASE}com.apple.chrono" 2>/dev/null
-rm -rf "${CACHEBASE}com.tokeneater.app" "${CACHEBASE}com.claudeusagewidget.app" 2>/dev/null
-
-# 6. Unregister widget plugins
-pluginkit -r -i com.tokeneater.app.widget 2>/dev/null
-pluginkit -r -i com.claudeusagewidget.app.widget 2>/dev/null
-
-# 7. Remove the app
-rm -rf /Applications/TokenEater.app
-```
-
-> Some `Operation not permitted` errors on container metadata files are normal - macOS protects those, but the actual data is cleaned.
-
-After this, reinstall from the [latest release](https://github.com/AThevon/TokenEater/releases/latest/download/TokenEater.dmg) or via Homebrew, then **remove old widgets from your desktop and add them again** (right-click > Edit Widgets > TokenEater).
+- [Setup](SETUP.md), building from source step by step
+- [Troubleshooting](docs/TROUBLESHOOTING.md), common fixes and the clean reset
+- [Contributing](CONTRIBUTING.md), workflow, commit conventions, and testing
+- [AGENTS.md](AGENTS.md), architecture, data flow, and the SwiftUI rules, for contributors and AI agents alike
+- [Design system](docs/design/MASTER.md), how the windows are built and colored
 
 ## Contributing
 
-Contributions are welcome! Bug reports, feature ideas and code PRs all help. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full guide - it covers the workflow, commit conventions, testing, and a few SwiftUI rules worth knowing before touching the code.
+Contributions are welcome: bug reports, feature ideas, and code PRs all help. Start with [`CONTRIBUTING.md`](CONTRIBUTING.md); it covers the workflow and a few SwiftUI rules worth knowing before touching the code.
 
 ## Support
 
-If TokenEater saves you from hitting your limits blindly, consider [buying me a coffee](https://buymeacoffee.com/athevon) ☕
+If TokenEater saves you from hitting your limits blindly, consider [buying me a coffee](https://buymeacoffee.com/athevon).
 
 ## License
 
 MIT
-

--- a/build.sh
+++ b/build.sh
@@ -10,27 +10,33 @@ GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
-echo -e "${BLUE}=== TokenEater — Build ===${NC}"
+echo -e "${BLUE}=== TokenEater build ===${NC}"
 
 # 1. Check Xcode
 if ! xcode-select -p | grep -q "Xcode.app"; then
-    echo -e "${RED}Xcode.app requis. Installe-le depuis le Mac App Store.${NC}"
-    echo "Puis lance: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer"
+    echo -e "${RED}Xcode.app required. Install it from the Mac App Store.${NC}"
+    echo "Then run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer"
     exit 1
 fi
 
 # 2. Check/install XcodeGen
 if ! command -v xcodegen &> /dev/null; then
-    echo -e "${BLUE}Installation de XcodeGen via Homebrew...${NC}"
+    echo -e "${BLUE}Installing XcodeGen via Homebrew...${NC}"
     brew install xcodegen
 fi
 
 # 3. Generate Xcode project
-echo -e "${BLUE}Generation du projet Xcode...${NC}"
+echo -e "${BLUE}Generating the Xcode project...${NC}"
 xcodegen generate
 
-# 4. Build
-echo -e "${BLUE}Build en cours...${NC}"
+# 4. Restore the widget's NSExtension key (XcodeGen strips it on every
+# generate; without it macOS never registers the widget and the gallery
+# stays empty). Load-bearing, same step as CI and SETUP.md.
+plutil -insert NSExtension -json '{"NSExtensionPointIdentifier":"com.apple.widgetkit-extension"}' \
+    TokenEaterWidget/Info.plist 2>/dev/null || true
+
+# 5. Build
+echo -e "${BLUE}Building...${NC}"
 xcodebuild \
     -project TokenEater.xcodeproj \
     -scheme TokenEaterApp \
@@ -38,18 +44,18 @@ xcodebuild \
     -derivedDataPath build \
     build 2>&1 | tail -20
 
-# 5. Find the built app
+# 6. Find the built app
 APP_PATH=$(find build -name "TokenEater.app" -type d | head -1)
 
 if [ -n "$APP_PATH" ]; then
     echo ""
-    echo -e "${GREEN}Build OK !${NC}"
+    echo -e "${GREEN}Build OK!${NC}"
     echo -e "App: ${BLUE}$APP_PATH${NC}"
     echo ""
-    echo "Pour installer:"
+    echo "To install:"
     echo "  cp -R \"$APP_PATH\" /Applications/"
     echo "  open \"/Applications/TokenEater.app\""
 else
-    echo -e "${RED}Build echoue. Verifie les erreurs ci-dessus.${NC}"
+    echo -e "${RED}Build failed. Check the errors above.${NC}"
     exit 1
 fi

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,59 @@
+# Troubleshooting
+
+Common fixes first, the full clean reset after. If none of this helps, [open an issue](https://github.com/AThevon/TokenEater/issues/new/choose) with your macOS version, your TokenEater version (shown on the update card in Settings), and what you saw.
+
+## Common issues
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| "Rate limited" or "API unavailable" | Your OAuth token has hit its per-token request limit | Run `claude /login` in your terminal for a fresh token. TokenEater detects the change and recovers automatically within seconds |
+| Keychain popup asking to access "Claude Code-credentials" | First run on a new install needs to authorize `/usr/bin/security` to read your Claude Code token | Click **Always Allow** once; it sticks across future app updates |
+| Widget stuck or not updating | macOS caches widget extensions aggressively | Remove the widget, run the clean reset below, re-add the widget |
+| A session is missing from Agent Watchers | The session runs from an old VSCode extension (2.0.x era), which executes through node and is invisible to the process scanner | Update the Claude Code extension; current versions ship a native binary the scanner detects |
+| Widget flagged as malware | You are running an ad-hoc local build without notarization | Reinstall the official notarized DMG from [Releases](https://github.com/AThevon/TokenEater/releases/latest), or approve the local build via System Settings > Privacy & Security > Open Anyway |
+
+## Clean reset
+
+If something is wedged and you want to start fresh, run this in your terminal. It kills all related processes, wipes caches, preferences, and containers, then removes the app:
+
+```bash
+# 1. Kill processes
+killall TokenEater NotificationCenter chronod cfprefsd 2>/dev/null; sleep 1
+
+# 2. Wipe preferences
+defaults delete com.tokeneater.app 2>/dev/null
+defaults delete com.claudeusagewidget.app 2>/dev/null
+rm -f ~/Library/Preferences/com.tokeneater.app.plist
+rm -f ~/Library/Preferences/com.claudeusagewidget.app.plist
+
+# 3. Wipe sandbox containers
+for c in com.tokeneater.app com.tokeneater.app.widget com.claudeusagewidget.app com.claudeusagewidget.app.widget; do
+    d="$HOME/Library/Containers/$c/Data"
+    [ -d "$d" ] && rm -rf "$d/Library/Preferences/"* "$d/Library/Caches/"* "$d/Library/Application Support/"* "$d/tmp/"* 2>/dev/null
+done
+
+# 4. Wipe shared data and caches
+rm -rf ~/Library/Application\ Support/com.tokeneater.shared
+rm -rf ~/Library/Application\ Support/com.claudeusagewidget.shared
+rm -rf ~/Library/Caches/com.tokeneater.app
+rm -rf ~/Library/Group\ Containers/group.com.claudeusagewidget.shared
+
+# 5. Wipe WidgetKit caches (critical: macOS keeps old widget binaries here)
+TMPBASE=$(getconf DARWIN_USER_TEMP_DIR)
+CACHEBASE=$(getconf DARWIN_USER_CACHE_DIR)
+rm -rf "${TMPBASE}com.apple.chrono" "${CACHEBASE}com.apple.chrono" 2>/dev/null
+rm -rf "${CACHEBASE}com.tokeneater.app" "${CACHEBASE}com.claudeusagewidget.app" 2>/dev/null
+
+# 6. Unregister widget plugins
+pluginkit -r -i com.tokeneater.app.widget 2>/dev/null
+pluginkit -r -i com.claudeusagewidget.app.widget 2>/dev/null
+
+# 7. Remove the app
+rm -rf /Applications/TokenEater.app
+```
+
+> Some `Operation not permitted` errors on container metadata files are normal; macOS protects those, but the actual data is cleaned.
+
+## After the reset
+
+Reinstall from the [latest release](https://github.com/AThevon/TokenEater/releases/latest/download/TokenEater.dmg) or via Homebrew, then **remove old widgets from your desktop and add them again** (right-click > Edit Widgets > TokenEater).


### PR DESCRIPTION
README pass inspired by vorssaint-utils' readability: prose and links over big code blocks, human titles, details pushed to docs/.

- New canonical [docs/TROUBLESHOOTING.md](https://github.com/AThevon/TokenEater/blob/docs/readme-restructure/docs/TROUBLESHOOTING.md) (common issues + clean reset); README keeps the symptom table and links out.
- Build from source is now `git clone` + `./build.sh`; the script gains the plutil NSExtension step it was missing (caught in review: the README used to carry it inline, and a build without it ships an app whose widget never registers), plus English messages.
- Architecture tree and raw HTTP block removed; privacy section rewritten around the two read-only calls, with corrected wording on why the keychain prompt sticks (the ACL belongs to Apple's `security` tool).
- Header anchors, downloads badge, Documentation index, tightened feature bullets, and a commented slot ready for four screenshots (popover, monitoring, watchers, widgets) in docs/assets/readme/.

No code changes outside build.sh.